### PR TITLE
Cleanup state dict of quantized model

### DIFF
--- a/brevitas/core/stats.py
+++ b/brevitas/core/stats.py
@@ -92,6 +92,11 @@ class _ViewParameterWrapper(torch.jit.ScriptModule):
         if parameter_key in missing_keys:
             missing_keys.remove(parameter_key)
 
+    def state_dict(self, destination=None, prefix='', keep_vars=False):
+        output_dict = super(_ViewParameterWrapper, self).state_dict(destination, prefix, keep_vars)
+        del output_dict[prefix + 'parameter']
+        return output_dict
+
 
 class _ViewCatParameterWrapper(torch.jit.ScriptModule):
     __constants__ = ['shape', 'cat_dim']
@@ -113,6 +118,11 @@ class _ViewCatParameterWrapper(torch.jit.ScriptModule):
         parameter_key = prefix + 'parameter'
         if parameter_key in missing_keys:
             missing_keys.remove(parameter_key)
+
+    def state_dict(self, destination=None, prefix='', keep_vars=False):
+        output_dict = super(_ViewCatParameterWrapper, self).state_dict(destination, prefix, keep_vars)
+        del output_dict[prefix + 'parameter']
+        return output_dict
 
 
 class AbsMax(torch.jit.ScriptModule):

--- a/brevitas/proxy/quant_proxy.py
+++ b/brevitas/proxy/quant_proxy.py
@@ -1,0 +1,29 @@
+from abc import ABCMeta
+
+import torch
+from torch import nn
+
+from brevitas.core import ZERO_HW_SENTINEL_NAME, ZERO_HW_SENTINEL_VALUE
+
+
+class QuantProxy(nn.Module):
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        super(QuantProxy, self).__init__()
+        self.register_buffer(ZERO_HW_SENTINEL_NAME, torch.tensor(ZERO_HW_SENTINEL_VALUE))
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        super(QuantProxy, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
+            missing_keys, unexpected_keys, error_msgs)
+        zero_hw_sentinel_key = prefix + ZERO_HW_SENTINEL_NAME
+        if zero_hw_sentinel_key in missing_keys:
+            missing_keys.remove(zero_hw_sentinel_key)
+        if zero_hw_sentinel_key in unexpected_keys:  # for retrocompatibility with when it wasn't removed
+            unexpected_keys.remove(zero_hw_sentinel_key)
+
+    def state_dict(self, destination=None, prefix='', keep_vars=False):
+        output_dict = super(QuantProxy, self).state_dict(destination, prefix, keep_vars)
+        del output_dict[prefix + ZERO_HW_SENTINEL_NAME]
+        return output_dict


### PR DESCRIPTION
Remove zero_hw_sentinel and weights tracked by statistics from the state_dict. Refactor proxies to inherit from a common abstract class.