### PR TITLE
Fix clamp ste

### DIFF
--- a/brevitas/proxy/parameter_quant.py
+++ b/brevitas/proxy/parameter_quant.py
@@ -187,10 +187,8 @@ def _weight_quant_init_impl(bit_width: Optional[int],
                     raise Exception("Bit width is not defined properly")
 
                 if bit_width_impl_type == BitWidthImplType.CONST:
-                    tensor_clamp_impl = TensorClampSte()
                     bit_width_impl = BitWidthConst(bit_width, restrict_bit_width_type)
                 elif bit_width_impl_type == BitWidthImplType.PARAMETER:
-                    tensor_clamp_impl = TensorClamp()
                     bit_width_impl = BitWidthParameter(bit_width_init=bit_width,
                                                        restrict_bit_width_type=restrict_bit_width_type,
                                                        min_overall_bit_width=min_overall_bit_width,
@@ -200,8 +198,12 @@ def _weight_quant_init_impl(bit_width: Optional[int],
                     raise Exception("Bit width type {} not supported for weight quantization."
                                     .format(str(bit_width_impl_type)))
             else:
-                tensor_clamp_impl = TensorClamp()
                 bit_width_impl = bit_width_impl_override
+
+            if scaling_impl_type == ScalingImplType.STATS or scaling_impl_type == ScalingImplType.AFFINE_STATS:
+                tensor_clamp_impl = TensorClampSte()
+            else:
+                tensor_clamp_impl = TensorClamp()
 
             float_to_int_impl = RestrictValue(restrict_value_type=RestrictValueType.INT,
                                               float_to_int_impl_type=FloatToIntImplType.ROUND,

--- a/brevitas/proxy/parameter_quant.py
+++ b/brevitas/proxy/parameter_quant.py
@@ -200,7 +200,9 @@ def _weight_quant_init_impl(bit_width: Optional[int],
             else:
                 bit_width_impl = bit_width_impl_override
 
-            if scaling_impl_type == ScalingImplType.STATS or scaling_impl_type == ScalingImplType.AFFINE_STATS:
+            if bit_width_impl_type == BitWidthImplType.CONST and \
+                    (scaling_impl_type == ScalingImplType.STATS
+                     or scaling_impl_type == ScalingImplType.AFFINE_STATS):
                 tensor_clamp_impl = TensorClampSte()
             else:
                 tensor_clamp_impl = TensorClamp()


### PR DESCRIPTION
Limit clamp w/ STE in int quantization only to stats based weight scaling, used non-STE version otherwise.