### PR TITLE
Fixed bug with keyworded argument and pytorch JIT

### DIFF
--- a/brevitas/core/function_wrapper.py
+++ b/brevitas/core/function_wrapper.py
@@ -103,7 +103,7 @@ class TensorClampSte(torch.jit.ScriptModule):
 
     @torch.jit.script_method
     def forward(self, x: torch.Tensor, min_val: torch.Tensor, max_val: torch.Tensor):
-        return tensor_clamp_ste(x, min_val=min_val, max_val=max_val)
+        return tensor_clamp_ste(x, min_val, max_val)
 
 
 class TensorClamp(torch.jit.ScriptModule):


### PR DESCRIPTION
This should fix the issue #29 .
It may be worth noticing that with pytorch version >= 1.3.0 this problem does not occur.