### PR TITLE
Avoid implicit propagation of jit.script_method for pytorch < 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ def get_extensions():
         # Determine replacement for templated file
         suffix = '_fn.apply'
         prefix = ''
-        torch_jit = ''
+        torch_jit = '@torch.jit.ignore'
 
     # Copy templated file and remove the .template extension
     shutil.copyfile("brevitas/function/ops_ste_n.py.template", "brevitas/function/ops_ste.py")


### PR DESCRIPTION
Fix for #48 