### PR TITLE
Enable python 3.6 on Windows on Github Actions

### DIFF
--- a/.github/workflows/develop_install.yml
+++ b/.github/workflows/develop_install.yml
@@ -19,9 +19,6 @@ jobs:
 
 
         exclude:
-          - platform: 'windows-latest'
-            conda_python_version: '3.6'
-
           - platform: 'macos-latest'
             pytorch_version: '1.1.0'
 

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -10,6 +10,7 @@ BASE_YML_TEMPLATE = 'base.yml.template'
 PYTEST_YML = 'pytest.yml'
 DEVELOP_INSTALL_YML = 'develop_install.yml'
 
+NIX_NEWLINE = '\n'
 
 # Data shared betwen Nox sessions and Github Actions, formatted as tuples
 CONDA_PYTHON_VERSIONS = ('3.6', '3.7', '3.8')
@@ -93,12 +94,12 @@ class Action:
         repr = first_line_prefix
         for name, val in d.items():
             if quote_val:
-                repr += f"{name}: '{val}'\n"
+                repr += f"{name}: '{val}'" + NIX_NEWLINE
             else:
-                repr += f"{name}: {val}\n"
+                repr += f"{name}: {val}" + NIX_NEWLINE
         if indent_first:
             repr = indent(repr, RELATIVE_INDENT*' ', predicate=lambda line: not first_line_prefix in line)
-        repr += '\n'
+        repr += NIX_NEWLINE
         return repr
 
     def gen_yaml(self, output_path):
@@ -109,7 +110,7 @@ class Action:
         template = CustomTemplate(open(BASE_YML_TEMPLATE).read())
         generated_file = template.substitute(d)
         yaml.safe_load(generated_file)  # validate the generated yaml
-        with open(output_path, 'w') as f:
+        with open(output_path, 'w', newline=NIX_NEWLINE) as f:
             f.write(generated_file)
 
 

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -21,9 +21,7 @@ JIT_STATUSES = ('jit_enabled', 'jit_disabled')
 # Data used only by Github Actions, formatted as lists or lists of oredered dicts
 PLATFORM_LIST = ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
-EXCLUDE_LIST = [od([('platform', 'windows-latest'),
-                    ('conda_python_version', '3.6')]),
-                od([('platform', 'macos-latest'),
+EXCLUDE_LIST = [od([('platform', 'macos-latest'),
                     ('pytorch_version', '1.1.0')]),
                 od([('pytorch_version', '1.1.0'),
                     ('conda_python_version', '3.8')]),

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,9 +20,6 @@ jobs:
 
 
         exclude:
-          - platform: 'windows-latest'
-            conda_python_version: '3.6'
-
           - platform: 'macos-latest'
             pytorch_version: '1.1.0'
 


### PR DESCRIPTION
Originally disabled because of issues with Nox + recent Numpy 1.18. #101 set Numpy to 1.17 on Windows, so this should allow to reenable running 3.6.