### PR TITLE
Don't use ONNX Sign node to export bipolar activations

### DIFF
--- a/brevitas/nn/quant_activation.py
+++ b/brevitas/nn/quant_activation.py
@@ -360,12 +360,14 @@ class QuantHardTanh(QuantActivation):
             for t in range(n_thresholds):
                 self.export_thres[0][t] = min_thres + step * t
         else:
+            # export bipolar act. quantization as a MultiThreshold node
+            # with a single threshold at 0, followed by 2*x - 1
             self.export_act_scale = torch.empty([1, ])
             self.export_act_scale[0] = 2.0
             self.export_act_bias = torch.empty([1, ])
             self.export_act_bias[0] = -1.0
             self.export_thres = torch.empty([1, 1])
-            self.export_act_bias[0] = 0
+            self.export_thres[0] = 0
 
     def forward(self, input):
         if self.export_mode:

--- a/brevitas/nn/quant_activation.py
+++ b/brevitas/nn/quant_activation.py
@@ -360,9 +360,12 @@ class QuantHardTanh(QuantActivation):
             for t in range(n_thresholds):
                 self.export_thres[0][t] = min_thres + step * t
         else:
-            self.export_act_scale = None
-            self.export_act_bias = None
-            self.export_thres = None
+            self.export_act_scale = torch.empty([1, ])
+            self.export_act_scale[0] = 2.0
+            self.export_act_bias = torch.empty([1, ])
+            self.export_act_bias[0] = -1.0
+            self.export_thres = torch.empty([1, 1])
+            self.export_act_bias[0] = 0
 
     def forward(self, input):
         if self.export_mode:

--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -42,12 +42,19 @@ class QuantizedConv2dPlaceholderFunction(Function):
 class QuantizedHardTanhPlaceholderFunction(Function):
     @staticmethod
     def symbolic(g, input, qnt_type, thres, bias, scale):
-        ret = g.op('MultiThreshold', input, thres, domain_s = "finn",
-                    out_dtype_s = qnt_type)
-        if scale is not None:
-            ret = g.op('Mul', ret, scale)
-        if bias is not None:
-            ret = g.op('Add', ret, bias)
+        if qnt_type == "BIPOLAR":
+            # don't export the scale/bias as separate nodes for bipolar,
+            # we don't want to get rid of them convert this node to binary
+            ret = g.op('MultiThreshold', input, thres, domain_s = "finn",
+                        out_scale_f = 2.0, out_bias_f = -1,
+                        out_dtype_s = qnt_type, activation_qnt_s = qnt_type)
+        else:
+            ret = g.op('MultiThreshold', input, thres, domain_s = "finn",
+                        out_dtype_s = qnt_type)
+            if scale is not None:
+                ret = g.op('Mul', ret, scale)
+            if bias is not None:
+                ret = g.op('Add', ret, bias)
         return ret
 
     @staticmethod

--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -42,17 +42,12 @@ class QuantizedConv2dPlaceholderFunction(Function):
 class QuantizedHardTanhPlaceholderFunction(Function):
     @staticmethod
     def symbolic(g, input, qnt_type, thres, bias, scale):
-        if qnt_type == "BIPOLAR":
-            # TODO ONNX Sign op returns 0 for a 0 input, which does not conform
-            # to bipolar {-1, +1} quantization.
-            ret = g.op('Sign', input, activation_qnt_s = qnt_type)
-        else:
-            ret = g.op('MultiThreshold', input, thres, domain_s = "finn",
-                        out_dtype_s = qnt_type)
-            if scale is not None:
-                ret = g.op('Mul', ret, scale)
-            if bias is not None:
-                ret = g.op('Add', ret, bias)
+        ret = g.op('MultiThreshold', input, thres, domain_s = "finn",
+                    out_dtype_s = qnt_type)
+        if scale is not None:
+            ret = g.op('Mul', ret, scale)
+        if bias is not None:
+            ret = g.op('Add', ret, bias)
         return ret
 
     @staticmethod

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -1,4 +1,4 @@
 bitstring
-onnx
+onnx==1.5.0
 onnxruntime
 finn @ git+https://github.com/Xilinx/finn@dev#egg=finn


### PR DESCRIPTION
This PR makes the ONNX export flow for bipolar activation quantization use MultiThreshold with threshold=0 scaled by 2 and biased by -1 using attributes on the same node. The ONNX version is also set to 1.5.0 to fix the segfault issues in the Brevitas/FINN integration tests.