### PR TITLE
Add export mode to QuantReLU and fix QuantHardTanh export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ docsrc/source/_static/
 # Test environments and logs
 .hypothesis/
 .nox/
+
+
+# Auto-gen python files
+brevitas/function/ops_ste.py


### PR DESCRIPTION
Add export mode to QuantReLU which retrieves the new QuantReLUPlaceholderFunction. 
Export of layer of type QuantReLU was not previously supported.
Tested exporting a one layer net (QuantReLU)  for all combinations of:
"bit_width": [1, 2, 4, 8], 
"max_val": [1.0, 1 - 2 ** (-7),2]

@maltanar 
Fix export of QuantHardTanh export for abs(min_val) < max_val and when bipolar activation has scale != 1
Also, the scale can be different than:
max(abs(min), abs(max))/(2^(bit_width-1)-1) (for narrow range)
I guess this happens for ScalingImplType.PARAMETER.
The previous implementation didn't take this into account, subtracting min_val after scaling.

Export logic was changed to reflect current brevitas behavior. 

Tested exporting a one layer net (QuantHardTanh)  for all combinations for (ScalingImplType.CONST):
"bit_width": [1, 2, 4, 8], 
"narrow_range": [False, True],
"min_val": [-1.0, -(1 - 2 ** (-7)),-2]
"max_val": [1.0, 1 - 2 ** (-7),2]

