### PR TITLE
Fix for concat dimension when sharing proxy across layers

### DIFF
--- a/brevitas/nn/quant_conv.py
+++ b/brevitas/nn/quant_conv.py
@@ -141,7 +141,7 @@ class QuantConv2d(QuantLayer, Conv2d):
             self.weight_quant = weight_quant_override
             self.weight_quant.add_tracked_parameter(self.weight)
         else:
-            weight_scaling_stats_input_concat_dim = 1
+            weight_scaling_stats_input_concat_dim = 0
             if weight_scaling_per_output_channel:
                 weight_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_OUTPUT_CHANNELS
                 weight_scaling_shape = self.per_output_channel_broadcastable_shape

--- a/brevitas/nn/quant_conv1d.py
+++ b/brevitas/nn/quant_conv1d.py
@@ -140,7 +140,7 @@ class QuantConv1d(QuantLayer, Conv1d):
             self.weight_quant = weight_quant_override
             self.weight_quant.add_tracked_parameter(self.weight)
         else:
-            weight_scaling_stats_input_concat_dim = 1
+            weight_scaling_stats_input_concat_dim = 0
             if weight_scaling_per_output_channel:
                 weight_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_OUTPUT_CHANNELS
                 weight_scaling_shape = self.per_output_channel_broadcastable_shape

--- a/brevitas/nn/quant_convtranspose1d.py
+++ b/brevitas/nn/quant_convtranspose1d.py
@@ -148,7 +148,7 @@ class QuantConvTranspose1d(QuantLayer, ConvTranspose1d):
             self.weight_quant = weight_quant_override
             self.weight_quant.add_tracked_parameter(self.weight)
         else:
-            weight_scaling_stats_input_concat_dim = 1
+            weight_scaling_stats_input_concat_dim = 0
             if weight_scaling_per_output_channel:
                 weight_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_OUTPUT_CHANNELS
                 weight_scaling_shape = self.per_output_channel_broadcastable_shape

--- a/brevitas/nn/quant_linear.py
+++ b/brevitas/nn/quant_linear.py
@@ -118,7 +118,7 @@ class QuantLinear(QuantLayer, Linear):
             self.weight_quant = weight_quant_override
             self.weight_quant.add_tracked_tensor(self.weight)
         else:
-            weight_scaling_stats_input_concat_dim = 1
+            weight_scaling_stats_input_concat_dim = 0
             if weight_scaling_per_output_channel:
                 weight_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_OUTPUT_CHANNELS
                 weight_scaling_shape = (self.out_features, 1)


### PR DESCRIPTION
As per #157, this should fix the problem when sharing weight proxies.
A similar solution is already used in dev0.3 branch when sharing the same proxy for gates in LSTM/GRU.