### PR TITLE
Export QuantTensor

### DIFF
--- a/brevitas/nn/quant_avg_pool.py
+++ b/brevitas/nn/quant_avg_pool.py
@@ -49,6 +49,7 @@ from brevitas.core.quant import QuantType
 from brevitas.function.ops_ste import ceil_ste
 from brevitas.function.ops import max_uint
 from brevitas.nn.quant_layer import QuantLayer
+from brevitas.onnx.onnx_custom_ops import QuantAvgPool2dPlaceholderFunction
 from brevitas.proxy.runtime_quant import TruncQuantProxy
 from brevitas.quant_tensor import pack_quant_tensor
 
@@ -84,16 +85,44 @@ class QuantAvgPool2d(QuantLayer, AvgPool2d):
                                                  explicit_rescaling=explicit_rescaling,
                                                  override_pretrained_bit_width=False)
 
+        self.output_scale = None
+        self.shift_value = 0
+
+    @QuantLayer.export_mode.setter
+    def export_mode(self, value):
+        self._export_mode = value
+        shift_value = self.shift_value
+        in_shape = self.export_in_shape
+        self.shift_tensor = torch.ones((in_shape), dtype=torch.int32)
+        self.shift_tensor.new_full((in_shape), shift_value)
+
+
     def forward(self, input):
-        input_tensor, input_scale, input_bit_width = self.unpack_input(input)
-        x = super(QuantAvgPool2d, self).forward(input_tensor)
-        if self.quant_type != QuantType.FP:
-            x = x * (self.kernel_size * self.kernel_size)  # remove scaling introduced by average
-            output_bit_width = self.max_output_bit_width(input_bit_width)
-            x, output_scale, output_bit_width = self.accumulator_quant(x, input_scale, output_bit_width)
-            return pack_quant_tensor(x, output_scale, output_bit_width)
+        import pdb; pdb.set_trace()
+        if self.export_mode:
+            return QuantAvgPool2dPlaceholderFunction.apply(
+                input,
+                self.export_out_shape,
+                self.output_scale,
+                self.export_out_bit_width,
+                self.kernel_size,
+                self.stride,
+                self.shift_tensor,
+            )
         else:
-            return pack_quant_tensor(x, input_scale, input_bit_width)
+            input_tensor, input_scale, input_bit_width = self.unpack_input(input)
+            import pdb; pdb.set_trace()
+            x = super(QuantAvgPool2d, self).forward(input_tensor)
+            if self.quant_type != QuantType.FP:
+                x = x * (self.kernel_size * self.kernel_size)  # remove scaling introduced by average
+                max_output_bit_width = self.max_output_bit_width(input_bit_width)
+                x, output_scale, output_bit_width = self.accumulator_quant(x, input_scale, max_output_bit_width)
+                self.output_scale = output_scale
+                self.shift_value = max_output_bit_width - output_bit_width
+                import pdb; pdb.set_trace()
+                return self.pack_output(x, output_scale, output_bit_width)
+            else:
+                return self.pack_output(x, input_scale, input_bit_width)
 
     def max_output_bit_width(self, input_bit_width):
         max_uint_input = max_uint(bit_width=input_bit_width, narrow_range=False)

--- a/brevitas/nn/quant_avg_pool.py
+++ b/brevitas/nn/quant_avg_pool.py
@@ -49,7 +49,6 @@ from brevitas.core.quant import QuantType
 from brevitas.function.ops_ste import ceil_ste
 from brevitas.function.ops import max_uint
 from brevitas.nn.quant_layer import QuantLayer
-from brevitas.onnx.onnx_custom_ops import QuantAvgPool2dPlaceholderFunction
 from brevitas.proxy.runtime_quant import TruncQuantProxy
 from brevitas.quant_tensor import pack_quant_tensor
 
@@ -86,25 +85,15 @@ class QuantAvgPool2d(QuantLayer, AvgPool2d):
                                                  override_pretrained_bit_width=False)
 
     def forward(self, input):
-        if self.export_mode:
-            input_shape = []
-            for i in range(len(input.shape)):
-                input_shape.append(input.shape[i].item())
-            shift = 6
-            output_shape = (1, 1024, 1, 1)
-            return QuantAvgPool2dPlaceholderFunction.apply(
-                input, tuple(input_shape), output_shape, self.kernel_size, self.stride, self.quant_type, shift
-            )
+        input_tensor, input_scale, input_bit_width = self.unpack_input(input)
+        x = super(QuantAvgPool2d, self).forward(input_tensor)
+        if self.quant_type != QuantType.FP:
+            x = x * (self.kernel_size * self.kernel_size)  # remove scaling introduced by average
+            output_bit_width = self.max_output_bit_width(input_bit_width)
+            x, output_scale, output_bit_width = self.accumulator_quant(x, input_scale, output_bit_width)
+            return pack_quant_tensor(x, output_scale, output_bit_width)
         else:
-            input_tensor, input_scale, input_bit_width = self.unpack_input(input)
-            x = super(QuantAvgPool2d, self).forward(input_tensor)
-            if self.quant_type != QuantType.FP:
-                x = x * (self.kernel_size * self.kernel_size)  # remove scaling introduced by average
-                output_bit_width = self.max_output_bit_width(input_bit_width)
-                x, output_scale, output_bit_width = self.accumulator_quant(x, input_scale, output_bit_width)
-                return pack_quant_tensor(x, output_scale, output_bit_width)
-            else:
-                return pack_quant_tensor(x, input_scale, input_bit_width)
+            return pack_quant_tensor(x, input_scale, input_bit_width)
 
     def max_output_bit_width(self, input_bit_width):
         max_uint_input = max_uint(bit_width=input_bit_width, narrow_range=False)

--- a/brevitas/nn/quant_avg_pool.py
+++ b/brevitas/nn/quant_avg_pool.py
@@ -85,44 +85,26 @@ class QuantAvgPool2d(QuantLayer, AvgPool2d):
                                                  explicit_rescaling=explicit_rescaling,
                                                  override_pretrained_bit_width=False)
 
-        self.output_scale = None
-        self.shift_value = 0
-
-    @QuantLayer.export_mode.setter
-    def export_mode(self, value):
-        self._export_mode = value
-        shift_value = self.shift_value
-        in_shape = self.export_in_shape
-        self.shift_tensor = torch.ones((in_shape), dtype=torch.int32)
-        self.shift_tensor.new_full((in_shape), shift_value)
-
-
     def forward(self, input):
-        import pdb; pdb.set_trace()
         if self.export_mode:
+            input_shape = []
+            for i in range(len(input.shape)):
+                input_shape.append(input.shape[i].item())
+            shift = 6
+            output_shape = (1, 1024, 1, 1)
             return QuantAvgPool2dPlaceholderFunction.apply(
-                input,
-                self.export_out_shape,
-                self.output_scale,
-                self.export_out_bit_width,
-                self.kernel_size,
-                self.stride,
-                self.shift_tensor,
+                input, tuple(input_shape), output_shape, self.kernel_size, self.stride, self.quant_type, shift
             )
         else:
             input_tensor, input_scale, input_bit_width = self.unpack_input(input)
-            import pdb; pdb.set_trace()
             x = super(QuantAvgPool2d, self).forward(input_tensor)
             if self.quant_type != QuantType.FP:
                 x = x * (self.kernel_size * self.kernel_size)  # remove scaling introduced by average
-                max_output_bit_width = self.max_output_bit_width(input_bit_width)
-                x, output_scale, output_bit_width = self.accumulator_quant(x, input_scale, max_output_bit_width)
-                self.output_scale = output_scale
-                self.shift_value = max_output_bit_width - output_bit_width
-                import pdb; pdb.set_trace()
-                return self.pack_output(x, output_scale, output_bit_width)
+                output_bit_width = self.max_output_bit_width(input_bit_width)
+                x, output_scale, output_bit_width = self.accumulator_quant(x, input_scale, output_bit_width)
+                return pack_quant_tensor(x, output_scale, output_bit_width)
             else:
-                return self.pack_output(x, input_scale, input_bit_width)
+                return pack_quant_tensor(x, input_scale, input_bit_width)
 
     def max_output_bit_width(self, input_bit_width):
         max_uint_input = max_uint(bit_width=input_bit_width, narrow_range=False)

--- a/brevitas/nn/quant_avg_pool.py
+++ b/brevitas/nn/quant_avg_pool.py
@@ -51,6 +51,7 @@ from brevitas.function.ops import max_uint
 from brevitas.nn.quant_layer import QuantLayer
 from brevitas.proxy.runtime_quant import TruncQuantProxy
 from brevitas.quant_tensor import pack_quant_tensor
+from brevitas.onnx.onnx_custom_ops import QuantAvgPool2dPlaceholderFunction
 
 
 class QuantAvgPool2d(QuantLayer, AvgPool2d):
@@ -84,16 +85,32 @@ class QuantAvgPool2d(QuantLayer, AvgPool2d):
                                                  explicit_rescaling=explicit_rescaling,
                                                  override_pretrained_bit_width=False)
 
+    @QuantLayer.export_mode.setter
+    def export_mode(self, value):
+        self._export_mode = value
+        self.export_signed = 1 if self.signed else 0
+        self.export_ibits = int(self.export_in_bit_width.detach().item())
+        self.export_obits = int(self.export_out_bit_width.detach().item())
+
     def forward(self, input):
         input_tensor, input_scale, input_bit_width = self.unpack_input(input)
-        x = super(QuantAvgPool2d, self).forward(input_tensor)
-        if self.quant_type != QuantType.FP:
-            x = x * (self.kernel_size * self.kernel_size)  # remove scaling introduced by average
-            output_bit_width = self.max_output_bit_width(input_bit_width)
-            x, output_scale, output_bit_width = self.accumulator_quant(x, input_scale, output_bit_width)
-            return pack_quant_tensor(x, output_scale, output_bit_width)
+        if self.export_mode:
+            x = QuantAvgPool2dPlaceholderFunction.apply(
+                input_tensor, self.export_out_shape, self.kernel_size,
+                self.stride, self.signed, self.export_ibits,
+                self.export_obits
+            )
+            # scale & bitwidth not propagated during export
+            return x
         else:
-            return pack_quant_tensor(x, input_scale, input_bit_width)
+            x = super(QuantAvgPool2d, self).forward(input_tensor)
+            if self.quant_type != QuantType.FP:
+                x = x * (self.kernel_size * self.kernel_size)  # remove scaling introduced by average
+                output_bit_width = self.max_output_bit_width(input_bit_width)
+                x, output_scale, output_bit_width = self.accumulator_quant(x, input_scale, output_bit_width)
+                return self.pack_output(x, output_scale, output_bit_width)
+            else:
+                return self.pack_output(x, input_scale, input_bit_width)
 
     def max_output_bit_width(self, input_bit_width):
         max_uint_input = max_uint(bit_width=input_bit_width, narrow_range=False)

--- a/brevitas/nn/quant_conv.py
+++ b/brevitas/nn/quant_conv.py
@@ -146,7 +146,7 @@ class QuantConv2d(QuantLayer, Conv2d):
             self.weight_quant = weight_quant_override
             self.weight_quant.add_tracked_parameter(self.weight)
         else:
-            weight_scaling_stats_input_concat_dim = 1
+            weight_scaling_stats_input_concat_dim = 0
             if weight_scaling_per_output_channel:
                 weight_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_OUTPUT_CHANNELS
                 weight_scaling_shape = self.per_output_channel_broadcastable_shape

--- a/brevitas/nn/quant_conv1d.py
+++ b/brevitas/nn/quant_conv1d.py
@@ -140,7 +140,7 @@ class QuantConv1d(QuantLayer, Conv1d):
             self.weight_quant = weight_quant_override
             self.weight_quant.add_tracked_parameter(self.weight)
         else:
-            weight_scaling_stats_input_concat_dim = 1
+            weight_scaling_stats_input_concat_dim = 0
             if weight_scaling_per_output_channel:
                 weight_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_OUTPUT_CHANNELS
                 weight_scaling_shape = self.per_output_channel_broadcastable_shape

--- a/brevitas/nn/quant_convtranspose1d.py
+++ b/brevitas/nn/quant_convtranspose1d.py
@@ -148,7 +148,7 @@ class QuantConvTranspose1d(QuantLayer, ConvTranspose1d):
             self.weight_quant = weight_quant_override
             self.weight_quant.add_tracked_parameter(self.weight)
         else:
-            weight_scaling_stats_input_concat_dim = 1
+            weight_scaling_stats_input_concat_dim = 0
             if weight_scaling_per_output_channel:
                 weight_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_OUTPUT_CHANNELS
                 weight_scaling_shape = self.per_output_channel_broadcastable_shape

--- a/brevitas/nn/quant_layer.py
+++ b/brevitas/nn/quant_layer.py
@@ -57,6 +57,7 @@ class QuantLayer(object):
         # .forward with an appropriately-sized input at least once before export
         self.export_in_shape = None
         self.export_out_shape = None
+        self.export_out_bit_width = None
 
     @property
     def export_mode(self):
@@ -79,6 +80,8 @@ class QuantLayer(object):
                     output_scale,
                     output_bit_width):
         self.export_out_shape = output.shape
+        self.export_out_bit_width = output_bit_width
+
         if self.return_quant_tensor:
             return QuantTensor(tensor=output, scale=output_scale, bit_width=output_bit_width)
         else:

--- a/brevitas/nn/quant_layer.py
+++ b/brevitas/nn/quant_layer.py
@@ -57,6 +57,11 @@ class QuantLayer(object):
         # .forward with an appropriately-sized input at least once before export
         self.export_in_shape = None
         self.export_out_shape = None
+        # these will be assinged during a normal forward pass during inference
+        self.export_in_scale = None
+        self.export_in_bit_width = None
+        self.export_out_scale = None
+        self.export_out_bit_width = None
 
     @property
     def export_mode(self):
@@ -67,19 +72,41 @@ class QuantLayer(object):
         self._export_mode = value
 
     def unpack_input(self, input):
-        if isinstance(input, QuantTensor):
-            self.export_in_shape = input.tensor.shape
-            return input
+        if self._export_mode:
+            if isinstance(input, QuantTensor):
+                raise Exception("QuantTensor I/O may not be used during export.")
+            else:
+                # return cached scale and bit width
+                # if input was never QuantTensor, those will be None
+                # if input was QuantTensor but now isn't (e.g. due to switch
+                # to export mode where all i/o is single tensors), return the
+                # cached values
+                return input, self.export_in_scale, self.export_in_bit_width
         else:
-            self.export_in_shape = input.shape
-            return input, None, None
+            if isinstance(input, QuantTensor):
+                self.export_in_shape = input.tensor.shape
+                # TODO control caching with own config variable
+                self.export_in_scale = input[1]
+                self.export_in_bit_width = input[2]
+                return input
+            else:
+                self.export_in_shape = input.shape
+                return input, None, None
 
     def pack_output(self,
                     output,
                     output_scale,
                     output_bit_width):
-        self.export_out_shape = output.shape
-        if self.return_quant_tensor:
-            return QuantTensor(tensor=output, scale=output_scale, bit_width=output_bit_width)
-        else:
+        if self._export_mode:
+            # do not ever return QuantTensor while exporting
+            # cached scale factors will be used in the next layer
             return output
+        else:
+            self.export_out_shape = output.shape
+            # TODO control caching with own config variable
+            self.export_out_scale = output_scale
+            self.export_out_bit_width = output_bit_width
+            if self.return_quant_tensor:
+                return QuantTensor(tensor=output, scale=output_scale, bit_width=output_bit_width)
+            else:
+                return output

--- a/brevitas/nn/quant_layer.py
+++ b/brevitas/nn/quant_layer.py
@@ -57,7 +57,6 @@ class QuantLayer(object):
         # .forward with an appropriately-sized input at least once before export
         self.export_in_shape = None
         self.export_out_shape = None
-        self.export_out_bit_width = None
 
     @property
     def export_mode(self):
@@ -80,8 +79,6 @@ class QuantLayer(object):
                     output_scale,
                     output_bit_width):
         self.export_out_shape = output.shape
-        self.export_out_bit_width = output_bit_width
-
         if self.return_quant_tensor:
             return QuantTensor(tensor=output, scale=output_scale, bit_width=output_bit_width)
         else:

--- a/brevitas/nn/quant_linear.py
+++ b/brevitas/nn/quant_linear.py
@@ -124,7 +124,7 @@ class QuantLinear(QuantLayer, Linear):
             self.weight_quant = weight_quant_override
             self.weight_quant.add_tracked_tensor(self.weight)
         else:
-            weight_scaling_stats_input_concat_dim = 1
+            weight_scaling_stats_input_concat_dim = 0
             if weight_scaling_per_output_channel:
                 weight_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_OUTPUT_CHANNELS
                 weight_scaling_shape = (self.out_features, 1)

--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -58,7 +58,7 @@ class QuantizedHardTanhPlaceholderFunction(Function):
     def forward(ctx, input, qnt_type, thres, bias, scale):
         return input.clamp(0)
 
-# Do we need a separate Place holder for this? 
+# Do we need a separate Place holder for this?
 # Use QuantizedHardTanhPlaceholderFunction?
 # keeping same interface
 class QuantReLUPlaceholderFunction(Function):
@@ -73,3 +73,17 @@ class QuantReLUPlaceholderFunction(Function):
     @staticmethod
     def forward(ctx, input, qnt_type, thres, bias, scale):
         return input.clamp(0)
+
+
+class QuantAvgPool2dPlaceholderFunction(Function):
+    @staticmethod
+    def symbolic(g, input, out_shape, kernel, stride, signed, ibits, obits):
+        ret = g.op('QuantAvgPool2d', input, kernel_i = kernel,
+            stride_i = stride, signed_i = signed, ibits_i = ibits,
+            obits_i = obits
+        )
+        return ret
+
+    @staticmethod
+    def forward(ctx, input, out_shape, kernel, stride, signed, ibits, obits):
+        return torch.empty(out_shape, dtype = torch.float)

--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -1,6 +1,5 @@
 import torch
 from torch.autograd import Function
-from brevitas.quant_tensor import QuantTensor
 
 class QuantizedLinearPlaceholderFunction(Function):
     @staticmethod
@@ -74,20 +73,3 @@ class QuantReLUPlaceholderFunction(Function):
     @staticmethod
     def forward(ctx, input, qnt_type, thres, bias, scale):
         return input.clamp(0)
-
-class QuantAvgPool2dPlaceholderFunction(Function):
-    @staticmethod
-    def symbolic(g, input, input_shape, output_shape, kernel, stride, quant_type, shift):
-        import pdb; pdb.set_trace()
-        ret = g.op('AveragePool', input, kernel_dim_i = kernel,
-            stride_dim_i = stride, quant_type_s = quant_type)
-        ret = g.op('Cast', ret, to_s = "TensorProto.UINT32")
-        shift_tensor = torch.ones((input_shape), dtype=torch.int32)
-        shift_tensor.new_full((input_shape), shift)
-        ret = g.op('BitShift', ret, direction_s="RIGHT")
-        return ret
-
-    @staticmethod
-    def forward(ctx, input, input_shape, output_shape, kernel, stride, quant_type, shift):
-        import pdb; pdb.set_trace()
-        return torch.empty(output_shape, dtype = torch.float)

--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -1,6 +1,6 @@
 import torch
 from torch.autograd import Function
-from brevitas.quant_tensor import pack_quant_tensor
+from brevitas.quant_tensor import QuantTensor
 
 class QuantizedLinearPlaceholderFunction(Function):
     @staticmethod
@@ -77,17 +77,17 @@ class QuantReLUPlaceholderFunction(Function):
 
 class QuantAvgPool2dPlaceholderFunction(Function):
     @staticmethod
-    def symbolic(g, input, out_shape, out_scale, out_bit_width, kernel, stride, shift_tensor):
+    def symbolic(g, input, input_shape, output_shape, kernel, stride, quant_type, shift):
         import pdb; pdb.set_trace()
         ret = g.op('AveragePool', input, kernel_dim_i = kernel,
             stride_dim_i = stride, quant_type_s = quant_type)
         ret = g.op('Cast', ret, to_s = "TensorProto.UINT32")
-        ret = g.op('BitShift', ret, shift_tensor, direction_s="RIGHT")
-        if scale is not None:
-            ret = g.op('Mul', ret, out_scale)
+        shift_tensor = torch.ones((input_shape), dtype=torch.int32)
+        shift_tensor.new_full((input_shape), shift)
+        ret = g.op('BitShift', ret, direction_s="RIGHT")
         return ret
 
     @staticmethod
-    def forward(ctx, input, out_shape, out_scale, out_bit_width, kernel, stride, shift_tensor):
-        out_tensor = torch.empty(out_shape, dtype = torch.float)
-        return pack_quant_tensor(out_tensor, out_scale, out_bit_width)
+    def forward(ctx, input, input_shape, output_shape, kernel, stride, quant_type, shift):
+        import pdb; pdb.set_trace()
+        return torch.empty(output_shape, dtype = torch.float)

--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -78,9 +78,9 @@ class QuantReLUPlaceholderFunction(Function):
 class QuantAvgPool2dPlaceholderFunction(Function):
     @staticmethod
     def symbolic(g, input, out_shape, kernel, stride, signed, ibits, obits):
-        ret = g.op('QuantAvgPool2d', input, kernel_i = kernel,
-            stride_i = stride, signed_i = signed, ibits_i = ibits,
-            obits_i = obits
+        ret = g.op('QuantAvgPool2d', input, domain_s = "finn",
+            kernel_i = kernel, stride_i = stride, signed_i = signed,
+            ibits_i = ibits, obits_i = obits
         )
         return ret
 

--- a/brevitas/quant_tensor.py
+++ b/brevitas/quant_tensor.py
@@ -61,6 +61,13 @@ class QuantTensor(namedtuple("QuantTensor", ["tensor", "scale", "bit_width"])):
         if not torch.allclose(self.scale, other.scale):
             raise Exception("Scalign factors are different")
 
+    def view(self, *args, **kwargs):
+        output = pack_quant_tensor(self.tensor.view(*args, **kwargs), self.scale, self.bit_width)
+        return output
+
+    def size(self, *args, **kwargs):
+        return self.tensor.size(*args, **kwargs)
+
     # Reference: https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
 
     def __neg__(self):

--- a/brevitas_examples/bnn_pynq/cfg/cnv_1w1a.ini
+++ b/brevitas_examples/bnn_pynq/cfg/cnv_1w1a.ini
@@ -1,6 +1,7 @@
 [MODEL]
 ARCH: CNV
 PRETRAINED_URL: https://github.com/Xilinx/brevitas/releases/download/bnn_pynq-r0/cnv_1w1a-758c8fef.pth
+EVAL_LOG: https://github.com/Xilinx/brevitas/releases/download/cnv_test_ref-r0/cnv_1w1a_eval-ea2f0427.txt
 DATASET: CIFAR10
 IN_CHANNELS: 3
 NUM_CLASSES: 10

--- a/brevitas_examples/bnn_pynq/cfg/cnv_1w2a.ini
+++ b/brevitas_examples/bnn_pynq/cfg/cnv_1w2a.ini
@@ -1,6 +1,7 @@
 [MODEL]
 ARCH: CNV
 PRETRAINED_URL: https://github.com/Xilinx/brevitas/releases/download/bnn_pynq-r0/cnv_1w2a-23b6e2e4.pth
+EVAL_LOG: https://github.com/Xilinx/brevitas/releases/download/cnv_test_ref-r0/cnv_1w2a_eval-e730a76d.txt
 DATASET: CIFAR10
 IN_CHANNELS: 3
 NUM_CLASSES: 10

--- a/brevitas_examples/bnn_pynq/cfg/cnv_2w2a.ini
+++ b/brevitas_examples/bnn_pynq/cfg/cnv_2w2a.ini
@@ -1,6 +1,7 @@
 [MODEL]
 ARCH: CNV
 PRETRAINED_URL: https://github.com/Xilinx/brevitas/releases/download/bnn_pynq-r0/cnv_2w2a-0702987f.pth
+EVAL_LOG: https://github.com/Xilinx/brevitas/releases/download/cnv_test_ref-r0/cnv_2w2a_eval-5aaca4c6.txt
 DATASET: CIFAR10
 IN_CHANNELS: 3
 NUM_CLASSES: 10

--- a/brevitas_examples/imagenet_classification/models/mobilenetv1.py
+++ b/brevitas_examples/imagenet_classification/models/mobilenetv1.py
@@ -31,8 +31,6 @@ __all__ = ['quant_mobilenet_v1']
 from torch import nn
 from torch.nn import Sequential
 
-from brevitas.quant_tensor import pack_quant_tensor
-
 from .common import *
 
 
@@ -149,10 +147,10 @@ class MobileNet(nn.Module):
                                         weight_scaling_per_output_channel=False)
 
     def forward(self, x):
-        quant_tensor = self.features(x)
-        x, scale, bit_width = self.final_pool(quant_tensor)
+        x = self.features(x)
+        x = self.final_pool(x)
         x = x.view(x.size(0), -1)
-        out = self.output(pack_quant_tensor(x, scale, bit_width))
+        out = self.output(x)
         return out
 
 

--- a/brevitas_examples/imagenet_classification/models/proxylessnas.py
+++ b/brevitas_examples/imagenet_classification/models/proxylessnas.py
@@ -23,7 +23,6 @@ SOFTWARE.
 __all__ = ['quant_proxylessnas_mobile14']
 
 import torch.nn as nn
-from brevitas.quant_tensor import pack_quant_tensor
 
 from .common import *
 
@@ -276,9 +275,9 @@ class ProxylessNAS(nn.Module):
 
     def forward(self, x):
         x = self.features(x)
-        x, scale, bit_width = self.final_pool(x)
+        x = self.final_pool(x)
         x = x.view(x.size(0), -1)
-        x = self.output(pack_quant_tensor(x, scale, bit_width))
+        x = self.output(x)
         return x
 
 

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -2,3 +2,4 @@ bitstring
 onnx==1.5.0
 onnxruntime
 finn @ git+https://github.com/Xilinx/finn@dev#egg=finn
+toposort

--- a/test/brevitas_examples/test_pretrained_accuracy.py
+++ b/test/brevitas_examples/test_pretrained_accuracy.py
@@ -6,10 +6,10 @@ from brevitas_examples.bnn_pynq.bnn_pynq_train import main
 from brevitas_examples.bnn_pynq.models import get_model_cfg
 
 
-@pytest.mark.parametrize("model", ["TFC", "SFC", "LFC"])
+@pytest.mark.parametrize("model", ["TFC", "SFC", "LFC", "CNV"])
 @pytest.mark.parametrize("weight_bit_width", [1, 2])
 @pytest.mark.parametrize("act_bit_width", [1, 2])
-def test_bnn_pynq_fc_pretrained_accuracy(caplog, model, weight_bit_width, act_bit_width):
+def test_bnn_pynq_pretrained_accuracy(caplog, model, weight_bit_width, act_bit_width):
     if model == "LFC" and weight_bit_width == 2 and act_bit_width == 2:
         pytest.skip("No pretrained LFC_W2A2 present.")
     if weight_bit_width > act_bit_width:
@@ -21,6 +21,6 @@ def test_bnn_pynq_fc_pretrained_accuracy(caplog, model, weight_bit_width, act_bi
     eval_log_url = cfg.get('MODEL', 'EVAL_LOG')
     main(['--pretrained', '--network', network, '--evaluate', '--gpus', 'None'])
     with request.urlopen(eval_log_url) as r:
-        log_list = [l[l.index('Prec@1'):] for l in caplog.text.splitlines()]
-        reference_prec_list = [l[l.index('Prec@1'):] for l in r.read().decode('utf-8').splitlines()]
+        log_list = [l[l.index('Prec@1'):l.index('Prec@5')].rstrip() for l in caplog.text.splitlines()]
+        reference_prec_list = [l[l.index('Prec@1'):l.index('Prec@5')].rstrip() for l in r.read().decode('utf-8').splitlines()]
         assert log_list == reference_prec_list


### PR DESCRIPTION
FINN/ONNX export for any layers that use QuantTensor named 3-tuples fail at the moment. Based on our previous discussions I had a first stab at converting all I/O to non-QuantTensors (single tensors) without having to rewrite lots of Brevitas modules.

The core idea is to override the unpack_input and pack_output functions in QuantLayer to do the following:

When export mode is not enabled: cache the incoming/outgoing scale factor and bitwidth values as a member variable in QuantLayer
When export mode is enabled: return cached values for scale factor and bitwidth (if cached, otherwise None) from unpack_input, and always return a single tensor (no QuantTensor 3-tuple) from pack_output
Note that for this scheme to work, all Brevitas modules that want to accept/return QuantTensors must use the pack_input and unpack_output functions, if they manually instantiate a QuantTensor the hook will not catch this and the export will fail. From what I can see, only QuantAvgPool2d actually does this (it calls pack_quant_tensor directly, which is easy to change to pack_output) but I may have missed something, which is also fixed in this PR.