### PR TITLE
[ONNX] Add scale as additional input to exported QuantAvgPool2d node

### DIFF
--- a/brevitas/nn/quant_avg_pool.py
+++ b/brevitas/nn/quant_avg_pool.py
@@ -98,7 +98,7 @@ class QuantAvgPool2d(QuantLayer, AvgPool2d):
             x = QuantAvgPool2dPlaceholderFunction.apply(
                 input_tensor, self.export_out_shape, self.kernel_size,
                 self.stride, self.signed, self.export_ibits,
-                self.export_obits
+                self.export_obits, self.export_in_scale
             )
             # scale & bitwidth not propagated during export
             return x

--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -77,13 +77,13 @@ class QuantReLUPlaceholderFunction(Function):
 
 class QuantAvgPool2dPlaceholderFunction(Function):
     @staticmethod
-    def symbolic(g, input, out_shape, kernel, stride, signed, ibits, obits):
-        ret = g.op('QuantAvgPool2d', input, domain_s = "finn",
+    def symbolic(g, input, out_shape, kernel, stride, signed, ibits, obits, scale):
+        ret = g.op('QuantAvgPool2d', input, scale, domain_s = "finn",
             kernel_i = kernel, stride_i = stride, signed_i = signed,
             ibits_i = ibits, obits_i = obits
         )
         return ret
 
     @staticmethod
-    def forward(ctx, input, out_shape, kernel, stride, signed, ibits, obits):
+    def forward(ctx, input, out_shape, kernel, stride, signed, ibits, obits, scale):
         return torch.empty(out_shape, dtype = torch.float)


### PR DESCRIPTION
Add input_scale as additional input for QuantAvgPool2d layer export to support floating point input values.