### PR TITLE
[ONNX] Export QuantAvgPool2d with Div + CustomOp + Mul

### DIFF
--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -77,9 +77,9 @@ class QuantReLUPlaceholderFunction(Function):
 
 class QuantAvgPool2dPlaceholderFunction(Function):
     @staticmethod
-    def symbolic(g, input, out_shape, kernel, stride, signed, ibits, obits, scale):
+    def symbolic(g, input, out_shape, kernel, stride, signed, ibits, obits, scale, qnt_type):
         if scale is not None:
-            input = g.op('Div', input, scale)
+            input = g.op('Div', input, scale, activation_qnt_s = qnt_type)
         ret = g.op('QuantAvgPool2d', input, domain_s = "finn",
             kernel_i = kernel, stride_i = stride, signed_i = signed,
             ibits_i = ibits, obits_i = obits
@@ -89,5 +89,5 @@ class QuantAvgPool2dPlaceholderFunction(Function):
         return ret
 
     @staticmethod
-    def forward(ctx, input, out_shape, kernel, stride, signed, ibits, obits, scale):
+    def forward(ctx, input, out_shape, kernel, stride, signed, ibits, obits, scale, qnt_type):
         return torch.empty(out_shape, dtype = torch.float)

--- a/brevitas/onnx/onnx_custom_ops.py
+++ b/brevitas/onnx/onnx_custom_ops.py
@@ -78,10 +78,14 @@ class QuantReLUPlaceholderFunction(Function):
 class QuantAvgPool2dPlaceholderFunction(Function):
     @staticmethod
     def symbolic(g, input, out_shape, kernel, stride, signed, ibits, obits, scale):
-        ret = g.op('QuantAvgPool2d', input, scale, domain_s = "finn",
+        if scale is not None:
+            input = g.op('Div', input, scale)
+        ret = g.op('QuantAvgPool2d', input, domain_s = "finn",
             kernel_i = kernel, stride_i = stride, signed_i = signed,
             ibits_i = ibits, obits_i = obits
         )
+        if scale is not None:
+            ret = g.op('Mul', ret, scale)
         return ret
 
     @staticmethod


### PR DESCRIPTION
Change QuantAvgPool2d layer finn onnx export to export three onnx nodes (div, a custom node and mul) instead of one high level custom op.