### PR TITLE
Cleaned-up implementation of RoundToZero, including csrc files.

### DIFF
--- a/.github/workflows/develop_install.yml
+++ b/.github/workflows/develop_install.yml
@@ -2,9 +2,9 @@ name: Test develop install
 
 on:
   push:
-    branches: [ master, infra, dev, feature/finn_onnx_export, test_qntavgpool2d ]
+    branches: [ master, infra, dev, feature/finn_onnx_export ]
   pull_request:
-    branches: [ master, infra, dev, feature/finn_onnx_export, test_qntavgpool2d ]
+    branches: [ master, infra, dev, feature/finn_onnx_export ]
 
 jobs:
   build:

--- a/.github/workflows/finn_integration.yml
+++ b/.github/workflows/finn_integration.yml
@@ -2,9 +2,9 @@ name: Test Brevitas-FINN integration
 
 on:
   push:
-    branches: [ master, infra, dev, feature/finn_onnx_export_dev, test_qntavgpool2d ]
+    branches: [ master, infra, dev, feature/finn_onnx_export_dev ]
   pull_request:
-    branches: [ master, infra, dev, feature/finn_onnx_export_dev, test_qntavgpool2d ]
+    branches: [ master, infra, dev, feature/finn_onnx_export_dev ]
 
 jobs:
   build:

--- a/brevitas/core/function_wrapper.py
+++ b/brevitas/core/function_wrapper.py
@@ -38,8 +38,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from brevitas.function.ops_ste import round_ste, tensor_clamp_ste, ceil_ste, floor_ste
-from brevitas.function.ops import round_to_zero_ste
+from brevitas.function.ops_ste import round_ste, tensor_clamp_ste, ceil_ste, floor_ste, round_to_zero_ste
 from brevitas.function.shape import *
 from brevitas.function import tensor_clamp, identity
 
@@ -69,6 +68,7 @@ class FloorSte(torch.jit.ScriptModule):
     @torch.jit.script_method
     def forward(self, x: torch.Tensor):
         return floor_ste(x)
+
 
 class RoundToZeroSte(torch.jit.ScriptModule):
     def __init__(self) -> None:

--- a/brevitas/csrc/ops.hpp
+++ b/brevitas/csrc/ops.hpp
@@ -154,6 +154,20 @@ class TernarySignSteFn : public torch::autograd::Function<TernarySignSteFn> {
    }
 };
 
+class RoundToZeroFn : public torch::autograd::Function<RoundToZeroFn> {
+ public:
+  static variable_list forward(
+    AutogradContext* ctx,
+    Variable input){
+    return {torch::sign(input) * torch::floor(torch::abs(input))};
+   };
+
+   static variable_list backward(
+    AutogradContext* ctx,
+    variable_list grad_output){
+     return {grad_output[0]};
+   }
+};
 
 
 Tensor ceil_ste(
@@ -193,4 +207,9 @@ Tensor scalar_clamp_ste(
  const double min_val,
  const double max_val){
  return ScalarClampSteFn::apply(input, min_val, max_val)[0];
+};
+
+Tensor round_to_zero(
+ const Tensor& input){
+ return RoundToZeroFn::apply(input)[0];
 };

--- a/brevitas/csrc/ops_register.cpp
+++ b/brevitas/csrc/ops_register.cpp
@@ -51,4 +51,5 @@ static auto registry =
     .op("brevitas::binary_sign_ste", &binary_sign_ste)
     .op("brevitas::ternary_sign_ste", &ternary_sign_ste)
     .op("brevitas::ceil_ste", &ceil_ste)
-    .op("brevitas::floor_ste", &floor_ste);
+    .op("brevitas::floor_ste", &floor_ste)
+    .op("brevitas::round_to_zero", &round_to_zero);

--- a/brevitas/function/autograd_ops.py
+++ b/brevitas/function/autograd_ops.py
@@ -60,6 +60,7 @@ class scalar_clamp_ste_fn(torch.autograd.Function):
         """
         return grad_y, None, None
 
+
 class round_to_zero_ste_fn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x: torch.Tensor):

--- a/brevitas/function/ops.py
+++ b/brevitas/function/ops.py
@@ -39,7 +39,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import torch
-from brevitas.function.autograd_ops import round_to_zero_ste_fn
 
 @torch.jit.script
 def tensor_clamp(x: torch.Tensor, min_val: torch.Tensor, max_val: torch.Tensor) -> torch.Tensor:
@@ -70,9 +69,6 @@ def tensor_clamp_(x: torch.Tensor, min_val: torch.Tensor, max_val: torch.Tensor)
     torch.max(x, min_val, out=x)
     return x
 
-@torch.jit.ignore
-def round_to_zero_ste(x: torch.Tensor) -> torch.Tensor:
-    return round_to_zero_ste_fn.apply(x)
 
 @torch.jit.script
 def identity(x: torch.Tensor) -> torch.Tensor:

--- a/brevitas/function/ops_ste.py.template
+++ b/brevitas/function/ops_ste.py.template
@@ -237,3 +237,8 @@ def ternary_sign_ste(x: torch.Tensor) -> torch.Tensor:
 
     """
     return ${function_prefix}ternary_sign_ste${function_suffix}(x)
+
+
+${torch_jit_template}
+def round_to_zero_ste(x:torch.Tensor) -> torch.Tensor:
+    return ${function_prefix}round_to_zero_ste${function_suffix}(x)


### PR DESCRIPTION
Although not used, the RoundToZero implementation was only partial. These changes extend its implementation to be on the same level with the other Straight-Through-Estimator functions present in Brevitas.