### PR TITLE
Added a version requirement on typing-extensions>=3.7.4

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,4 +2,4 @@ torch>=1.1.0
 docrep
 packaging
 dependencies>=2.0.1
-typing-extensions
+typing-extensions>=3.7.4


### PR DESCRIPTION
With `typing-extensions==3.7.2` I get the following importation error:

```
 ImportError: cannot import name 'runtime_checkable'
```

v3.7.3 is not installable through `pip`, so wasn't tested.