### PR TITLE
Reimplement truncation and QuantAvgPool2d

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,12 @@
 
 Brevitas is a Pytorch library for quantization-aware training.
 
-*Brevitas is currently under active development and to be considered in alpha stage. APIs might and probably will change. Documentation, examples, and pretrained models will be progressively released.*
+*Brevitas is currently under active development and on a rolling release. It should be considered in beta stage. Minor API changes are still planned. Documentation, tests, examples, and pretrained models will be progressively released.*
 
 ## Requirements
-* [Pytorch](https://pytorch.org) >= 1.1.0
 
-## Introduction
-
-Brevitas implements a set of building blocks to model a reduced precision hardware data-path at training time.
-While partially biased towards modelling dataflow-style, very low-precision implementations, the building blocks can be parametrized and assembled together to target all sorts of reduced precision hardware.
-
-The implementations tries to adhere to the following design principles:
-- Idiomatic Pytorch, when possible.
-- Modularity first, at the cost of some verbosity.
-- Easily extendible.
-
-## Target audience
-Brevitas is mainly targeted at researchers and practicioners in the fields of training for reduced precision inference. 
-
-The implementation is quite rich in options and allows for very fine grained control over the trained model. 
-However, compared to other software solutions in this space, the burden of correctly modelling the target data-path is currently placed on the user. 
+* Python >= 3.6
+* [Pytorch](https://pytorch.org) >= 1.1.0 (minimal), 1.3.1 (suggested)
 
 
 ## Installation
@@ -38,77 +24,39 @@ You can install the latest master directly from GitHub:
 pip install git+https://github.com/Xilinx/brevitas.git
 ```
 
-##### Dev install
+## Introduction
 
-Alternatively, you can install a dev copy straight from the cloned repo:
+Brevitas implements a set of building blocks at different levels of abstraction to model a reduced precision hardware data-path at training time. 
 
-```bash
-git clone https://github.com/Xilinx/brevitas.git
-cd brevitas
-pip install -e .
-```
-
-## Features
-
-Brevitas' features are organized along the following (mostly) orthogonal axes:
-
-- **Quantization type**: binary, ternary, or uniform integer quantization.
-- **Target tensor**: weights, activations or accumulators.
-- **Scaling**: support for various shapes, learning strategies and constraints.
-- **Precision**: constant or learned bit-width.
-- **Cost**: model the hardware cost at training-time.
-
-
-## Supported Layers
-The following layers and operations are supported out-of-the-box:
-
-- QuantScaleBias
-- QuantLinear
-- QuantConv2d
-- QuantReLU, QuantHardTanh, QuantTanh, QuantSigmoid
-- QuantAvgPool2d
-- BatchNorm2dToQuantScaleBias
-- Element-wise add, concat
-- Saturating integer accumulator
-
-Additional layers can be easily supported using a combination of pre-existing modules.
-
+Brevitas provides a platform both for researchers interested in implementing new quantization-aware training techinques, as well as for practitioners interested in applying current techniques to their models.
 
 ## Getting started
 
-Here's how a simple quantized LeNet might look like, starting from a ReLU6 for activations and using default settings for scaling:
+Here's how a simple 4 bit weights, 8 bit activations LeNet looks like, using default settings for scaling:
 
 
 ```python
 from torch.nn import Module
 import torch.nn.functional as F
-import brevitas.nn as qnn
+from brevitas.nn import QuantIdentity, QuantConv2d, QuantReLU
 from brevitas.core.quant import QuantType
 
 class QuantLeNet(Module):
     def __init__(self):
         super(QuantLeNet, self).__init__()
-        self.conv1 = qnn.QuantConv2d(3, 6, 5, 
-                                     weight_quant_type=QuantType.INT, 
-                                     weight_bit_width=8)
-        self.relu1 = qnn.QuantReLU(quant_type=QuantType.INT, bit_width=8, max_val=6)
-        self.conv2 = qnn.QuantConv2d(6, 16, 5, 
-                                     weight_quant_type=QuantType.INT, 
-                                     weight_bit_width=8)
-        self.relu2 = qnn.QuantReLU(quant_type=QuantType.INT, bit_width=8, max_val=6)
-        self.fc1   = qnn.QuantLinear(16*5*5, 120, bias=True, 
-                                     weight_quant_type=QuantType.INT, 
-                                     weight_bit_width=8)
-        self.relu3 = qnn.QuantReLU(quant_type=QuantType.INT, bit_width=8, max_val=6)
-        self.fc2   = qnn.QuantLinear(120, 84, bias=True, 
-                                     weight_quant_type=QuantType.INT, 
-                                     weight_bit_width=8)
-        self.relu4 = qnn.QuantReLU(quant_type=QuantType.INT, bit_width=8, max_val=6)
-        self.fc3   = qnn.QuantLinear(84, 10, bias=False, 
-                                     weight_quant_type=QuantType.INT, 
-                                     weight_bit_width=8)
+        self.quant_inp = QuantIdentity(bit_width=8, min_val=-1.0, max_val=1.0)
+        self.conv1 = QuantConv2d(3, 6, 5, weight_bit_width=4)
+        self.relu1 = QuantReLU(bit_width=8, max_val=6)
+        self.conv2 = QuantConv2d(6, 16, 5, weight_bit_width=4)
+        self.relu2 = QuantReLU(bit_width=4, max_val=6)
+        self.fc1   = QuantLinear(16*5*5, 120, bias=True, weight_bit_width=4)
+        self.relu3 = QuantReLU(bit_width=8, max_val=6)
+        self.fc2   = QuantLinear(120, 84, bias=True, weight_bit_width=4)
+        self.relu4 = QuantReLU(bit_width=8, max_val=6)
+        self.fc3   = QuantLinear(84, 10, bias=False, weight_bit_width=4)
 
     def forward(self, x):
+        out = self.inp(x)
         out = self.relu1(self.conv1(x))
         out = F.max_pool2d(out, 2)
         out = self.relu2(self.conv2(out))
@@ -120,92 +68,8 @@ class QuantLeNet(Module):
         return out
 ```
 
-## Pretrained models
-
-Below a list of relevant pretrained models available, currently for evaluation only. Look at the `examples` folder for how to verify accuracy. Training scripts will be made available in the near future.
-
-
-| Name         | Scaling Type               | First layer weights | Weights | Activations | Avg pool | Top1  | Top5  | Pretrained model                                                                                | Retrained from                                                |
-|--------------|----------------------------|---------------------|---------|-------------|----------|-------|-------|-------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| MobileNet V1 | Floating-point per channel | 8 bit               | 4 bit   | 4 bit       | 4 bit    | 71.14 | 90.10 | [Download](https://github.com/Xilinx/brevitas/releases/download/quant_mobilenet_v1_4b-r1/quant_mobilenet_v1_4b-0100a667.pth) | [link](https://github.com/osmr/imgclsmob/tree/master/pytorch) |
-| ProxylessNAS Mobile14 w/ Hadamard classifier | Floating-point per channel | 8 bit               | 4 bit  | 4 bit       | 4 bit    | 73.52 | 91.46 | [Download](https://github.com/Xilinx/brevitas/releases/download/quant_proxylessnas_mobile14_hadamard_4b-r0/quant_proxylessnas_mobile14_hadamard_4b-4acbfa9f.pth) | [link](https://github.com/osmr/imgclsmob/tree/master/pytorch) |
-| ProxylessNAS Mobile14 | Floating-point per channel | 8 bit               | 4 bit  | 4 bit       | 4 bit    | 74.42 | 92.04 | [Download](https://github.com/Xilinx/brevitas/releases/download/quant_proxylessnas_mobile14_4b-r0/quant_proxylessnas_mobile14_4b-e10882e1.pth) | [link](https://github.com/osmr/imgclsmob/tree/master/pytorch) |
-| ProxylessNAS Mobile14 | Floating-point per channel | 8 bit               | 4 bit, 5 bit  | 4 bit, 5 bit       | 4 bit    | 75.01 | 92.33 | [Download](https://github.com/Xilinx/brevitas/releases/download/quant_proxylessnas_mobile14_4b5b-r0/quant_proxylessnas_mobile14_4b5b-2bdf7f8d.pth) | [link](https://github.com/osmr/imgclsmob/tree/master/pytorch) |
-
-
-## Scaling
-
-Brevitas supports multiple alternative options for scaling factors.
-
-
-With respect to the number of dimensions:
-- Per tensor or per (output) channel scaling, for both weights and activations.
-For activations, per channel scaling usually makes sense only before a depth-wise separable convolution.
-
-With respect to how they are learned:
-- As a standalone Pytorch *Parameter*, initialized from statistics (for weights) or from user-defined values (for activations).
-- as a statistical function of the full-precision version of the target tensor, possibly along with affine coefficients. 
-  Various function as supported, such as *max(abs(x))*, and more can be easily added. 
-  For activations, learning of this kind is done in the style of batch-norm, i.e. statistics are collected at training-time to use them at inference time.
-  In all cases, gradients are allowed to backprop through the defined function for best accuracy results.
-  
-Possibly shared between different layers that have to scaled equally:
-- By sharing the underlying Parameter, when the scale factor is a learned parameter.
-- By applying the statistical function to a concatenation of the different set of weights involved, when the scale factors are learned as a function of the weights.
-
-Possibly constrained to:
-- A standard floating point number, i.e. no restrictions.
-- A floating point power-of-two exponent, i.e. a floating point number learned in log domain.
-- An integer power-of-two value exponent, i.e. rounding the above fp log version to the next integer.
-
-
-## Precision
-Brevitas supports both constant and learned precision.
-
-In an quantization flow leveraging integer uniform quantization, the *bit-width* (together with the *sign*) determines the *min* and *max* integer values
-used for scaling and clamping. Assuming that an integer bit-width can be modelled as the rounded copy of an underlying floating point value (with a straight-through estimator in the backward pass), 
-all the operations involving bit-width are differentiable. As such, the bit-width can a learned parameter, 
-without resorting to more complicated approaches leveraging AutoML or Gumbel-Softmax categorical variables.
-
-- For weights and activation:
-Learned bit-width is equal to *base_bit_width + round_ste(abs(offset))*, where *base_bit_width* is a constant representing the minimum bit-width to converge to (required to be *>= 2*) and offset is a learned parameter.
-
-- For modelling an accumulator saturate to a learned bit width:
-The bit-width of the accumulator (computed by upstream layers) is taken as an input, and a learned negative offset is subtracted from it.
-In order to avoid conflicting with regularization losses that promotes small magnitude of learned parameters, such as weight-decay, 
-the offset is implemented with the learned parameter at the denominator, so that smaller values results in reduced overall bit-width.
-
-Additional requirements or relaxations can be put on the resulting bit-width:
-- Avoid the rounding step, and learn a floating point bit-width first (with the goal of retrained afterwards).
-- Constrain the bit width to power-of-two values, e.g. 2, 4, 8.
-- Share the learned bit-width between two or more layers, in order to e.g. keep the precision of a Conv2d layer and the precision of its input the same.
-
-
-
-## Code organization
-
-The implementation in organized in three different levels, each corresponding to a package:
-- **core**: contains the implementation of all Brevitas' quantization routines, leveraging the *JIT* as much as possible.
-- **proxy**: combines the routines implemented in the core in way that makes sense for different target tensors, namely weights, activations and accumulators.
-- **nn**: wraps the different proxies in a user-facing API, which can be used as a drop-in replacement for torch.nn modules. 
-
-Additionally, the following packages are present:
-- **function**: implements various support routines.
-- **cost**: exposes different loss functions for modelling the hardware cost at training-time or for regularization purposes. 
-
-## A note on the implementation
-
-Brevitas operates (possibly but not strictly) on a *QuantTensor*, currently implemented as a *NamedTuple* because of a lack of support for custom Tensor sub-classes in Pytorch. This might change in the future.
-
-A QuantTensor propagates the following information:
-- **quant_tensor**: the quantized tensor, in dequantized representation (i.e. floating-point order of magnitude).
-- **scale_factor**: the scale factor implicit in *quant_tensor*.
-- **bit_width**: the precision of *quant_tensor* in bits. 
-
-Propagating scale factors and bit-width along the forward pass allows to model and operate on accumulators, whose bit-width and scale factor depends on the layers contributing to them. 
-However, propagating a tuple of values in a forward() call breaks compatibility with certain modules like *nn.Sequential*, which assumes 1 input and 1 output. As such, operating on a QuantTensor is optional.
-
-
 ## Author
 
-Alessandro Pappalardo @ Xilinx Research Labs.
+Alessandro Pappalardo (@volcacius) @ Xilinx Research Labs.
+
+

--- a/brevitas/inject/defaults.py
+++ b/brevitas/inject/defaults.py
@@ -35,11 +35,9 @@ class DefaultActQuantInjector(Injector):
 
 class DefaultTruncQuantInjector(Injector):
     quant_type = 'INT'
-    lsb_trunc_bit_width_impl_type = 'CONST'
-    narrow_range = False
-    min_overall_bit_width = 2  # TODO deprecate
-    max_overall_bit_width = 32  # TODO deprecate
-    signed = True
+    bit_width_impl_type = 'CONST'
+    float_to_int_impl_type = 'FLOOR'
+    bit_width = 8
 
 
 class DefaultSignedActQuantInjector(DefaultActQuantInjector):

--- a/brevitas/nn/mixin/acc.py
+++ b/brevitas/nn/mixin/acc.py
@@ -98,22 +98,12 @@ class QuantTruncMixin(QuantAccMixin):
             proxy_from_injector_impl=TruncQuantProxyFromInjector,
             kwargs_prefix='',
             proxy_prefix='trunc_',
-            none_inject={'quant_type': None, 'lsb_trunc_bit_width_impl': None},
+            none_inject={'quant_type': None},
             **kwargs)
 
     @property
     def is_trunc_quant_enabled(self):
         return self.trunc_quant.is_quant_enabled
-
-    @property
-    def is_quant_trunc_narrow_range(self):
-        assert self.is_trunc_quant_enabled
-        return self.trunc_quant.is_narrow_range
-
-    @property
-    def is_quant_trunc_signed(self):
-        assert self.is_trunc_quant_enabled
-        return self.trunc_quant.is_signed
 
 
 class QuantClampMixin(QuantAccMixin):

--- a/brevitas/nn/quant_avg_pool.py
+++ b/brevitas/nn/quant_avg_pool.py
@@ -75,7 +75,6 @@ class QuantAvgPool2d(QuantTruncMixin, QuantLayerMixin, AvgPool2d):
             self,
             trunc_quant=trunc_quant,
             update_injector=update_injector,
-            ls_bit_width_to_trunc=math.ceil(math.log2(kernel_size * kernel_size)),
             **kwargs)
 
     @property

--- a/test/brevitas_finn_integration/brevitas/test_brevitas_avg_pool_export.py
+++ b/test/brevitas_finn_integration/brevitas/test_brevitas_avg_pool_export.py
@@ -23,9 +23,9 @@ export_onnx_path = "test_brevitas_avg_pool_export.onnx"
 
 @pytest.mark.parametrize("kernel_size", [2, 3])
 @pytest.mark.parametrize("stride", [1, 2])
-@pytest.mark.parametrize("signed", [False, True])
+@pytest.mark.parametrize("signed", [True, False])
 @pytest.mark.parametrize("bit_width", [2, 4])
-@pytest.mark.parametrize("input_bit_width", [4, 8, 32])
+@pytest.mark.parametrize("input_bit_width", [4, 8, 16])
 @pytest.mark.parametrize("channels", [2, 4])
 @pytest.mark.parametrize("idim", [7, 8])
 def test_brevitas_avg_pool_export(
@@ -36,11 +36,8 @@ def test_brevitas_avg_pool_export(
     b_avgpool = QuantAvgPool2d(
         kernel_size=kernel_size,
         stride=stride,
-        signed=signed,
-        min_overall_bit_width=bit_width,
-        max_overall_bit_width=bit_width,
-        quant_type=QuantType.INT,
-    )
+        bit_width=bit_width,
+        quant_type=QuantType.INT)
     # call forward pass manually once to cache scale factor and bitwidth
     input_tensor = torch.from_numpy(np.zeros(ishape)).float()
     scale = np.ones((1, channels, 1, 1))
@@ -54,7 +51,7 @@ def test_brevitas_avg_pool_export(
         prefix = "INT"
     else:
         prefix = "UINT"
-    dt_name = prefix + str(input_bit_width // 2)
+    dt_name = prefix + str(input_bit_width)
     dtype = DataType[dt_name]
     model = model.transform(InferShapes())
     model = model.transform(InferDataTypes())

--- a/test/brevitas_finn_integration/brevitas_examples/test_bnn_pynq_finn_export.py
+++ b/test/brevitas_finn_integration/brevitas_examples/test_bnn_pynq_finn_export.py
@@ -72,6 +72,8 @@ def test_brevitas_fc_onnx_export_and_exec(size, wbits, abits, pretrained):
     fc, _ = model_with_cfg(nname.lower(), pretrained=pretrained)
     FINNManager.export_onnx(fc, FC_INPUT_SIZE, finn_onnx)
     model = ModelWrapper(finn_onnx)
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(DoubleToSingleFloat())
     model = model.transform(InferShapes())
     model = model.transform(FoldConstants())
     model = model.transform(RemoveStaticGraphInputs())


### PR DESCRIPTION
Reimplement truncation by sticking to the principle (used already for weights and activations) that bit_width should specify the output bit width, not the bit width to remove (as it is currently). Behaviour doesn't change, but the API and the implementation is much simpler.