### PR TITLE
Core: add clamp_min_ste, fix bug caused by TODO in _RestrictClampValue

### DIFF
--- a/brevitas/core/function_wrapper.py
+++ b/brevitas/core/function_wrapper.py
@@ -149,6 +149,18 @@ class ClampMin(torch.jit.ScriptModule):
         return x.clamp_min(self.min_val)
 
 
+class ClampMinSte(torch.jit.ScriptModule):
+    __constants__ = ['min_val']
+
+    def __init__(self, min_val: float) -> None:
+        super(ClampMinSte, self).__init__()
+        self.min_val = min_val
+
+    @torch.jit.script_method
+    def forward(self, x: torch.Tensor):
+        return x.clamp_min(self.min_val)
+
+
 class OverTensorView(torch.jit.ScriptModule):
 
     def __init__(self) -> None:

--- a/brevitas/core/restrict_val.py
+++ b/brevitas/core/restrict_val.py
@@ -47,7 +47,7 @@ from torch.nn import Module
 
 from brevitas.inject.enum import RestrictValueType, FloatToIntImplType  # retrocompatibility
 
-from .function_wrapper import Identity, PowerOfTwo, LogTwo, ClampMin
+from .function_wrapper import Identity, PowerOfTwo, LogTwo, ClampMinSte
 
 assert RestrictValueType  # prevent removal of unused import
 assert FloatToIntImplType
@@ -60,12 +60,12 @@ class _RestrictClampValue(torch.jit.ScriptModule):
         self.restrict_value_impl = restrict_value_impl
         if scaling_min_val is not None and scaling_min_val != 0:
             scaling_min_val = restrict_value_impl.restrict_init_float(scaling_min_val)
-            self.clamp_min = ClampMin(scaling_min_val) # TODO: should be STE
+            self.clamp_min_ste = ClampMinSte(scaling_min_val)
         else:
-            self.clamp_min = Identity()
+            self.clamp_min_ste = Identity()
 
     def forward(self, x: torch.Tensor):
-        x = self.clamp_min(x)
+        x = self.clamp_min_ste(x)
         return self.restrict_value_impl(x)
 
 

--- a/brevitas/csrc/ops.hpp
+++ b/brevitas/csrc/ops.hpp
@@ -91,6 +91,25 @@ class ScalarClampSteFn : public torch::autograd::Function<ScalarClampSteFn> {
 };
 
 
+class ScalarClampMinSteFn : public torch::autograd::Function<ScalarClampMinSteFn> {
+ public:
+  static variable_list forward(
+    AutogradContext* ctx,
+    Variable input,
+    const double min_val){
+    Variable output;
+    output = at::clamp_min(input, min_val);
+    return {output};
+   };
+
+   static variable_list backward(
+    AutogradContext* ctx,
+    variable_list grad_output){
+     return {grad_output[0], Variable()};
+   }
+};
+
+
 class CeilSteFn : public torch::autograd::Function<CeilSteFn> {
  public:
   static variable_list forward(
@@ -207,6 +226,12 @@ Tensor scalar_clamp_ste(
  const double min_val,
  const double max_val){
  return ScalarClampSteFn::apply(input, min_val, max_val)[0];
+};
+
+Tensor scalar_clamp_min_ste(
+ const Tensor& input,
+ const double min_val){
+ return ScalarClampMinSteFn::apply(input, min_val)[0];
 };
 
 Tensor round_to_zero_ste(

--- a/brevitas/csrc/ops_register.cpp
+++ b/brevitas/csrc/ops_register.cpp
@@ -48,6 +48,7 @@ static auto registry =
     .op("brevitas::round_ste", &round_ste)
     .op("brevitas::tensor_clamp_ste", &tensor_clamp_ste)
     .op("brevitas::scalar_clamp_ste", &scalar_clamp_ste)
+    .op("brevitas::scalar_clamp_min_ste", &scalar_clamp_min_ste)
     .op("brevitas::binary_sign_ste", &binary_sign_ste)
     .op("brevitas::ternary_sign_ste", &ternary_sign_ste)
     .op("brevitas::ceil_ste", &ceil_ste)

--- a/brevitas/function/autograd_ops.py
+++ b/brevitas/function/autograd_ops.py
@@ -61,6 +61,26 @@ class scalar_clamp_ste_fn(torch.autograd.Function):
         return grad_y, None, None
 
 
+class scalar_clamp_min_ste_fn(torch.autograd.Function):
+    """ Autograd function that implements scalar_clamp_min with a straight through estimator
+
+    Look at the documentation of :func:`~brevitas.function.ops_ste.scalar_clamp_min_ste` for further details.
+
+    """
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, min_val: float):
+        """
+        """
+        y = torch.clamp_min(x, min_val)
+        return y
+
+    @staticmethod
+    def backward(ctx, grad_y):
+        """
+        """
+        return grad_y, None
+
+
 class round_to_zero_ste_fn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x: torch.Tensor):

--- a/brevitas/function/ops_ste.py.template
+++ b/brevitas/function/ops_ste.py.template
@@ -183,6 +183,34 @@ def scalar_clamp_ste(x: torch.Tensor, min_val: float, max_val: float) -> torch.T
 
 
 ${torch_jit_template}
+def scalar_clamp_min_ste(x: torch.Tensor, min_val: float) -> torch.Tensor:
+    """ Perform clamp_min operation with Straight Trough Estimation (STE) of the Gradient
+
+    This operation behaves like an identity on the backward pass.
+    For Pytorch version >= 1.3.0, the STE operator is implemented in C++ using the
+    torch::autograd::Function class and compiled. At execution time, the Just-In-Time (JIT) compiler of Pytorch
+    is used to speed-up the computation.
+    For Pytorch version < 1.3.0, the STE operator is implemented using the
+    torch.autograd.Function class in python, and the JIT cannot be used.
+
+
+    Parameters
+    ----------
+    x : Tensor
+        Tensor on which to apply the clamp operation
+    min_val : Float
+        Scalar containing the minimum value for the clamp operation
+
+    Returns
+    -------
+    Tensor
+        Tensor for which every element of `x` is clamped to `min_val`.
+        When backpropagating through this value, a straight through estimator is applied.
+    """
+    return ${function_prefix}scalar_clamp_min_ste${function_suffix}(x, min_val)
+
+
+${torch_jit_template}
 def binary_sign_ste(x: torch.Tensor) -> torch.Tensor:
     """ Perform binarization with Straight Trough Estimation (STE) of the Gradient
 


### PR DESCRIPTION
Leftover TODO was preventing propagation of gradients to scale factors or clamped bit width when a min value was set.