### PR TITLE
New activation quantization

### DIFF
--- a/brevitas/core/scaling.py
+++ b/brevitas/core/scaling.py
@@ -52,7 +52,6 @@ from .stats import _ParameterListStats, _RuntimeStats, _Stats, SCALAR_SHAPE
 from .utils import StatelessBuffer
 from .restrict_val import _RestrictClampValue
 
-SCALING_SCALAR_SHAPE = ()
 SCALING_STATS_REDUCE_DIM = 1
 DEFAULT_MOMENTUM = 0.1
 DEFAULT_AFFINE = False

--- a/brevitas/core/stats.py
+++ b/brevitas/core/stats.py
@@ -55,6 +55,7 @@ assert StatsOp  # prevent removal of unused import
 
 
 DEFAULT_STD_DEV_EPSILON = 1e-8
+SCALAR_SHAPE = ()
 
 
 class StatsInputViewShapeImpl(object):

--- a/brevitas/core/stats.py
+++ b/brevitas/core/stats.py
@@ -286,9 +286,11 @@ class _RuntimeStats(torch.jit.ScriptModule):
             stats_impl: nn.Module,
             stats_output_shape: Tuple[int, ...],
             stats_input_view_shape_impl: nn.Module,
-            stats_permute_dims: Tuple[int, ...],
+            stats_permute_dims: Optional[Tuple[int, ...]],
             stats_buffer_momentum: float) -> None:
         super(_RuntimeStats, self).__init__()
+        if stats_output_shape != SCALAR_SHAPE and stats_permute_dims is None:
+            raise RuntimeError("Per channel runtime stats require a permute shape")
         self.first_batch = torch.jit.Attribute(True, bool)
         self.stats_permute_dims = stats_permute_dims
         self.stats_input_view_shape_impl = stats_input_view_shape_impl

--- a/brevitas/core/stats.py
+++ b/brevitas/core/stats.py
@@ -38,6 +38,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import math
 from typing import Tuple, List, Optional
 
 from torch import nn
@@ -114,6 +115,30 @@ class _ViewCatParameterWrapper(torch.jit.ScriptModule):
         output_dict = super(_ViewCatParameterWrapper, self).state_dict(dest, prefix, keep_vars)
         del output_dict[prefix + 'parameter']
         return output_dict
+
+
+class AbsPercentile(torch.jit.ScriptModule):
+    __constants__ = ['q', 'stats_reduce_dim']
+
+    def __init__(self, percentile_q: float, stats_reduce_dim: Optional[int]):
+        super(AbsPercentile, self).__init__()
+        assert percentile_q <= 100, "q has to be a percentage"
+        self.q = percentile_q
+        self.stats_reduce_dim = stats_reduce_dim
+
+    def forward(self, x):
+        if self.stats_reduce_dim is None:
+            # k is 1-indexed, so round away from zero
+            k = math.floor(.01 * self.q * x.numel() + 0.5)
+            result = x.abs().view(-1).kthvalue(k).values
+        else:
+            # assuming x is two dimensional, get the other dimension
+            other_dim = abs(self.stats_reduce_dim - 1)
+            dim_slice = torch.narrow(x, dim=other_dim, start=0, length=1)
+            # k is 1-indexed, so round away from zero
+            k = math.floor(.01 * self.q * dim_slice.numel() + 0.5)
+            result = x.abs().kthvalue(k, dim=self.stats_reduce_dim).values
+        return result
 
 
 class AbsMax(torch.jit.ScriptModule):

--- a/brevitas/inject/solver.py
+++ b/brevitas/inject/solver.py
@@ -213,6 +213,7 @@ def _solve_act_scaling_impl_type(qi):
     solver = partial(_solve_attr, name='scaling_impl_type', solved_key='scaling_impl')
     qi = solver(qi, ScalingImplType.PARAMETER, ParameterScaling)
     qi = solver(qi, ScalingImplType.CONST, ConstScaling)
+    qi = solver(qi, ScalingImplType.PARAMETER_FROM_STATS, ParameterFromRuntimeStatsScaling)
     qi = solver(qi, ScalingImplType.STATS,
                  {'scaling_impl': RuntimeStatsScaling, 'affine_rescaling': False})
     qi = solver(qi, ScalingImplType.AFFINE_STATS,

--- a/brevitas/inject/solver.py
+++ b/brevitas/inject/solver.py
@@ -184,6 +184,7 @@ def _solve_scaling_stats_op(qi):
     qi = solver(qi, StatsOp.AVE, AbsAve)
     qi = solver(qi, StatsOp.MEAN_SIGMA_STD, MeanSigmaStd)
     qi = solver(qi, StatsOp.MEAN_LEARN_SIGMA_STD, MeanLearnedSigmaStd)
+    qi = solver(qi, StatsOp.PERCENTILE, AbsPercentile)
     qi = qi.let(sigma=this.scaling_stats_sigma)
     return qi
 

--- a/brevitas/inject/solver.py
+++ b/brevitas/inject/solver.py
@@ -51,7 +51,7 @@ from brevitas.core.function_wrapper import ConstScalarClamp
 from brevitas.core.bit_width import *
 from brevitas.core.quant import QuantType
 from brevitas.core.stats import *
-from brevitas.core.scaling import ScalingImplType, SCALING_SCALAR_SHAPE
+from brevitas.core.scaling import ScalingImplType, SCALAR_SHAPE
 from brevitas.proxy.utils import ConvertRuntimeStatsToParameter
 
 
@@ -297,7 +297,7 @@ def _solve_scaling_shape(qi, spoc, per_channel_shape_attr):
     name = 'scaling_shape'
     if name not in qi:
         if spoc: qi = qi.let(**{name: per_channel_shape_attr})
-        if not spoc: qi = qi.let(**{name: SCALING_SCALAR_SHAPE})
+        if not spoc: qi = qi.let(**{name: SCALAR_SHAPE})
     return qi
 
 

--- a/test/brevitas/core/test_stats.py
+++ b/test/brevitas/core/test_stats.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-     Xilinx, Inc              (Alessandro Pappalardo)
+# Copyright (c) 2020-     Xilinx, Inc              (Alessandro Pappalardo)
 # Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
 # Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
 # Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
@@ -38,51 +38,25 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from enum import auto
+import torch
 
-from brevitas.utils.python_utils import AutoName
-
-
-class BitWidthImplType(AutoName):
-    CONST = auto()
-    PARAMETER = auto()
+from brevitas.core.stats import AbsPercentile
 
 
-class QuantType(AutoName):
-    BINARY = auto()
-    TERNARY = auto()
-    INT = auto()
-    FP = auto()
+def test_abs_percentile_per_tensor():
+    values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    for v in values:
+        tensor = torch.Tensor(values)
+        abs_percentile = AbsPercentile(v * 10, None)
+        out = abs_percentile(tensor)
+        assert v == out.item()
 
 
-class RestrictValueType(AutoName):
-    FP = auto()
-    LOG_FP = auto()
-    INT = auto()
-    POWER_OF_TWO = auto()
-
-
-class FloatToIntImplType(AutoName):
-    ROUND = auto()
-    CEIL = auto()
-    FLOOR = auto()
-    ROUND_TO_ZERO = auto()
-
-
-class ScalingImplType(AutoName):
-    HE = auto()
-    CONST = auto()
-    STATS = auto()
-    AFFINE_STATS = auto()
-    PARAMETER = auto()
-    PARAMETER_FROM_STATS = auto()
-    OVERRIDE = auto()
-
-
-class StatsOp(AutoName):
-    MAX = auto()
-    AVE = auto()
-    MAX_AVE = auto()
-    MEAN_SIGMA_STD = auto()
-    MEAN_LEARN_SIGMA_STD = auto()
-    PERCENTILE = auto()
+def test_abs_percentile_per_channel():
+    v = 90
+    values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    tensor = torch.Tensor(values)
+    tensor = tensor.repeat(2, 1)
+    abs_percentile = AbsPercentile(v, stats_reduce_dim=1)
+    out = abs_percentile(tensor)
+    assert out.isclose(torch.Tensor([9, 9])).all().item()

--- a/test/brevitas/nn/test_act.py
+++ b/test/brevitas/nn/test_act.py
@@ -1,6 +1,7 @@
+import pytest
 import torch
-from brevitas.nn import QuantReLU
-from dependencies import Injector
+
+from brevitas.nn import QuantReLU, QuantIdentity
 
 
 class TestQuantReLU:
@@ -10,3 +11,25 @@ class TestQuantReLU:
 
     def test_module_init_const_scaling(self):
         mod = QuantReLU(max_val=6, scaling_impl_type='CONST')
+
+
+class TestQuantDelay:
+
+    @pytest.mark.parametrize("bw_quant_type", [(4, "INT"), (1, "BINARY"), (2, "TERNARY")])
+    def test_quant_identity_delay(self, bw_quant_type):
+        DELAY = 10
+        bit_width, quant_type = bw_quant_type
+        mod = QuantIdentity(
+            min_val=-6.0,
+            max_val=6.0,
+            threshold=0.5,  # for ternary quant
+            bit_width=bit_width,
+            quant_type=quant_type,
+            quant_delay_steps=DELAY)
+        for i in range(DELAY):
+            t = torch.randn(1, 10, 5, 5)
+            out = mod(t)
+            assert t.isclose(out).all().item()
+        t = torch.randn(1, 10, 5, 5)
+        out = mod(t)
+        assert not t.isclose(out).all().item()

--- a/test/brevitas/nn/test_act.py
+++ b/test/brevitas/nn/test_act.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from brevitas.nn import QuantReLU, QuantIdentity
-
+from common import check_expected_pyt_110_fail
 
 class TestQuantReLU:
 
@@ -15,6 +15,7 @@ class TestQuantReLU:
 
 class TestQuantDelay:
 
+    @check_expected_pyt_110_fail
     @pytest.mark.parametrize("bw_quant_type", [(4, "INT"), (1, "BINARY"), (2, "TERNARY")])
     def test_quant_identity_delay(self, bw_quant_type):
         DELAY = 10

--- a/test/brevitas/proxy/test_act_scaling.py
+++ b/test/brevitas/proxy/test_act_scaling.py
@@ -16,12 +16,13 @@ class TestQuantReLU:
     @check_expected_pyt_110_fail
     def test_scaling_stats_to_parameter(self):
 
-        stats_act = QuantReLU(bit_width=BIT_WIDTH,
-                              max_val=MAX_VAL,
-                              quant_type=QuantType.INT,
-                              scaling_impl_type=ScalingImplType.STATS,
-                              scaling_stats_permute_dims=(1, 0, 2, 3),
-                              scaling_stats_op=StatsOp.MAX)
+        stats_act = QuantReLU(
+            bit_width=BIT_WIDTH,
+            max_val=MAX_VAL,
+            quant_type=QuantType.INT,
+            scaling_impl_type=ScalingImplType.STATS,
+            scaling_stats_permute_dims=None,
+            scaling_stats_op=StatsOp.MAX)
         stats_act.train()
         for i in range(RANDOM_ITERS):
             inp = torch.randn([8, 3, 64, 64])
@@ -29,10 +30,11 @@ class TestQuantReLU:
 
         stats_state_dict = stats_act.state_dict()
 
-        param_act = QuantReLU(bit_width=BIT_WIDTH,
-                              max_val=MAX_VAL,
-                              quant_type=QuantType.INT,
-                              scaling_impl_type=ScalingImplType.PARAMETER)
+        param_act = QuantReLU(
+            bit_width=BIT_WIDTH,
+            max_val=MAX_VAL,
+            quant_type=QuantType.INT,
+            scaling_impl_type=ScalingImplType.PARAMETER)
         param_act.load_state_dict(stats_state_dict)
 
         stats_act.eval()

--- a/test/brevitas/proxy/test_act_scaling.py
+++ b/test/brevitas/proxy/test_act_scaling.py
@@ -42,6 +42,7 @@ class TestQuantReLU:
 
         assert(torch.allclose(stats_act.quant_act_scale(), param_act.quant_act_scale()))
 
+    @check_expected_pyt_110_fail
     def test_scaling_parameter_grad(self):
         stats_act = QuantReLU(
             bit_width=BIT_WIDTH,


### PR DESCRIPTION
Support for:
- percentile statistics (to collect 99.999% percentile of activation)
- parameter from runtime stats (to convert percentile statistics after a number of steps)
- delayed quantization (to delay quantization while collecting statistics)