### PR TITLE
FINN ONNX domain update

### DIFF
--- a/brevitas/onnx/debug.py
+++ b/brevitas/onnx/debug.py
@@ -8,7 +8,7 @@ class DebugMarkerFunction(Function):
 
     @staticmethod
     def symbolic(g, input, export_debug_name):
-        ret = g.op('DebugMarker', input, export_debug_name_s=export_debug_name, domain_s="finn")
+        ret = g.op('DebugMarker', input, export_debug_name_s=export_debug_name, domain_s="finn.custom_op.general")
         return ret
 
     @staticmethod

--- a/brevitas/onnx/finn/function/acc.py
+++ b/brevitas/onnx/finn/function/acc.py
@@ -10,7 +10,7 @@ class QuantAvgPool2dPlaceholderFunction(Function):
             input = g.op('Div', input, scale, activation_qnt_s=qnt_type)
         ret = g.op(
             'QuantAvgPool2d', input,
-            domain_s="finn",
+            domain_s="finn.custom_op.general",
             kernel_i=kernel,
             stride_i=stride,
             signed_i=signed,

--- a/brevitas/onnx/finn/function/act.py
+++ b/brevitas/onnx/finn/function/act.py
@@ -8,12 +8,12 @@ class QuantHardTanhPlaceholderFunction(Function):
         if qnt_type == "BIPOLAR":
             return g.op(
                 'MultiThreshold', input, thres,
-                domain_s="finn",
+                domain_s="finn.custom_op.general",
                 out_dtype_s=qnt_type,
                 out_scale_f=2.0,
                 out_bias_f=-1.0)
         else:
-            ret = g.op('MultiThreshold', input, thres, domain_s="finn", out_dtype_s=qnt_type)
+            ret = g.op('MultiThreshold', input, thres, domain_s="finn.custom_op.general", out_dtype_s=qnt_type)
             if bias is not None:
                 ret = g.op('Add', ret, bias)
             if scale is not None:
@@ -30,7 +30,7 @@ class QuantReLUPlaceholderFunction(Function):
     @staticmethod
     def symbolic(g, input, qnt_type, thres, bias, scale):
         ret = g.op('MultiThreshold', input, thres,
-                   domain_s="finn", out_dtype_s=qnt_type)
+                   domain_s="finn.custom_op.general", out_dtype_s=qnt_type)
         if scale is not None:
             ret = g.op('Mul', ret, scale)
         return ret


### PR DESCRIPTION
To make FINN custom ops more modular we've slightly changed how we use the `domain` field in ONNX nodes. This means the exported custom ops from Brevitas should now have `domain=finn.custom_op.general` instead of just `domain=finn`. This PR addresses that.

For more info please see: https://github.com/Xilinx/finn-base/pull/6