### PR TITLE
Clamp Half-precision tensors

### DIFF
--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -112,8 +112,8 @@ def tensor_clamp(x: Tensor, min_val: Tensor, max_val: Tensor) -> Tensor:
         >>> tensor_clamp(torch.tensor([1.7, -0.5, 0.1]), torch.tensor(0.0), torch.tensor(1.0))
         tensor([1.0000, 0.0000, 0.1000])
     """
-    out = torch.where(x > max_val, max_val, x)
-    out = torch.where(out < min_val, min_val, out)
+    out = torch.where(x > max_val, max_val.type_as(x), x)
+    out = torch.where(out < min_val, min_val.type_as(x), out)
     return out
 
 

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -113,7 +113,7 @@ def tensor_clamp(x: Tensor, min_val: Tensor, max_val: Tensor) -> Tensor:
         tensor([1.0000, 0.0000, 0.1000])
     """
     out = torch.where(x > max_val, max_val.type_as(x), x)
-    out = torch.where(out < min_val, min_val.type_as(x), out)
+    out = torch.where(out < min_val, min_val.type_as(out), out)
     return out
 
 


### PR DESCRIPTION
The current implementation of `tensor_clamp` does not work if the input tensor is not the same type as `min_val` and `max_val`. One case where this would happen is if PyTorch's AMP is being used to train at half-precision. With this change, half-precision training is enabled and allowed a 2x training speedup in my use-case. 

This fix was accomplished by casting `min_val` and `max_val` to match the type of input `x` using [`torch.Tensor.type_as()`](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.type_as). Per PyTorch's docs, this results in a no-op if the types already match so there should be no performance hit from this change on standard-precision training.

Thanks for all the great work guys!