### PR TITLE
Fix resuming in brevitas_bnn_pynq_train by adding strict arg

### DIFF
--- a/src/brevitas_examples/bnn_pynq/bnn_pynq_train.py
+++ b/src/brevitas_examples/bnn_pynq/bnn_pynq_train.py
@@ -81,6 +81,7 @@ def parse_args(args):
     # Neural network Architecture
     parser.add_argument("--network", default="LFC_1W1A", type=str, help="neural network")
     parser.add_argument("--pretrained", action='store_true', help="Load pretrained model")
+    parser.add_argument("--strict", action='store_true', help="Strict state dictionary loading")
     return parser.parse_args(args)
 
 


### PR DESCRIPTION
Fix resuming from a checkpoint by adding a `strict` arg, which is expected here: https://github.com/Xilinx/brevitas/blob/dev/src/brevitas_examples/bnn_pynq/trainer.py#L156

Otherwise, the current code doesn't work, for example:
```bash
BREVITAS_JIT=1 brevitas_bnn_pynq_train --network CNV_1W1A --experiments /path/to/experiments --epochs 1
BREVITAS_JIT=1 brevitas_bnn_pynq_train --network CNV_1W1A --resume /path/to/checkpoint.tar --evaluate
```
