### PR TITLE
Fix order of return values/arguments

### DIFF
--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -198,15 +198,15 @@ class BiasQuantProxyFromInjector(ParameterQuantProxyFromInjector, BiasQuantProxy
                 raise RuntimeError("Input bit-width required")
             if self.requires_input_scale and self.requires_input_bit_width:
                 input_scale = input_scale.view(-1)
-                out, out_scale, out_bit_width, out_zp = impl(x, input_scale, input_bit_width)
+                out, out_scale, out_zp, out_bit_width = impl(x, input_scale, input_bit_width)
             elif self.requires_input_scale and not self.requires_input_bit_width:
                 input_scale = input_scale.view(-1)
-                out, out_scale, out_bit_width, out_zp = impl(x, input_scale)
+                out, out_scale, out_zp, out_bit_width = impl(x, input_scale)
             elif not self.requires_input_scale and not self.requires_input_bit_width:
-                out, out_scale, out_bit_width, out_zp = impl(x)
+                out, out_scale, out_zp, out_bit_width = impl(x)
             else:
                 raise RuntimeError("Internally defined bit-width required")
-            return QuantTensor(out, out_scale, out_bit_width, out_zp, self.is_signed, self.training)
+            return QuantTensor(out, out_scale, out_zp, out_bit_width, self.is_signed, self.training)
         else:
             return QuantTensor(x, training=self.training)
 


### PR DESCRIPTION
100th fork :tada: 

This fixes issue #352 by simply swapping `out_bit_width` and `out_zp` every time they appear in the `forward` function.
As such, this should have no effect on the result (the resulting `QuantTensor` will be the same).