### PR TITLE
Fix (onnx): enable_onnx_checker only for correct torch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you adopt Brevitas in your work, please cite it as:
 
 
 ## History
+
+- *2021/12/13* - Release version 0.7.1, fix a bunch of issues. Added TVMCon 2021 tutorial notebook.
 - *2021/11/03* - Re-release version 0.7.0 (build 1) on PyPI to fix a packaging issue.
 - *2021/10/29* - Release version 0.7.0, see the [release notes](https://github.com/Xilinx/brevitas/releases/tag/v0.7.0).
 - *2021/06/04* - Release version 0.6.0, see the [release notes](https://github.com/Xilinx/brevitas/releases/tag/v0.6.0).

--- a/src/brevitas/export/onnx/manager.py
+++ b/src/brevitas/export/onnx/manager.py
@@ -47,7 +47,9 @@ class ONNXBaseManager(BaseManager, ABC):
     @classmethod
     def solve_enable_onnx_checker(cls, export_kwargs):
         ka = 'enable_onnx_checker'
-        if torch_version >= version.parse('1.5.0') and ka not in export_kwargs:
+        if torch_version >= version.parse('1.5.0') \
+            and torch_version <= version.parse('1.10.0') \
+            and ka not in export_kwargs:
             export_kwargs[ka] = False
 
     @classmethod


### PR DESCRIPTION
The `enable_onnx_checker` feature was deprecated and removed starting with torch 1.10

This may close #402 