### PR TITLE
[requirements] Updated requirements to reflect the requirements stated in the README

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.1.0
+torch>=1.5.0
 packaging
 setuptools
 future-annotations


### PR DESCRIPTION
If an unsupported version of PyTorch is installed, importing Brevitas classes results in errors, such as:

```
Traceback (most recent call last):                                                                                                                                                                                                             
  File "static_analysis.py", line 10, in <module>                                                                                                                                                                                              
    from brevitas.core.quant import QuantType                                                                                                                                                                                                  
  File "/proj/xlabs/users/nfraser/opt/miniforge3/envs/qrn50_brv0.6_20220714/lib/python3.6/site-packages/brevitas/__init__.py", line 25, in <module>                                                                                            
    from torch._overrides import has_torch_function, handle_torch_function                                                                                                                                                                     
ModuleNotFoundError: No module named 'torch._overrides'
```

Ideally, `pip` should spot that the wrong version of PyTorch is installed.