### PR TITLE
Fix (flexml): PTQ calibration fix for training/eval mode

### DIFF
--- a/notebooks/Brevitas_TVMCon2021.ipynb
+++ b/notebooks/Brevitas_TVMCon2021.ipynb
@@ -2242,16 +2242,16 @@
    "source": [
     "from brevitas.graph.calibrate import finalize_collect_stats\n",
     "from brevitas.graph.calibrate import BiasCorrection\n",
-    "from brevitas.graph.calibrate import DisableQuantInference\n",
+    "from brevitas.graph.calibrate import calibration_mode\n",
     "\n",
     "def calibrate_model(calibration_loader, quant_model, args):\n",
     "    with torch.no_grad():\n",
-    "        # Put the model in training mode to collect statistics\n",
-    "        quant_model.train()\n",
-    "        for i, (images, _) in enumerate(calibration_loader):\n",
-    "            print(f'Calibration iteration {i}')\n",
-    "            # Disable quantization while collecting statistics\n",
-    "            DisableQuantInference().apply(quant_model, images)\n",
+    "        # Put the model in calibration mode to collect statistics\n",
+    "        # Quantization is automatically disabled during the calibration, and re-enabled at the end\n",
+    "        with calibration_mode(quant_model):\n",
+    "            for i, (images, _) in enumerate(calibration_loader):\n",
+    "                print(f'Calibration iteration {i}')\n",
+    "                quant_model(images)\n",
     "        # Put the model in inference mode to use those statistics\n",
     "        quant_model.eval()\n",
     "        bc = BiasCorrection(iterations=len(calibration_loader))\n",
@@ -2259,8 +2259,8 @@
     "            print(f'Bias correction iteration {i}')\n",
     "            # Apply bias correction\n",
     "            quant_model = bc.apply(quant_model, images)\n",
-    "    model.apply(finalize_collect_stats)\n",
-    "    return model"
+    "    quant_model.apply(finalize_collect_stats)\n",
+    "    return quant_model"
    ]
   }
  ],

--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -18,7 +18,6 @@ from .base import Transform
 __all__ = [
     'ClipFloatWeights',
     'DisableEnableQuantization',
-    'DisableQuantInference',
     'BiasCorrection',
     'calibration_mode'
 ]

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -1,0 +1,68 @@
+import torch
+import brevitas.nn as qnn
+import torch.nn as nn
+from brevitas.graph.calibrate import calibration_mode,finalize_collect_stats
+from brevitas.quant import Int8ActPerTensorFixedPoint
+from tests.brevitas.hyp_helper import float_tensor_random_size_st
+from hypothesis import given
+import math
+
+def compute_quantile(x, q):
+    k = int(math.floor(.01 * q * x.numel() + 0.5))
+    result = x.abs().view(-1).kthvalue(k).values
+    return result
+
+def reference_implementation_scale_factors_po2(x, q=99.999, min_val=torch.tensor(1e-10)):
+    quant = compute_quantile(x,q)
+    quant = torch.max(min_val, quant)
+    quant_float_to_int = torch.ceil(torch.log2(quant)) # Float to Int Implementation for PowerOfTwo scale
+    
+    int_scale = 128. # Signed, PowerOfTwo int scale
+    scale =  torch.pow(torch.tensor(2.), quant_float_to_int)/int_scale
+    
+    return scale
+
+@given(inp=float_tensor_random_size_st())
+def test_scale_factors_ptq_calibration_po2(inp):
+    class TestModel(nn.Module):
+
+        def __init__(self):
+            super(TestModel, self).__init__()
+            self.act = qnn.QuantIdentity(Int8ActPerTensorFixedPoint)
+
+        def forward(self, x):
+            return self.act(x)
+        
+    model = TestModel()
+    model.eval()
+    with torch.no_grad():
+        with calibration_mode(model):
+            model(inp)
+    model.apply(finalize_collect_stats)
+
+    expected_scale = reference_implementation_scale_factors_po2(inp)
+    scale = model.act.quant_act_scale()
+
+    assert torch.allclose(expected_scale, scale)
+
+
+def test_calibration_training_state():
+    
+    class TestModel(nn.Module):
+
+        def __init__(self):
+            super(TestModel, self).__init__()
+            self.act = qnn.QuantIdentity(Int8ActPerTensorFixedPoint)
+
+        def forward(self, x):
+            return self.act(x)
+        
+    model = TestModel()
+    model.eval()
+    with torch.no_grad():
+        with calibration_mode(model):
+            assert model.act.act_quant.training == True
+            assert model.training == False
+    
+    assert model.act.act_quant.training == False
+    assert model.training == False

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -12,12 +12,11 @@ def compute_quantile(x, q):
     result = x.abs().view(-1).kthvalue(k).values
     return result
 
-def reference_implementation_scale_factors_po2(x, q=99.999, min_val=torch.tensor(1e-10)):
+def reference_implementation_scale_factors_po2(x, q=99.999, min_val=torch.tensor(1e-10), int_scale=128.):
     quant = compute_quantile(x,q)
     quant = torch.max(min_val, quant)
     quant_float_to_int = torch.ceil(torch.log2(quant)) # Float to Int Implementation for PowerOfTwo scale
     
-    int_scale = 128. # Signed, PowerOfTwo int scale
     scale =  torch.pow(torch.tensor(2.), quant_float_to_int)/int_scale
     
     return scale
@@ -28,7 +27,7 @@ def test_scale_factors_ptq_calibration_po2(inp):
 
         def __init__(self):
             super(TestModel, self).__init__()
-            self.act = qnn.QuantIdentity(Int8ActPerTensorFixedPoint)
+            self.act = qnn.QuantIdentity(act_quant=Int8ActPerTensorFixedPoint)
 
         def forward(self, x):
             return self.act(x)
@@ -52,7 +51,7 @@ def test_calibration_training_state():
 
         def __init__(self):
             super(TestModel, self).__init__()
-            self.act = qnn.QuantIdentity(Int8ActPerTensorFixedPoint)
+            self.act = qnn.QuantIdentity(act_quant=Int8ActPerTensorFixedPoint)
 
         def forward(self, x):
             return self.act(x)


### PR DESCRIPTION
Fix for correct handling of training state of layers and proxies during calibration.

BiasCorrection requires more adaptations to match this interface.

```python
self.model = quantize_flexml(self.model)
self.model.eval()
with torch.no_grad():
    with do_calibration(self.model):
        for i, (images, _) in enumerate(self.dataloader_calibration):
            out = self.model(images)
```