### PR TITLE
fixed wrong runtime shape inference for BatchNorm1dToQuantScaleBias

### DIFF
--- a/src/brevitas/nn/quant_bn.py
+++ b/src/brevitas/nn/quant_bn.py
@@ -97,7 +97,7 @@ class BatchNorm1dToQuantScaleBias(_BatchNormToQuantScaleBias):
         super(BatchNorm1dToQuantScaleBias, self).__init__(
             num_features,
             bias=True,
-            runtime_shape=(1, -1),
+            runtime_shape=(1, -1, 1),
             weight_quant=weight_quant,
             bias_quant=bias_quant,
             input_quant=input_quant,

--- a/src/brevitas/nn/quant_bn.py
+++ b/src/brevitas/nn/quant_bn.py
@@ -97,7 +97,7 @@ class BatchNorm1dToQuantScaleBias(_BatchNormToQuantScaleBias):
         super(BatchNorm1dToQuantScaleBias, self).__init__(
             num_features,
             bias=True,
-            runtime_shape=(1, -1, 1),
+            runtime_shape=(1, -1),
             weight_quant=weight_quant,
             bias_quant=bias_quant,
             input_quant=input_quant,

--- a/src/brevitas/nn/quant_scale_bias.py
+++ b/src/brevitas/nn/quant_scale_bias.py
@@ -80,8 +80,9 @@ class QuantScaleBias(QuantWBIOL, ScaleBias):
             input_quant: Optional[ActQuantType] = None,
             output_quant: Optional[ActQuantType] = None,
             return_quant_tensor: bool = False,
+            runtime_shape=(1, -1, 1, 1),
             **kwargs) -> None:
-        ScaleBias.__init__(self, num_features, bias)
+        ScaleBias.__init__(self, num_features, bias, runtime_shape=runtime_shape)
         QuantWBIOL.__init__(
             self,
             weight_quant=weight_quant,


### PR DESCRIPTION
Fixed issue where the output shape of `class BatchNorm1dToQuantScaleBias` was giving an unexpected shape of `[1, input_dim, batch_dim, input_dim]` instead of `[batch_dim, input_dim]`. 

The issue came from the fact that the class ultimately had a default value of `runtime_shape = (1, -1, 1, 1)`  when it should be `runtime_shape = (1, -1)` .

We had `runtime_shape = (1, -1, 1, 1)`  because `class BatchNorm1dToQuantScaleBias` wasn't properly passing down the `runtime_shape` parameter to `class ScaleBias` . That issue has been also fixed.

Original issue from https://github.com/Xilinx/brevitas/issues/450
