### PR TITLE
Fix/pytorch syntax in wrappers

### DIFF
--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -301,7 +301,7 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         output_dict = super(ParameterFromRuntimeStatsScaling, self).state_dict(
-            destination, prefix, keep_vars)        
+            destination=destination, prefix=prefix, keep_vars=keep_vars)
         # Avoid saving the buffer
         del output_dict[prefix + 'buffer']
         # Avoid saving the init value

--- a/src/brevitas/core/stats/view_wrapper.py
+++ b/src/brevitas/core/stats/view_wrapper.py
@@ -67,7 +67,8 @@ class _ViewParameterWrapper(brevitas.jit.ScriptModule):
             missing_keys.remove(parameter_key)
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
-        output_dict = super(_ViewParameterWrapper, self).state_dict(destination, prefix, keep_vars)
+        output_dict = super(_ViewParameterWrapper, self).state_dict(
+            destination=destination, prefix=prefix, keep_vars=keep_vars)
         del output_dict[prefix + 'parameter']
         return output_dict
 
@@ -95,6 +96,6 @@ class _ViewCatParameterWrapper(brevitas.jit.ScriptModule):
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         output_dict = super(_ViewCatParameterWrapper, self).state_dict(
-            destination, prefix, keep_vars)
+            destination=destination, prefix=prefix, keep_vars=keep_vars)
         del output_dict[prefix + 'parameter']
         return output_dict

--- a/src/brevitas/core/utils.py
+++ b/src/brevitas/core/utils.py
@@ -53,6 +53,7 @@ class StatelessBuffer(brevitas.jit.ScriptModule):
             missing_keys.remove(value_key)
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
-        output_dict = super(StatelessBuffer, self).state_dict(destination, prefix, keep_vars)
+        output_dict = super(StatelessBuffer, self).state_dict(
+            destination=destination, prefix=prefix, keep_vars=keep_vars)
         del output_dict[prefix + VALUE_ATTR_NAME]
         return output_dict

--- a/src/brevitas/nn/hadamard_classifier.py
+++ b/src/brevitas/nn/hadamard_classifier.py
@@ -77,7 +77,8 @@ class HadamardClassifier(QuantLayerMixin, nn.Module):
         return output_bit_width
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
-        state_dict = super(HadamardClassifier, self).state_dict(destination, prefix, keep_vars)
+        state_dict = super(HadamardClassifier, self).state_dict(
+            destination=destination, prefix=prefix, keep_vars=keep_vars)
         del state_dict[prefix + 'proj']
         return state_dict
 

--- a/src/brevitas/nn/mixin/base.py
+++ b/src/brevitas/nn/mixin/base.py
@@ -267,7 +267,8 @@ class QuantRecurrentLayerMixin(ExportMixin):
         return True
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
-        output_dict = super(QuantRecurrentLayerMixin, self).state_dict(destination, prefix, keep_vars)
+        output_dict = super(QuantRecurrentLayerMixin, self).state_dict(
+            destination=destination, prefix=prefix, keep_vars=keep_vars)
         for key in list(output_dict.keys()):
             if '_fast_cell' in key:
                 del output_dict[key]

--- a/tests/brevitas/core/test_standalone_scaling.py
+++ b/tests/brevitas/core/test_standalone_scaling.py
@@ -1,0 +1,17 @@
+import warnings
+
+from brevitas.core.scaling import (
+    ParameterFromRuntimeStatsScaling,
+)
+from brevitas.core.stats.stats_op import AbsMax
+
+
+def test_scaling_state_dict():
+    scaling_op = ParameterFromRuntimeStatsScaling(
+        collect_stats_steps=10, scaling_stats_impl=AbsMax()
+    )
+
+    with warnings.catch_warnings(record=True) as wlist:
+        scaling_op.state_dict()
+        for w in wlist:
+            assert "Positional args are being deprecated" not in str(w.message)

--- a/tests/brevitas/core/test_standalone_view_wrapper.py
+++ b/tests/brevitas/core/test_standalone_view_wrapper.py
@@ -1,0 +1,35 @@
+import pytest
+import warnings
+import torch
+import torch.nn as nn
+
+from brevitas.core.stats.view_wrapper import _ViewParameterWrapper, _ViewCatParameterWrapper
+from brevitas.core.stats.stats_op import AbsMax
+
+
+def test_scaling_state_dict():
+    class TestModuleStd(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, 3)
+            self.scaling_op = _ViewParameterWrapper(self.conv.weight, nn.Identity())
+
+    mod = TestModuleStd()
+
+    with warnings.catch_warnings(record=True) as wlist:
+        mod.state_dict()
+        for w in wlist:
+            assert "Positional args are being deprecated" not in str(w.message)
+
+    class TestModuleCat(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, 3)
+            self.scaling_op = _ViewCatParameterWrapper(self.conv.weight, nn.Identity(), 1)
+
+    mod = TestModuleCat()
+
+    with warnings.catch_warnings(record=True) as wlist:
+        mod.state_dict()
+        for w in wlist:
+            assert "Positional args are being deprecated" not in str(w.message)

--- a/tests/brevitas/core/test_stats_view_wrapper.py
+++ b/tests/brevitas/core/test_stats_view_wrapper.py
@@ -7,7 +7,7 @@ from brevitas.core.stats.view_wrapper import _ViewParameterWrapper, _ViewCatPara
 from brevitas.core.stats.stats_op import AbsMax
 
 
-def test_scaling_state_dict():
+def test_scaling_state_dict_viewparameterwrapper():
     class TestModuleStd(nn.Module):
         def __init__(self) -> None:
             super().__init__()
@@ -21,6 +21,7 @@ def test_scaling_state_dict():
         for w in wlist:
             assert "Positional args are being deprecated" not in str(w.message)
 
+def test_scaling_state_dict_viewcatparameterwrapper():
     class TestModuleCat(nn.Module):
         def __init__(self) -> None:
             super().__init__()

--- a/tests/brevitas/nn/test_hadamard.py
+++ b/tests/brevitas/nn/test_hadamard.py
@@ -1,0 +1,22 @@
+from torch.nn import Module
+from brevitas.nn import HadamardClassifier
+
+from brevitas.quant import IntBias
+from brevitas.quant_tensor import QuantTensor
+
+import torch
+
+OUTPUT_FEATURES = 10
+INPUT_FEATURES = 5
+BIT_WIDTH = 5
+
+
+class TestHadamardStateDict:
+    def test_module_state_dict(self):
+        """Check that the Hadamard classifier can save and load state_dict without warning."""
+
+        mod = HadamardClassifier(out_channels=OUTPUT_FEATURES, in_channels=INPUT_FEATURES)
+
+        mod2 = HadamardClassifier(out_channels=OUTPUT_FEATURES, in_channels=INPUT_FEATURES)
+
+        mod2.load_state_dict(mod.state_dict())

--- a/tests/brevitas/nn/test_recurrent.py
+++ b/tests/brevitas/nn/test_recurrent.py
@@ -40,6 +40,7 @@
 
 from hypothesis import given
 import pytest
+import warnings
 
 import torch
 from brevitas.nn import QuantRNN, QuantLSTM
@@ -87,6 +88,11 @@ class TestRecurrent:
         assert torch.isclose(out[0], ref_out[0], atol=ATOL).all()
         assert torch.isclose(out[1], ref_out[1], atol=ATOL).all()
 
+        # Test that the brevitas model can be saved/loaded without warning
+        with warnings.catch_warnings(record=True) as wlist:
+            qm.load_state_dict(qm.state_dict())
+            for w in wlist:
+                assert "Positional args are being deprecated" not in str(w.message)
 
     @given(
          inp=float_tensor_random_size_st(dims=3, max_size=3),
@@ -129,6 +135,14 @@ class TestRecurrent:
         assert torch.isclose(out[1][0], ref_out[1][0], atol=ATOL).all()
         # cell states
         assert torch.isclose(out[1][1], ref_out[1][1], atol=ATOL).all()
+
+        # Test that the brevitas model can be saved/loaded without warning
+        # Test that the brevitas model can be saved/loaded without warning
+        with warnings.catch_warnings(record=True) as wlist:
+            qm.load_state_dict(qm.state_dict())
+            for w in wlist:
+                assert "Positional args are being deprecated" not in str(w.message)
+
 
     @pytest.mark.parametrize("batch_first", [True, False])
     @pytest.mark.parametrize("bidirectional", [True, False, 'shared_input_hidden_weights'])

--- a/tests/brevitas/nn/test_recurrent.py
+++ b/tests/brevitas/nn/test_recurrent.py
@@ -72,7 +72,7 @@ class TestRecurrent:
             num_layers=num_layers,
             bias=bias)
         qm = QuantRNN(
-            inp_size, 
+            inp_size,
             hidden_size,
             weight_quant=None,
             bias_quant=None,
@@ -88,6 +88,34 @@ class TestRecurrent:
         assert torch.isclose(out[0], ref_out[0], atol=ATOL).all()
         assert torch.isclose(out[1], ref_out[1], atol=ATOL).all()
 
+        # Test that the brevitas model can be saved/loaded without warning
+        with warnings.catch_warnings(record=True) as wlist:
+            qm.load_state_dict(qm.state_dict())
+            for w in wlist:
+                assert "Positional args are being deprecated" not in str(w.message)
+
+
+    @given(
+        inp=float_tensor_random_size_st(dims=3, max_size=3),
+        hidden_size=st.integers(min_value=1, max_value=3))
+    @pytest.mark.parametrize("batch_first", [True, False])
+    @pytest.mark.parametrize("bidirectional", [True, False])
+    @pytest.mark.parametrize("num_layers", [1, 2])
+    @pytest.mark.parametrize("bias", [True, False])
+    def test_rnn_quant_disabled_fwd_state_dict(
+            self, inp, hidden_size, batch_first, bidirectional, num_layers, bias):
+        inp_size = inp.size(-1)
+        qm = QuantRNN(
+            inp_size,
+            hidden_size,
+            weight_quant=None,
+            bias_quant=None,
+            io_quant=None,
+            gate_acc_quant=None,
+            batch_first=batch_first,
+            bidirectional=bidirectional,
+            num_layers=num_layers,
+            bias=bias)
         # Test that the brevitas model can be saved/loaded without warning
         with warnings.catch_warnings(record=True) as wlist:
             qm.load_state_dict(qm.state_dict())
@@ -136,6 +164,31 @@ class TestRecurrent:
         # cell states
         assert torch.isclose(out[1][1], ref_out[1][1], atol=ATOL).all()
 
+    @given(
+        inp=float_tensor_random_size_st(dims=3, max_size=3),
+        hidden_size=st.integers(min_value=1, max_value=3))
+    @pytest.mark.parametrize("batch_first", [True, False])
+    @pytest.mark.parametrize("bidirectional", [True, False])
+    @pytest.mark.parametrize("num_layers", [1, 2])
+    @pytest.mark.parametrize("bias", [True, False])
+    def test_lstm_quant_disabled_fwd_state_dict(
+            self, inp, hidden_size, batch_first, bidirectional, num_layers, bias):
+        inp_size = inp.size(-1)
+        qm = QuantLSTM(
+            inp_size,
+            hidden_size,
+            weight_quant=None,
+            io_quant=None,
+            gate_acc_quant=None,
+            cell_state_quant=None,
+            bias_quant=None,
+            sigmoid_quant=None,
+            tanh_quant=None,
+            cat_output_cell_states=True,
+            batch_first=batch_first,
+            bidirectional=bidirectional,
+            num_layers=num_layers,
+            bias=bias)
         # Test that the brevitas model can be saved/loaded without warning
         with warnings.catch_warnings(record=True) as wlist:
             qm.load_state_dict(qm.state_dict())
@@ -168,6 +221,35 @@ class TestRecurrent:
             shared_input_hidden_weights=bidirectional=='shared_input_hidden_weights',
             return_quant_tensor=return_quant_tensor)
         assert m(inp) is not None
+
+    @pytest.mark.parametrize("batch_first", [True, False])
+    @pytest.mark.parametrize("bidirectional", [True, False, 'shared_input_hidden_weights'])
+    @pytest.mark.parametrize("num_layers", [1, 2])
+    @pytest.mark.parametrize("bias", [True, False])
+    @pytest.mark.parametrize("return_quant_tensor", [True, False])
+    @pytest.mark.skip("FIXME: many warnings due to __torch_function__")
+    def test_quant_rnn_state_dict(
+            self,
+            batch_first,
+            bidirectional,
+            num_layers,
+            bias,
+            return_quant_tensor):
+        inp_size = 4
+        hidden_size = 5
+        m = QuantRNN(
+            inp_size,
+            hidden_size,
+            num_layers=num_layers,
+            batch_first=batch_first,
+            bidirectional=bidirectional,
+            bias=bias,
+            shared_input_hidden_weights=bidirectional=='shared_input_hidden_weights',
+            return_quant_tensor=return_quant_tensor)
+        with warnings.catch_warnings(record=True) as wlist:
+            m.load_state_dict(m.state_dict())
+            for w in wlist:
+                assert "Positional args are being deprecated" not in str(w.message)
 
     @pytest.mark.parametrize("batch_first", [True, False])
     @pytest.mark.parametrize("bidirectional", [True, False, 'shared_input_hidden_weights'])
@@ -207,3 +289,46 @@ class TestRecurrent:
             cat_output_cell_states=shared_cell_state_quant,
             return_quant_tensor=return_quant_tensor)
         assert m(inp) is not None
+
+    @pytest.mark.parametrize("batch_first", [True, False])
+    @pytest.mark.parametrize("bidirectional", [True, False, 'shared_input_hidden_weights'])
+    @pytest.mark.parametrize("num_layers", [1, 2])
+    @pytest.mark.parametrize("bias", [True, False])
+    @pytest.mark.parametrize("coupled_input_forget_gates", [True, False])
+    @pytest.mark.parametrize("return_quant_tensor", [True, False])
+    @pytest.mark.parametrize("shared_intra_layer_weight_quant", [True, False])
+    @pytest.mark.parametrize("shared_intra_layer_gate_acc_quant", [True, False])
+    @pytest.mark.parametrize("shared_cell_state_quant", [True, False])
+    @pytest.mark.skip("FIXME: many warnings due to __torch_function__")
+    def test_quant_lstm_fwd_state_dict(
+            self,
+            batch_first,
+            bidirectional,
+            num_layers,
+            bias,
+            coupled_input_forget_gates,
+            return_quant_tensor,
+            shared_intra_layer_weight_quant,
+            shared_intra_layer_gate_acc_quant,
+            shared_cell_state_quant):
+        inp_size = 4
+        hidden_size = 5
+        qm = QuantLSTM(
+            inp_size,
+            hidden_size,
+            num_layers=num_layers,
+            batch_first=batch_first,
+            bidirectional=bidirectional,
+            bias=bias,
+            coupled_input_forget_gates=coupled_input_forget_gates,
+            shared_input_hidden_weights=bidirectional=='shared_input_hidden_weights',
+            shared_intra_layer_weight_quant=shared_intra_layer_weight_quant,
+            shared_intra_layer_gate_acc_quant=shared_intra_layer_gate_acc_quant,
+            shared_cell_state_quant=shared_cell_state_quant,
+            cat_output_cell_states=shared_cell_state_quant,
+            return_quant_tensor=return_quant_tensor)
+        # Test that the brevitas model can be saved/loaded without warning
+        with warnings.catch_warnings(record=True) as wlist:
+            qm.load_state_dict(qm.state_dict())
+            for w in wlist:
+                assert "Positional args are being deprecated" not in str(w.message)

--- a/tests/brevitas/nn/test_recurrent.py
+++ b/tests/brevitas/nn/test_recurrent.py
@@ -137,7 +137,6 @@ class TestRecurrent:
         assert torch.isclose(out[1][1], ref_out[1][1], atol=ATOL).all()
 
         # Test that the brevitas model can be saved/loaded without warning
-        # Test that the brevitas model can be saved/loaded without warning
         with warnings.catch_warnings(record=True) as wlist:
             qm.load_state_dict(qm.state_dict())
             for w in wlist:

--- a/tests/brevitas/nn/test_recurrent.py
+++ b/tests/brevitas/nn/test_recurrent.py
@@ -88,13 +88,6 @@ class TestRecurrent:
         assert torch.isclose(out[0], ref_out[0], atol=ATOL).all()
         assert torch.isclose(out[1], ref_out[1], atol=ATOL).all()
 
-        # Test that the brevitas model can be saved/loaded without warning
-        with warnings.catch_warnings(record=True) as wlist:
-            qm.load_state_dict(qm.state_dict())
-            for w in wlist:
-                assert "Positional args are being deprecated" not in str(w.message)
-
-
     @given(
         inp=float_tensor_random_size_st(dims=3, max_size=3),
         hidden_size=st.integers(min_value=1, max_value=3))


### PR DESCRIPTION
New pytorch versions need `destination` kwarg or they issue a warning

Please note that I could only test the changes in the `ba8c12d` commit, so the other changes in `2331ed3` are not tested