### PR TITLE
fix: better initialize quant tensor, avoir torch warning

### DIFF
--- a/src/brevitas/quant_tensor/__init__.py
+++ b/src/brevitas/quant_tensor/__init__.py
@@ -86,15 +86,16 @@ class QuantTensor(QuantTensorBase):
 
     def __new__(
             cls, value, scale=None, zero_point=None, bit_width=None, signed=None, training=None):
+
         if scale is not None and not isinstance(scale, torch.Tensor):
             scale = torch.tensor(scale, dtype=torch.float)
         if zero_point is not None and not isinstance(zero_point, torch.Tensor):
             zero_point = torch.tensor(zero_point, dtype=torch.float)
         if bit_width is not None and not isinstance(bit_width, torch.Tensor):
             bit_width = torch.tensor(bit_width, dtype=torch.float)
-        if signed is not None:
+        if signed is not None and not isinstance(signed, torch.Tensor):
             signed = torch.tensor(signed, dtype=torch.bool)
-        if training is not None:
+        if training is not None and not isinstance(training, torch.Tensor):
             training = torch.tensor(training, dtype=torch.bool)
         return super().__new__(cls, value, scale, zero_point, bit_width, signed, training)
 


### PR DESCRIPTION
Pytorch issues a warning if you create a `tensor.Tensor` based on another tensor. They propose this solution with `.clone().detach()`

Closes #456 