### PR TITLE
Test: test for inception_v3

### DIFF
--- a/src/brevitas/graph/fixed_point.py
+++ b/src/brevitas/graph/fixed_point.py
@@ -149,7 +149,7 @@ class CollapseConsecutiveConcats(UntilFixedPointGraphTransform):
                             and inp_node.target is torch.cat
                             and node.kwargs['dim'] == inp_node.kwargs['dim']
                             and len(inp_node.users) == 1):
-                        self.merge_tensor_args(inp_node, node)
+                        self.merge_tensor_kwargs(inp_node, node)
                         graph_model.graph.erase_node(inp_node)
                         graph_model.graph.lint()
                         graph_model.recompile()

--- a/src/brevitas/graph/fixed_point.py
+++ b/src/brevitas/graph/fixed_point.py
@@ -136,9 +136,11 @@ class CollapseConsecutiveConcats(UntilFixedPointGraphTransform):
         cat_tensors2 = node_to_merge_in.kwargs['tensors']
         if not isinstance(cat_tensors2, (list, tuple)):
             cat_tensors2 = [cat_tensors2]
+        index_for_insertion = cat_tensors2.index(node_to_extract)
         cat_tensors2 = [t for t in cat_tensors2 if t is not node_to_extract]
+        cat_tensors2[index_for_insertion:index_for_insertion] = cat_tensors1
         kwargs = dict(node_to_merge_in.kwargs)
-        kwargs['tensors'] = (cat_tensors1 + cat_tensors2)
+        kwargs['tensors'] = cat_tensors2
         node_to_merge_in.kwargs = immutable_dict(kwargs)
 
     def is_converged(self, graph_model):

--- a/src/brevitas/quant_tensor/__init__.py
+++ b/src/brevitas/quant_tensor/__init__.py
@@ -274,11 +274,16 @@ class QuantTensor(QuantTensorBase):
                     first_qt.check_bit_width_same(qt)
                     first_qt.check_sign_same(qt)
                 output_value = torch.cat([qt.value for qt in tensors], dim=dim)
-                output_scale = sum([qt.scale for qt in tensors]) / len(tensors)
-                output_zero_point = sum([qt.zero_point for qt in tensors]) / len(tensors)
-                output_bit_width = sum([qt.bit_width for qt in tensors]) / len(tensors)
-                output_signed = first_qt.signed  # they are the same
                 output_training = any([qt.training for qt in tensors])
+                if output_training:
+                    output_scale = sum([qt.scale for qt in tensors]) / len(tensors)
+                    output_zero_point = sum([qt.zero_point for qt in tensors]) / len(tensors)
+                    output_bit_width = sum([qt.bit_width for qt in tensors]) / len(tensors)
+                else: # at eval time, they are the same
+                    output_scale = first_qt.scale
+                    output_zero_point = first_qt.zero_point
+                    output_bit_width = first_qt.bit_width
+                output_signed = first_qt.signed  # they are the same
                 return QuantTensor(
                     value=output_value,
                     scale=output_scale,

--- a/tests/brevitas_end_to_end/test_torchvision_models.py
+++ b/tests/brevitas_end_to_end/test_torchvision_models.py
@@ -18,7 +18,7 @@ from brevitas import torch_version
 BATCH = 1
 HEIGHT, WIDTH = 224, 224
 IN_CH = 3
-MODEL_LIST = ['mobilenet_v2', 'resnet50', 'resnet18', 'mnasnet0_5', 'alexnet', 'googlenet', 'vgg11', 'densenet121', 'deeplabv3_resnet50', 'fcn_resnet50', 'regnet_x_400mf','squeezenet1_0']
+MODEL_LIST = ['mobilenet_v2', 'resnet50', 'resnet18', 'mnasnet0_5', 'alexnet', 'googlenet', 'vgg11', 'densenet121', 'deeplabv3_resnet50', 'fcn_resnet50', 'regnet_x_400mf','squeezenet1_0', 'inception_v3']
 
 class NoDictModel(torch.nn.Module):
 


### PR DESCRIPTION
Three things to fix:
- ~~typo in merge_tensor_args -> merge_tensor_kwargs~~
- ~~When merging concats, the order of the tensors is not respected~~
- When exporting the model, there's a comparison between uint8 and int32 that causes the export to fail: Potential fix proposed