### PR TITLE
Activation equalization implementation

### DIFF
--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -140,6 +140,12 @@ class DisableEnableQuantization(Transform):
                 module.train(is_training)
                 module.disable_quant = True
 
+    def disable_bias_quantization(self, model, is_training):
+        for module in model.modules():
+            if isinstance(module, _PARAM_PROXIES[1]):
+                module.train(is_training)
+                module.disable_quant = True
+
     def enable_act_quantization(self, model, is_training):
         for module in model.modules():
             if isinstance(module, _ACC_PROXIES):
@@ -154,6 +160,12 @@ class DisableEnableQuantization(Transform):
     def enable_param_quantization(self, model, is_training):
         for module in model.modules():
             if isinstance(module, _PARAM_PROXIES):
+                module.disable_quant = False
+                module.train(is_training)
+
+    def enable_bias_quantization(self, model, is_training):
+        for module in model.modules():
+            if isinstance(module, _PARAM_PROXIES[1]):
                 module.disable_quant = False
                 module.train(is_training)
 

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -258,7 +258,7 @@ def walk_region(graph_model: GraphModule, starting_node: Node, history, srcs, si
                 sinks.add(node.target)
             else:
                 srcs.add(node.target)
-                walk_region(graph_model, node, history, srcs, acts,  sinks, walk_forward=True, scale_varying_layers=scale_varying_layers)
+                walk_region(graph_model, node, history, srcs, sinks, acts, walk_forward=True, scale_varying_layers=scale_varying_layers)
         elif _is_scale_invariant_module(graph_model, node) or _is_scale_invariant_function(node):
             if _is_scale_invariant_activation(graph_model, node):
                 acts.add(node.target)


### PR DESCRIPTION
Changes:

- walk_region extended to keep track of activations encoutered in the path, 
- walk_region can walk through scale varying activations (e.g., sigmoid)
- walk_region works also on QuantModule
- Possibility to disable only bias quantization

**Activation Equalization support**:
- Can be performed on FP or Quantized Models
- Possibility to set and tune alpha
- For now, if there are multiple activations in one region, no equalization is performed (it could be mathematically possible but I have doubt about its usefulness)
- If performed on QuantModules, QuantWeights are used to compute ranges
- If scale varying activations are used, then a standalone MUL op is added after the activation. If this is done on Quantized Models, the MUL will be executed in FP

Missing tests. On a FP model, this transformation does not alter the math of the model, similar to graph equalization. Tests will be performed in a similar fashion.