### PR TITLE
Feat (ptq): activation equalization support

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -400,6 +400,7 @@ def _cross_layer_equalization(
     # Determine the srcs_range based on where we are performing activation equalization or
     # weight equalization
     if list_of_act_val is not None:
+        list_of_act_val_shapes = [act_val.shape for act_val in list_of_act_val]
         list_of_act_val = [
             transpose(WeightBiasTuple(act_val), act_axis) for act_val in list_of_act_val]
         srcs_range = scale_fn(
@@ -434,8 +435,8 @@ def _cross_layer_equalization(
     inverse_scaling_factors = torch.reciprocal(scaling_factors)
 
     if list_of_act_val is not None and list_of_insert_mul_node_fn is not None:
-        for act_val, insert_mul_node_fn in zip(list_of_act_val, list_of_insert_mul_node_fn):
-            insert_mul_node_fn(inverse_scaling_factors, act_val.shape, act_axis)
+        for act_val_shape, insert_mul_node_fn in zip(list_of_act_val_shapes, list_of_insert_mul_node_fn):
+            insert_mul_node_fn(inverse_scaling_factors, act_val_shape, act_axis)
     if len(src_axes) > 0:
         for module, axis in src_axes.items():
             if hasattr(module, 'bias') and module.bias is not None:

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -8,15 +8,23 @@ from dataclasses import field
 from functools import partial
 import operator
 from typing import Callable, Dict, List, Optional, Set, Tuple, Union
+import warnings
 
 import torch
 import torch.nn as nn
 
 from brevitas.fx import GraphModule
 from brevitas.fx import Node
+from brevitas.graph.base import GraphTransform
+from brevitas.graph.base import ModuleInstanceToModuleInstance
 from brevitas.graph.utils import get_module
+from brevitas.graph.utils import get_node
+from brevitas.nn.equalized_layer import EqualizedModule
+from brevitas.nn.quant_scale_bias import ScaleBias
 
 from .base import GraphTransform
+from .base import InsertModuleCallAfter
+from .base import ModuleToModuleByInstance
 
 __all__ = ['EqualizeGraph']
 
@@ -40,7 +48,6 @@ _scale_invariant_layers = (
     nn.Dropout,
     nn.Dropout2d,
     nn.Dropout3d,
-    nn.ReLU,
     nn.MaxPool1d,
     nn.MaxPool2d,
     nn.MaxPool3d,
@@ -54,6 +61,11 @@ _scale_invariant_layers = (
 _scale_invariant_op = (torch.mul, operator.mul, operator.imul, operator.__mul__, operator.__imul__)
 
 _select_op = (operator.getitem, operator.__getitem__)
+
+_scale_invariant_activations = (torch.nn.ReLU,)
+
+_scale_varying_activations = (
+    torch.nn.Sigmoid, torch.nn.Tanh, torch.nn.ReLU6, torch.nn.GELU, torch.nn.SiLU)
 
 _residual_methods = ('add', 'add_')
 
@@ -74,13 +86,16 @@ class WeightBiasTuple:
 class Region:
     srcs: Tuple = field(default_factory=tuple)
     sinks: Tuple = field(default_factory=tuple)
+    acts: Tuple = field(default_factory=tuple)
 
 
 @dataclass
 class WalkRegionState:
     srcs: Set = field(default_factory=set)
     sinks: Set = field(default_factory=set)
+    acts: Set = field(default_factory=set)
     history: set = field(default_factory=set)
+    add_mul_node: bool = False
 
 
 def _select_scale_computation_fn(
@@ -93,13 +108,56 @@ def _select_scale_computation_fn(
         raise RuntimeError(f"Scale computation type {scale_computation_type} not supported")
 
 
-def _channel_range(inp: torch.Tensor) -> torch.Tensor:
-    mins, _ = inp.min(dim=1)
-    maxs, _ = inp.max(dim=1)
+class activation_equalization_mode:
+
+    def __init__(self, graph_model, alpha, add_mul_node, layerwise=False, enabled=True) -> None:
+        self.graph_model = graph_model
+        self.alpha = alpha
+        self.enabled = enabled
+        self.add_mul_node = add_mul_node
+        if layerwise:
+            self.add_mul_node = True
+            self.graph_act_eq = LayerwiseActivationEqualization(self.graph_model)
+        else:
+            self.graph_act_eq = GraphActivationEqualization(self.graph_model, self.add_mul_node)
+        self.scale_factors = None
+
+    def __enter__(self):
+        if self.enabled:
+            self.graph_act_eq.setup()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.enabled:
+            self.scale_factors = self.graph_act_eq.apply(self.alpha)
+            self.graph_act_eq.remove_hooks()
+            return True  # To propagate exceptions
+
+
+def dict_name_to_module(model, regions):
+    name_to_module: Dict[str, torch.nn.Module] = {}
+    # name_set = {name for region in regions for module_set in region for name in module_set}
+    name_set = set()
+    for region in regions:
+        for name in region.srcs:
+            name_set.add(name)
+        for name in region.sinks:
+            name_set.add(name)
+        for name in region.acts:
+            name_set.add(name)
+    for name, module in model.named_modules():
+        if name in name_set:
+            name_to_module[name] = module
+    return name_to_module
+
+
+def _channel_range(inp: torch.Tensor, dim: int = 1) -> torch.Tensor:
+    mins, _ = inp.min(dim=dim)
+    maxs, _ = inp.max(dim=dim)
     out = maxs - mins
     # correct corner case where where all weights along a channel have the same value
     # e.g. when a mean/nn.AvgPool/nn.AdaptiveAvgPool is converted to a depth-wise conv
-    out = torch.where(out == 0., torch.mean(inp, dim=1), out)
+    out = torch.where(out == 0., torch.mean(inp, dim=dim), out)
 
     # convert to positive range, in case any of the values are negative,
     # highly likely in cases when there is only one value per channel, such as in Batch Norm
@@ -107,8 +165,8 @@ def _channel_range(inp: torch.Tensor) -> torch.Tensor:
     return out
 
 
-def _channel_maxabs(inp: torch.Tensor) -> torch.Tensor:
-    out = torch.max(torch.abs(inp), dim=1)[0]
+def _channel_maxabs(inp: torch.Tensor, dim: int = 1) -> torch.Tensor:
+    out = torch.max(torch.abs(inp), dim=dim)[0]
     return out
 
 
@@ -177,6 +235,21 @@ def _get_output_axis(module: nn.Module) -> Optional[int]:
         return None
 
 
+def _get_act_axis(sink_module: nn.Module) -> Optional[int]:
+    if isinstance(sink_module, (nn.Linear, nn.MultiheadAttention)):
+        return -1
+    elif isinstance(sink_module,
+                    (nn.Conv1d,
+                     nn.Conv2d,
+                     nn.Conv3d,
+                     nn.ConvTranspose1d,
+                     nn.ConvTranspose2d,
+                     nn.ConvTranspose3d)):
+        return 0
+    else:
+        return None
+
+
 def _combine_weights_bias(
         weight: torch.Tensor, bias_shrinkage: Union[float, str],
         bias: Optional[torch.Tensor]) -> torch.Tensor:
@@ -192,7 +265,7 @@ def _combine_weights_bias(
         return weight.data
 
     bias = bias.data
-    weight = weight.reshape(weight.shape[0], -1)
+    weight = weight.data.reshape(weight.shape[0], -1)
     bias = bias.reshape(-1, 1)
 
     weight = torch.where(torch.abs(weight) < EPSILON, torch.tensor(EPSILON).type_as(weight), weight)
@@ -220,23 +293,36 @@ def _combine_weights_bias(
     return weight_bias
 
 
+def transpose(module, axis):
+    shape = list(range(module.weight.ndim))  #list(module.weight.shape)
+    axis = shape[axis]
+    shape.insert(0, axis)
+    del shape[axis + 1]
+    return module.weight.permute(shape)
+
+
 def _cross_layer_equalization(
         srcs: List[nn.Module],
         sinks: List[nn.Module],
         merge_bias: bool,
-        bias_shrinkage: Union[float, str],
-        scale_computation_type: str) -> torch.Tensor:
+        scale_computation_type: str,
+        bias_shrinkage: Optional[Union[float, str]] = None,
+        list_of_act_val: Optional[torch.Tensor] = None,
+        list_of_insert_mul_node_fn: Optional[List[Callable]] = None,
+        alpha: float = 0.5) -> torch.Tensor:
     """
     Given two adjacent tensors', the weights are scaled such that
     the ranges of the first tensors' output channel are equal to the
     ranges of the second tensors' input channel
     """
     # Determine device and type of tensors
-    device = next(srcs[0].parameters()).device
-    dtype = next(srcs[0].parameters()).dtype
+    device = next(sinks[0].parameters()).device
+    dtype = next(sinks[0].parameters()).dtype
 
     src_axes = {}
     sink_axes = {}
+    act_sink_axes = {}
+    act_sources_axes = {}
 
     for i, module in enumerate(srcs):
         # If module is not supported, do not perform graph equalization
@@ -245,55 +331,100 @@ def _cross_layer_equalization(
         if isinstance(module, nn.MultiheadAttention):
             srcs[i] = module.out_proj
         src_axes[srcs[i]] = _get_output_axis(module)
+        act_sources_axes[srcs[i]] = _get_act_axis(module)
 
     for i, module in enumerate(sinks):
         # If module is not supported, do not perform graph equalization
         if not isinstance(module, _supported_layers):
             return torch.tensor(1., dtype=dtype, device=device)
         # For MultiheadAttention, we support only self-attetion
-        if isinstance(module, nn.MultiheadAttention) and hasattr(sinks[i], 'in_proj_weight'):
+        if isinstance(module, nn.MultiheadAttention) and module.in_proj_weight is not None:
             # For sinks, we only need to modify the weight but not the bias
             sinks[i] = WeightBiasTuple(weight=module.in_proj_weight)
-        elif isinstance(module, nn.MultiheadAttention) and not hasattr(sinks[i], 'in_proj_weight'):
+        elif isinstance(module, nn.MultiheadAttention) and module.in_proj_weight is None:
             return torch.tensor(1., dtype=dtype, device=device)
         sink_axes[sinks[i]] = _get_input_axis(module)
+        act_sink_axes[sinks[i]] = _get_act_axis(module)
+
+    # If act_val is enabled, use source or sink weights to determine the activation channel
+    # For example, if the source is BatchNorm, we need to use the sink information
+    if list_of_act_val is not None:
+        list_of_sink_axes = [x for x in list(act_sink_axes.values()) if x is not None]
+        list_of_source_axes = [x for x in list(act_sources_axes.values()) if x is not None]
+        if len(list_of_sink_axes) > 0:
+            act_axis = list_of_sink_axes[0]
+        elif len(list_of_source_axes) > 0:
+            act_axis = list_of_source_axes[0]
+        else:
+            return torch.tensor(1., dtype=dtype, device=device)
+        # If there is a mismatch in the activation channel (e.g. a transpose/flatten op in between),
+        # do not perform equalization
+        if any([act_axis != axis for axis in list_of_source_axes + list_of_sink_axes]):
+            return torch.tensor(1., dtype=dtype, device=device)
 
     # Check if any of the axis is None, which means that the module is not supported.
     # In that case, do not perform graph equalization
-    if None in [*src_axes.values(), *sink_axes.values()]:
+    axes_to_check = [*src_axes.values(), *sink_axes.values()]
+    if None in axes_to_check:
         return torch.tensor(1., dtype=dtype, device=device)
 
-    src_size = _get_size(src_axes)
+    # Check if the sink_size is None,
+    # which means that the some of the sinks do not have the same size as the others.
     sink_size = _get_size(sink_axes)
-
-    # Check if any of the src_size or sink_size is None, which means that the some of the
-    # sources or sinks do not have the same size as the others.
-    # Similarly, exit if source and sink have different different sizes
-    if None in [src_size, sink_size] or src_size != sink_size:
+    if None in [sink_size]:
         return torch.tensor(1., dtype=dtype, device=device)
-    transpose = lambda module, axis: module.weight if axis == 0 else module.weight.transpose(0, 1)
-    scale_fn = _select_scale_computation_fn(scale_computation_type)
-    if merge_bias:
-        src_weights = [
-            _combine_weights_bias(transpose(m, axis), bias_shrinkage, m.bias) for m,
-            axis in src_axes.items()]
-    else:
-        src_weights = [transpose(m, axis) for m, axis in src_axes.items()]
-    sink_weights = [transpose(m, axis) for m, axis in sink_axes.items()]
-    srcs_range = scale_fn(torch.cat([w.reshape(w.size(0), -1) for w in src_weights], 1))
-    sinks_range = scale_fn(torch.cat([w.reshape(w.size(0), -1) for w in sink_weights], 1))
-    sinks_range += EPSILON
 
-    scaling_factors = torch.sqrt(srcs_range / sinks_range)
+    scale_fn = _select_scale_computation_fn(scale_computation_type)
+    sink_weights = [transpose(m, axis) for m, axis in sink_axes.items()]
+    sinks_range = scale_fn(torch.cat([w.reshape(w.size(0), -1) for w in sink_weights], 1))
+    sinks_range = torch.clamp(sinks_range, EPSILON)
+
+    # Determine the srcs_range based on where we are performing activation equalization or
+    # weight equalization
+    if list_of_act_val is not None:
+        act_shape = list_of_act_val[0].shape
+        # act_val = [WeightBiasTuple(act_val) for act_val in list_of_act_val]
+        list_of_act_val = [
+            transpose(WeightBiasTuple(act_val), act_axis) for act_val in list_of_act_val]
+        srcs_range = scale_fn(
+            torch.cat([act_val.reshape(act_val.size(0), -1) for act_val in list_of_act_val],
+                      1))  # scale_fn(act_val.reshape(act_val.size(0), -1))
+    else:
+        # If we do weight equalization, perform additional check on source size
+        src_size = _get_size(src_axes)
+        # Exit if source and sink have different different sizes, or if sources contains None
+        if src_size != sink_size or None in [src_size]:
+            return torch.tensor(1., dtype=dtype, device=device)
+
+        if merge_bias:
+            src_weights = [
+                _combine_weights_bias(transpose(m, axis), bias_shrinkage, m.bias) for m,
+                axis in src_axes.items()]
+        else:
+            src_weights = [transpose(m, axis) for m, axis in src_axes.items()]
+        srcs_range = scale_fn(torch.cat([w.reshape(w.size(0), -1) for w in src_weights], 1))
+
+    # If there is a mismatch between srcs and sinks values, exit
+    if srcs_range.shape != sinks_range.shape:
+        return torch.tensor(1., dtype=dtype, device=device)
+
+    srcs_range = torch.pow(srcs_range, alpha)
+    sinks_range = torch.pow(sinks_range, 1 - alpha)
+    scaling_factors = srcs_range / sinks_range
+    scaling_factors = torch.clamp(scaling_factors, EPSILON)
     inverse_scaling_factors = torch.reciprocal(scaling_factors)
 
-    for module, axis in src_axes.items():
-        if hasattr(module, 'bias') and module.bias is not None:
-            module.bias.data = module.bias.data * inverse_scaling_factors.view_as(module.bias)
-        src_broadcast_size = [1] * module.weight.ndim
-        src_broadcast_size[axis] = module.weight.size(axis)
-        module.weight.data = module.weight.data * torch.reshape(
-            inverse_scaling_factors, src_broadcast_size)
+    if list_of_act_val is not None and list_of_insert_mul_node_fn is not None:
+        for insert_mul_node_fn in list_of_insert_mul_node_fn:
+            insert_mul_node_fn(inverse_scaling_factors, act_shape, act_axis)
+    if len(src_axes) > 0:
+        for module, axis in src_axes.items():
+            if hasattr(module, 'bias') and module.bias is not None:
+                module.bias.data = module.bias.data * inverse_scaling_factors.view_as(module.bias)
+            src_broadcast_size = [1] * module.weight.ndim
+            src_broadcast_size[axis] = module.weight.size(axis)
+            module.weight.data = module.weight.data * torch.reshape(
+                inverse_scaling_factors, src_broadcast_size)
     for module, axis in sink_axes.items():
         src_broadcast_size = [1] * module.weight.ndim
         src_broadcast_size[axis] = module.weight.size(axis)
@@ -335,9 +466,9 @@ def _equalize(
         for region in regions:
             scale_factors_region = _cross_layer_equalization(
                 [name_to_module[n] for n in region.srcs], [name_to_module[n] for n in region.sinks],
-                merge_bias,
-                bias_shrinkage,
-                scale_computation_type)
+                merge_bias=merge_bias,
+                scale_computation_type=scale_computation_type,
+                bias_shrinkage=bias_shrinkage)
             scale_factor_region_max = torch.max(torch.abs(1 - scale_factors_region))
             if scale_factor_max is not None:
                 scale_factor_max = torch.max(scale_factor_max, scale_factor_region_max)
@@ -361,7 +492,18 @@ def _is_supported_module(graph_model: GraphModule, node: Node) -> bool:
 
 def _is_scale_invariant_module(graph_model: GraphModule, node: Node) -> bool:
     return node.op == 'call_module' and isinstance(
-        get_module(graph_model, node.target), _scale_invariant_layers)
+        get_module(graph_model, node.target),
+        _scale_invariant_layers + _scale_invariant_activations)
+
+
+def _is_scale_invariant_activation(graph_model, node):
+    return node.op == 'call_module' and isinstance(
+        get_module(graph_model, node.target), _scale_invariant_activations)
+
+
+def _is_scale_varying_activation(graph_model, node):
+    return node.op == 'call_module' and isinstance(
+        get_module(graph_model, node.target), _scale_varying_activations)
 
 
 def _is_scale_invariant_function(node: Node) -> bool:
@@ -391,6 +533,8 @@ def find_srcs(graph_model: GraphModule, starting_node: Node,
             find_sinks(graph_model, node, state)
         elif _is_scale_invariant_module(
                 graph_model, node) or _is_scale_invariant_function(node) or _is_reshaping_op(node):
+            if _is_scale_invariant_activation(graph_model, node):
+                state.acts.add(node.target)
             find_srcs(graph_model, node, state)
             find_sinks(graph_model, node, state)
         elif (node.op == 'call_method' and node.target in _residual_methods or
@@ -421,6 +565,8 @@ def find_sinks(graph_model: GraphModule, starting_node: Node,
                 state.sinks.add(node.target)
         elif _is_scale_invariant_module(
                 graph_model, node) or _is_scale_invariant_function(node) or _is_reshaping_op(node):
+            if _is_scale_invariant_activation(graph_model, node):
+                state.acts.add(node.target)
             find_sinks(graph_model, node, state)
         elif (node.op == 'call_method' and node.target in _residual_methods or
               node.op == 'call_function' and node.target in _residual_fns):
@@ -431,18 +577,30 @@ def find_sinks(graph_model: GraphModule, starting_node: Node,
             state.sinks.add(None)
 
 
-def _extract_regions(graph_model: GraphModule) -> Set[Tuple[str]]:
+def _extract_regions(
+        graph_model: GraphModule,
+        add_mul_node: bool = False,
+        return_acts: bool = False) -> Set[Tuple[str]]:
     regions = set()
     for node in graph_model.graph.nodes:
-        if _is_supported_module(graph_model, node):
-            state = WalkRegionState(srcs={node.target})
+        if _is_supported_module(graph_model,
+                                node) or (add_mul_node and
+                                          _is_scale_varying_activation(graph_model, node)):
+            state = WalkRegionState(srcs={node.target}, add_mul_node=add_mul_node)
+            if _is_scale_varying_activation(graph_model, node):
+                state.acts.add(node.target)
             find_sinks(graph_model, node, state)
             if state.sinks and None not in state.sinks and None not in state.srcs:
                 # each region should appear only once, so to make it hashable
                 # we convert srcs and sinks to ordered lists first, and then to tuples
                 srcs = tuple(sorted(state.srcs))
                 sinks = tuple(sorted(state.sinks))
-                regions.add(Region(srcs=srcs, sinks=sinks))
+                acts = tuple(sorted(state.acts))
+                if return_acts:
+                    region_to_add = Region(srcs=srcs, sinks=sinks, acts=acts)
+                else:
+                    region_to_add = Region(srcs=srcs, sinks=sinks)
+                regions.add(region_to_add)
     return regions
 
 
@@ -482,73 +640,206 @@ class EqualizeGraph(GraphTransform):
             return graph_model
 
 
-class AbsorbBiasByBatchNorm(GraphTransform):
+class LayerwiseActivationEqualization(GraphTransform):
 
-    def __init__(self):
-        super(AbsorbBiasByBatchNorm, self).__init__()
-        self.inp_shape_map = {}
-        self.collect_inp_shape_hooks = []
+    def __init__(self, model, scale_computation_type: str = 'maxabs'):
+        super(LayerwiseActivationEqualization, self).__init__()
+        self.model = model
+        self.float_act_map = {}
+        self.hooks = []
+        self.add_mul_node = True
 
-    def add_to_bias(self, module, tensor):
-        if module.bias is not None:
-            module.bias.data += tensor.view_as(module.bias)
+        regions = []
+        self.find_module(model, regions)
+        self.regions = regions
+
+        self.scale_computation_type = scale_computation_type
+        if self.scale_computation_type == 'maxabs':
+            self.scale_fn = _channel_maxabs
+        elif self.scale_computation_type == 'range':
+            self.scale_fn = _channel_range
+
+    def find_module(self, model, regions: List):
+        """
+        Iterate through the model looking at immediate children of every module to look for supported modules.
+        This allows us to stop the search when we meet a top-level module that is supported.
+        Specifically, it allows to map nn.MultiheadAttetion to its quantized counterpart and not its
+        Linear submodules.
+        """
+        if isinstance(model,
+                      _supported_layers) and not isinstance(model, _batch_norm + (nn.LayerNorm,)):
+            regions.append(model)
         else:
-            module.bias = nn.Parameter(tensor)
+            for module in model.children():
+                self.find_module(module, regions)
 
-    def absorb_biases(self, groups):
-        for layer, bn, (next_layer_name, next_layer) in groups:
-            cfactor = bn.running_mean - 3 * torch.sqrt(bn.running_var)
-            zeroes = torch.zeros_like(cfactor).to(cfactor.device)
-            cfactor = torch.where(cfactor > 0., cfactor, zeroes)
-            if (cfactor > 0).any():
-                self.add_to_bias(layer, -cfactor)
-                broadcast_shape = [1] * next_layer.weight.ndim
-                broadcast_shape[1] = cfactor.numel()
-                cfactor = cfactor.view(broadcast_shape)
-                cfactor = cfactor.expand(self.inp_shape_map[next_layer_name])
-                next_layer_cfactor = next_layer(cfactor).transpose(0, 1)
-                next_layer_cfactor = next_layer_cfactor.view(next_layer_cfactor.shape[0], -1)
-                next_layer_cfactor = torch.mean(next_layer_cfactor, dim=1)
-                self.add_to_bias(next_layer, next_layer_cfactor)
-        self.inp_shape_map = {}
+    def setup(self):
+        for region in self.regions:
+            hook_fn = partial(self.forward_stats_hook, name=region)
+            self.hooks.append(region.register_forward_pre_hook(hook_fn))
 
-    def extract_groups(self, graph_model: GraphModule):
-        groups = []
-        for node in graph_model.graph.nodes:
-            if (_is_supported_module(graph_model, node) and node.next.op == 'call_module' and
-                    isinstance(get_module(graph_model, node.next.target), _batch_norm)):
-                node_next = node.next.next
-                while _is_scale_invariant_module(graph_model,
-                                                 node_next) or _is_reshaping_op(node_next):
-                    node_next = node_next.next
-                if _is_supported_module(graph_model, node_next):
-                    group = (
-                        get_module(graph_model, node.target),
-                        get_module(graph_model, node.next.target),
-                        (node_next.target, get_module(graph_model, node_next.target)))
-                    groups.append(group)
-        return groups
+    def apply(self, alpha):
+        scale_factors = []
+        for region in self.regions:
+            if self.float_act_map[region] == None:
+                continue
+            sinks = region
+            insert_mul_fn = partial(self.insert_mul_node, region=region)
+            scale_factors.append(
+                _cross_layer_equalization([], [sinks],
+                                          False,
+                                          scale_computation_type=self.scale_computation_type,
+                                          list_of_act_val=[self.float_act_map[region]],
+                                          list_of_insert_mul_node_fn=[insert_mul_fn],
+                                          alpha=alpha))
+        return scale_factors
 
-    def collect_inp_shape_hook(self, module, inp, name):
-        if name in self.inp_shape_map.keys():
-            raise RuntimeError("Module called multiple times, not supported.")
-        if isinstance(inp, tuple):
-            inp = inp[0]
-        self.inp_shape_map[name] = [1] + list(inp.shape[1:])
-
-    def collect_inp_shapes(self, model, inp):
-        for name, module in model.named_modules():
-            if isinstance(module, (_supported_layers)):
-                hook_fn = partial(self.collect_inp_shape_hook, name=name)
-                hook = module.register_forward_pre_hook(hook_fn)
-                self.collect_inp_shape_hooks.append(hook)
-        model(inp)
-        for hook in self.collect_inp_shape_hooks:
+    def remove_hooks(self):
+        for hook in self.hooks:
             hook.remove()
-        self.collect_inp_shape_hooks = []
 
-    def apply(self, graph_model: GraphModule, inp):
-        self.collect_inp_shapes(graph_model, inp)
-        groups = self.extract_groups(graph_model)
-        self.absorb_biases(groups)
-        return graph_model
+    def forward_stats_hook(self, module, inp, name):
+        if len(inp) == 0:
+            warnings.warn(
+                "Cannot perform layerwise activation equalization with only kwargs as input")
+            self.float_act_map[name] = None
+            return
+
+        if len(inp) > 1:
+            # check that they are all equal for self-attention MHA
+            self_attention = all([inp[0].data_ptr() == i.data_ptr() for i in inp])
+            if not self_attention:
+                self.float_act_map[name] = None
+                return
+            inp = inp[0]
+        else:
+            inp = inp[0]
+        # Compute stats along the batch dimension
+        if name not in self.float_act_map:
+            self.float_act_map[name] = self.scale_fn(inp, dim=0)
+        else:
+            batch_data = torch.cat([self.float_act_map[name].unsqueeze(0), inp], dim=0)
+            self.float_act_map[name] = self.scale_fn(batch_data, dim=0)
+
+    def insert_mul_node(self, scale, shape, axis, region):
+        broadcastable_shape = [1] * len(shape)
+        broadcastable_shape[axis] = shape[axis]
+        # Add Batch Dim
+        broadcastable_shape.insert(0, 1)
+        mul_factor = ScaleBias(
+            num_features=shape[axis], bias=False, runtime_shape=broadcastable_shape)
+        mul_factor.weight.data = scale
+        rewriter = ModuleInstanceToModuleInstance(
+            region, EqualizedModule(scale_module=mul_factor, layer=region))
+        rewriter.apply(self.model)
+
+
+class GraphActivationEqualization(GraphTransform):
+
+    def __init__(
+            self, model, add_mul_node, layerwise=False, scale_computation_type: str = 'maxabs'):
+        super(GraphActivationEqualization, self).__init__()
+        self.graph_model = model
+        self.float_act_map = {}
+        self.hooks = []
+        self.layerwise = layerwise
+        if self.layerwise:
+            self.add_mul_node = True
+        else:
+            self.add_mul_node = add_mul_node
+        if self.layerwise:
+            regions = []
+            self.find_module(model, regions)
+            self.regions = regions
+        else:
+            self.regions = _extract_regions(model, add_mul_node=add_mul_node, return_acts=True)
+
+        self.scale_computation_type = scale_computation_type
+        if self.scale_computation_type == 'maxabs':
+            self.scale_fn = _channel_maxabs
+        elif self.scale_computation_type == 'range':
+            self.scale_fn = _channel_range
+
+    def setup(self):
+        name_to_module = dict_name_to_module(self.graph_model, self.regions)
+        # Select only regions with activation to equalize through.
+        # If a region has no activations, it is dropped.
+        # If a region has multiple scale varying activation, must also be dropped
+        # because we can't propagate scaling factors
+        regions_to_drop = []
+        for region in self.regions:
+            if len(region.acts) == 0:
+                regions_to_drop.append(region)
+            # This condition is for redudancy, since
+            # a region with two scale-varying activations cannot be detected in the first place
+            elif len(region.acts) > 1 and any([isinstance(name_to_module[act_name],
+                                                          _scale_varying_activations)
+                                               for act_name in region.acts]):
+                regions_to_drop.append(region)
+            else:
+                for act_name in region.acts:
+                    # act_name = region.acts[0]
+                    act_module = name_to_module[act_name]
+                    hook_fn = partial(self.forward_stats_hook, name=act_name)
+                    self.hooks.append(act_module.register_forward_hook(hook_fn))
+
+        self.regions = [x for x in self.regions if x not in regions_to_drop]
+
+    def apply(self, alpha):
+        scale_factors = []
+        name_to_module = dict_name_to_module(self.graph_model, self.regions)
+        for region in self.regions:
+            act_module = [name_to_module[act_name] for act_name in region.acts]
+            list_of_act_val = [self.float_act_map[act_name] for act_name in region.acts]
+            sinks = [name_to_module[sink] for sink in region.sinks]
+            # Filter out scale_varying activations from the srcs
+            srcs = [
+                name_to_module[src]
+                for src in region.srcs
+                if not isinstance(name_to_module[src], _scale_varying_activations)]
+
+            list_of_insert_mul_node_fn = None
+            if self.add_mul_node and any([
+                    isinstance(act, _scale_varying_activations) for act in act_module]):
+                # Even though we iterate, this list will always have a single element by definition
+                list_of_insert_mul_node_fn = []
+                for act_name in region.acts:
+                    act_node = get_node(self.graph_model, act_name)
+                    list_of_insert_mul_node_fn.append(
+                        partial(self.insert_mul_node, act_node=act_node))
+            scale_factors.append(
+                _cross_layer_equalization(
+                    srcs,
+                    sinks,
+                    False,
+                    scale_computation_type=self.scale_computation_type,
+                    list_of_act_val=list_of_act_val,
+                    list_of_insert_mul_node_fn=list_of_insert_mul_node_fn,
+                    alpha=alpha))
+
+        return scale_factors
+
+    def remove_hooks(self):
+        for hook in self.hooks:
+            hook.remove()
+
+    def forward_stats_hook(self, module, inp, out, name):
+        # Compute stats along the batch dimension
+        if name not in self.float_act_map:
+            self.float_act_map[name] = self.scale_fn(out, dim=0)
+        else:
+            batch_data = torch.cat([self.float_act_map[name].unsqueeze(0), out], dim=0)
+            self.float_act_map[name] = self.scale_fn(batch_data, dim=0)
+
+    def insert_mul_node(self, scale, shape, axis, act_node):
+        broadcastable_shape = [1] * len(shape)
+        broadcastable_shape[axis] = shape[axis]
+        # Add Batch Dim
+        broadcastable_shape.insert(0, 1)
+        mul_factor = ScaleBias(
+            num_features=shape[axis], bias=False, runtime_shape=broadcastable_shape)
+        mul_factor.weight.data = scale
+        mul_factor_name = act_node.name + 'act_eq_mul'
+        self.graph_model.add_module(mul_factor_name, mul_factor)
+        rewriter = InsertModuleCallAfter(mul_factor_name, act_node)
+        rewriter.apply(self.graph_model)

--- a/src/brevitas/graph/quantize.py
+++ b/src/brevitas/graph/quantize.py
@@ -13,6 +13,7 @@ from brevitas.graph.fixed_point import CollapseConsecutiveConcats
 from brevitas.graph.fixed_point import MergeBatchNorm
 from brevitas.graph.fixed_point import MoveSplitBatchNormBeforeCat
 from brevitas.graph.per_input import AdaptiveAvgPoolToAvgPool
+from brevitas.graph.quantize_impl import act_handler
 from brevitas.graph.quantize_impl import add_output_quant_handler
 from brevitas.graph.quantize_impl import inp_placeholder_handler
 from brevitas.graph.quantize_impl import layer_handler
@@ -301,7 +302,7 @@ def quantize(
     graph_model.eval()
     graph_model = inp_placeholder_handler(
         graph_model, input_quantizer=quant_identity_map.get('signed', None))
-    graph_model = layer_handler(graph_model, layer_map=quant_act_map, requantize_output=False)
+    graph_model = act_handler(graph_model, layer_map=quant_act_map)
     graph_model = add_output_quant_handler(
         graph_model, quant_identity_map, quant_act_map, unsigned_act_tuple)
     graph_model = layer_handler(

--- a/src/brevitas/graph/target/flexml.py
+++ b/src/brevitas/graph/target/flexml.py
@@ -4,19 +4,11 @@
 from torch import nn
 
 from brevitas.fx.brevitas_tracer import symbolic_trace
-from brevitas.graph.base import ModuleToModuleByClass
-from brevitas.graph.equalize import EqualizeGraph
-from brevitas.graph.fixed_point import CollapseConsecutiveConcats
-from brevitas.graph.fixed_point import MergeBatchNorm
-from brevitas.graph.fixed_point import MoveSplitBatchNormBeforeCat
 from brevitas.graph.per_input import AdaptiveAvgPoolToAvgPool
 from brevitas.graph.quantize import preprocess_for_quantize
 from brevitas.graph.quantize import quantize
 from brevitas.graph.quantize import UNSIGNED_ACT_TUPLE
-from brevitas.graph.standardize import DuplicateSharedStatelessModule
 from brevitas.graph.standardize import MeanMethodToAdaptiveAvgPool2d
-from brevitas.graph.standardize import RemoveStochasticModules
-from brevitas.graph.standardize import TorchFunctionalToModule
 import brevitas.nn as qnn
 from brevitas.quant import Int8ActPerTensorFixedPoint
 from brevitas.quant import Int8WeightPerTensorFixedPoint
@@ -113,19 +105,7 @@ FLEXML_QUANT_ACT_MAP = {
     nn.Sigmoid: (
         qnn.QuantSigmoid, {
             'act_quant': Uint8ActPerTensorFixedPoint,
-            'return_quant_tensor': True,}),
-    nn.SiLU: (
-        qnn.flexml.FlexMLQuantSwish, {
-            'act_quant': Int8ActPerTensorFixedPoint,
-            'return_quant_tensor': True,}),
-    nn.Hardswish: (
-        qnn.flexml.FlexMLQuantHardswish, {
-            'act_quant': Int8ActPerTensorFixedPoint,
-            'return_quant_tensor': True,}),
-    nn.Hardsigmoid: (
-        qnn.flexml.FlexMLQuantHardsigmoid, {
-            'act_quant': Uint8ActPerTensorFixedPoint,
-            'return_quant_tensor': True,})}
+            'return_quant_tensor': True,}),}
 
 FLEXML_QUANT_IDENTITY_MAP = {
     'signed':

--- a/src/brevitas/graph/utils.py
+++ b/src/brevitas/graph/utils.py
@@ -157,3 +157,9 @@ def get_output_channel_dim(module):
 
 def get_output_channels(module):
     return module.weight.shape[get_output_channel_dim(module)]
+
+
+def get_node(graph_model, name):
+    for node in graph_model.graph.nodes:
+        if node.target == name:
+            return node

--- a/src/brevitas/nn/equalized_layer.py
+++ b/src/brevitas/nn/equalized_layer.py
@@ -1,0 +1,40 @@
+import torch
+
+from brevitas.nn.quant_mha import QuantMultiheadAttention
+
+
+class EqualizedModule(torch.nn.Module):
+
+    def __init__(self, scale_module, layer) -> None:
+        super().__init__()
+        self.scale = scale_module
+        self.layer = layer
+
+    def forward(self, x, *args, **kwargs):
+        args = list(args)
+        out = x
+        if 'key' in kwargs:
+            if kwargs['key'].data_ptr() != out.data_ptr():
+                raise ValueError(
+                    "Cross MHA is not supported for activation equalization."
+                    "Replace kwargs with positional args to avoid this exception.")
+        out = self.scale(out)
+
+        pos_inputs = [out]
+        # QuantMultiheadAttention is not a subclass of MultiheadAttention
+        # We need to preserve the correctness of the forward even after
+        # quantization has been applied
+        if isinstance(self.layer, (torch.nn.MultiheadAttention, QuantMultiheadAttention)):
+            if 'key' not in kwargs.items():
+                pos_inputs.append(out)
+                args.pop(0)
+            else:
+                kwargs['key'] = out
+            if 'value' not in kwargs.items():
+                pos_inputs.append(out)
+                args.pop(0)
+            else:
+                kwargs['value'] = out
+
+        out = self.layer(*pos_inputs, *args, **kwargs)
+        return out

--- a/src/brevitas/nn/quant_scale_bias.py
+++ b/src/brevitas/nn/quant_scale_bias.py
@@ -31,7 +31,10 @@ class ScaleBias(Module):
         self.runtime_shape = runtime_shape
 
     def forward(self, input):
-        return input * self.weight.view(self.runtime_shape) + self.bias.view(self.runtime_shape)
+        out = input * self.weight.view(self.runtime_shape)
+        if self.bias:
+            out += self.bias.view(self.runtime_shape)
+        return out
 
 
 class QuantScaleBias(QuantWBIOL, ScaleBias):

--- a/src/brevitas/nn/target/flexml.py
+++ b/src/brevitas/nn/target/flexml.py
@@ -51,60 +51,6 @@ class FlexMLQuantLeakyReLU(nn.Module):
         return self.output_quant.is_quant_act_signed
 
 
-class FlexMLQuantSwish(QuantNLAL):
-
-    def __init__(
-            self,
-            act_quant: Optional[ActQuantType] = Int8ActPerTensorFixedPoint,
-            input_quant: Optional[ActQuantType] = None,
-            return_quant_tensor: bool = False,
-            **kwargs):
-        QuantNLAL.__init__(
-            self,
-            act_impl=nn.SiLU,
-            passthrough_act=False,
-            input_quant=input_quant,
-            act_quant=act_quant,
-            return_quant_tensor=return_quant_tensor,
-            **kwargs)
-
-
-class FlexMLQuantHardsigmoid(QuantNLAL):
-
-    def __init__(
-            self,
-            act_quant: Optional[ActQuantType] = Uint8ActPerTensorFixedPoint,
-            input_quant: Optional[ActQuantType] = None,
-            return_quant_tensor: bool = False,
-            **kwargs):
-        QuantNLAL.__init__(
-            self,
-            act_impl=nn.Hardsigmoid,
-            passthrough_act=False,
-            input_quant=input_quant,
-            act_quant=act_quant,
-            return_quant_tensor=return_quant_tensor,
-            **kwargs)
-
-
-class FlexMLQuantHardswish(QuantNLAL):
-
-    def __init__(
-            self,
-            act_quant: Optional[ActQuantType] = Int8ActPerTensorFixedPoint,
-            input_quant: Optional[ActQuantType] = None,
-            return_quant_tensor: bool = False,
-            **kwargs):
-        QuantNLAL.__init__(
-            self,
-            act_impl=nn.Hardswish,
-            passthrough_act=False,
-            input_quant=input_quant,
-            act_quant=act_quant,
-            return_quant_tensor=return_quant_tensor,
-            **kwargs)
-
-
 class FlexMLQuantAvgPool2d(QuantLayerMixin, nn.AvgPool2d):
 
     class Int16QuantAvgPoolDivQuant(Int8ActPerTensorFixedPoint):

--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -140,7 +140,7 @@ def test_models(toy_model, merge_bias, request):
     assert torch.allclose(expected_out, out, atol=ATOL)
     # Check that at least one region performs "true" equalization
     # If all shapes are scalar, no equalization has been performed
-    assert any([shape != () for shape in shape_scale_regions])
+    assert all([shape != () for shape in shape_scale_regions])
 
 
 @pytest_cases.parametrize("layerwise", [True, False])

--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -10,6 +10,8 @@ from brevitas.fx import symbolic_trace
 from brevitas.graph.equalize import _batch_norm
 from brevitas.graph.equalize import _extract_regions
 from brevitas.graph.equalize import _is_supported_module
+from brevitas.graph.equalize import activation_equalization_mode
+from brevitas.graph.standardize import DuplicateSharedStatelessModule
 from brevitas.graph.standardize import TorchFunctionalToModule
 from brevitas.graph.utils import get_module
 
@@ -138,4 +140,81 @@ def test_models(toy_model, merge_bias, request):
     assert torch.allclose(expected_out, out, atol=ATOL)
     # Check that at least one region performs "true" equalization
     # If all shapes are scalar, no equalization has been performed
-    assert all([shape != () for shape in shape_scale_regions])
+    assert any([shape != () for shape in shape_scale_regions])
+
+
+@pytest_cases.parametrize("layerwise", [True, False])
+def test_act_equalization_models(toy_model, layerwise, request):
+    test_id = request.node.callspec.id
+
+    if 'mha' in test_id:
+        in_shape = IN_SIZE_LINEAR
+    else:
+        in_shape = IN_SIZE_CONV
+
+    model_class = toy_model
+    model = model_class()
+    inp = torch.randn(in_shape)
+
+    model.eval()
+    expected_out = model(inp)
+    model = symbolic_trace(model)
+    with torch.no_grad():
+        with activation_equalization_mode(model, 0.5, True, layerwise=layerwise) as aem:
+            regions = aem.graph_act_eq.regions
+            model(inp)
+    scale_factor_regions = aem.scale_factors
+    shape_scale_regions = [scale.shape for scale in scale_factor_regions]
+
+    out = model(inp)
+    assert torch.allclose(expected_out, out, atol=ATOL)
+
+    # This region is made up of a residual branch, so no regions are found for act equalization
+    if 'srcsinkconflict_mode' not in test_id:
+        assert len(regions) > 0
+        # Check that at least one region performs "true" equalization
+        # If all shapes are scalar, no equalization has been performed
+        assert any([shape != () for shape in shape_scale_regions])
+
+
+@pytest_cases.parametrize(
+    "model_dict", [(model_name, coverage) for model_name, coverage in MODELS.items()],
+    ids=[model_name for model_name, _ in MODELS.items()])
+@pytest_cases.parametrize("layerwise", [True, False])
+def test_act_equalization_torchvision_models(model_dict: dict, layerwise: bool):
+    model, coverage = model_dict
+
+    if model == 'googlenet' and torch_version == version.parse('1.8.1'):
+        pytest.skip(
+            'Skip because of PyTorch error = AttributeError: \'function\' object has no attribute \'GoogLeNetOutputs\' '
+        )
+    if 'vit' in model and torch_version < version.parse('1.13'):
+        pytest.skip(
+            f'ViT supported from torch version 1.13, current torch version is {torch_version}')
+
+    try:
+        model = getattr(models, model)(pretrained=True, transform_input=False)
+    except TypeError:
+        model = getattr(models, model)(pretrained=True)
+
+    torch.manual_seed(SEED)
+    inp = torch.randn(IN_SIZE_CONV)
+    model.eval()
+
+    model = symbolic_trace(model)
+    model = TorchFunctionalToModule().apply(model)
+    model = DuplicateSharedStatelessModule().apply(model)
+    expected_out = model(inp)
+
+    with torch.no_grad():
+        with activation_equalization_mode(model, 0.5, True, layerwise=layerwise) as aem:
+            model(inp)
+    scale_factor_regions = aem.scale_factors
+    shape_scale_regions = [scale.shape for scale in scale_factor_regions]
+
+    out = model(inp)
+
+    assert torch.allclose(expected_out, out, atol=ATOL)
+    # Check that at least one region performs "true" equalization
+    # If all shapes are scalar, no equalization has been performed
+    assert any([shape != () for shape in shape_scale_regions])

--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -174,7 +174,7 @@ def test_act_equalization_models(toy_model, layerwise, request):
         assert len(regions) > 0
         # Check that at least one region performs "true" equalization
         # If all shapes are scalar, no equalization has been performed
-        assert any([shape != () for shape in shape_scale_regions])
+        assert all([shape != () for shape in shape_scale_regions])
 
 
 @pytest_cases.parametrize(


### PR DESCRIPTION
Changes:

- walk_region extended to keep track of activations encoutered in the path, 
- walk_region can walk through scale varying activations (e.g., sigmoid)

**Activation Equalization support**:
- Possibility to set and tune alpha
- For now, if there are multiple activations in one region, no equalization is performed (it could be mathematically possible but I have doubt about its usefulness)
- If scale varying activations are used, then a standalone MUL op is added after the activation. 

~~Missing tests. On a FP model, this transformation does not alter the math of the model, similar to graph equalization. Tests will be performed in a similar fashion.~~