### PR TITLE
Fix UserWarning: Defining your `__torch_function__` as a plain method is deprecated and will be an error in future, please define it as a classmethod.

### DIFF
--- a/src/brevitas/quant_tensor/__init__.py
+++ b/src/brevitas/quant_tensor/__init__.py
@@ -79,6 +79,7 @@ class QuantTensor(QuantTensorBase):
         else:
             return None
 
+    @classmethod
     def __torch_function__(self, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}


### PR DESCRIPTION
See: https://github.com/pytorch/pytorch/blob/08766b23de8ed50a8f52973df78114426500cb65/torch/overrides.py#L1547.

I get this error with the latest version of Brevitas (installed via `pip` one week ago) with PyTorch 1.13