### PR TITLE
Fix single linear test

### DIFF
--- a/src/brevitas_examples/llm/test_linear_mlir_export.py
+++ b/src/brevitas_examples/llm/test_linear_mlir_export.py
@@ -1,4 +1,5 @@
 import argparse
+from typing import List, Tuple
 
 import torch
 from torch import nn
@@ -14,6 +15,32 @@ from brevitas_examples.llm.llm_quant.export import LinearWeightBlockQuantHandler
 from brevitas_examples.llm.llm_quant.export import replace_call_fn_target
 from brevitas_examples.llm.llm_quant.mlir_custom_mm import brevitas_matmul_rhs_group_quant_library
 from brevitas_examples.llm.llm_quant.quantize import quantize_model
+
+
+def brevitas〇matmul_rhs_group_quant〡shape(lhs: List[int], rhs: List[int], rhs_scale: List[int], rhs_zero_point: List[int], rhs_bit_width: int, rhs_group_size: int) -> List[int]:
+    if len(lhs) == 3 and len(rhs) == 2:
+        return [lhs[0], lhs[1], rhs[0]]
+    elif len(lhs) == 2 and len(rhs) == 2:
+        return [lhs[0], rhs[0]]
+    else:
+        raise ValueError("Input shapes not supported.")
+
+
+def brevitas〇matmul_rhs_group_quant〡dtype(lhs_rank_dtype: Tuple[int, int], rhs_rank_dtype: Tuple[int, int], rhs_scale_rank_dtype: Tuple[int, int], rhs_zero_point_rank_dtype: Tuple[int, int], rhs_bit_width: int, rhs_group_size: int) -> int:
+    # output dtype is the dtype of the lhs float input
+    lhs_rank, lhs_dtype = lhs_rank_dtype
+    return lhs_dtype
+
+
+def brevitas〇matmul_rhs_group_quant〡has_value_semantics(lhs, rhs, rhs_scale, rhs_zero_point, rhs_bit_width, rhs_group_size) -> None:
+    return
+# yapf: enable
+
+
+brevitas_matmul_rhs_group_quant_library = [
+    brevitas〇matmul_rhs_group_quant〡shape,
+    brevitas〇matmul_rhs_group_quant〡dtype,
+    brevitas〇matmul_rhs_group_quant〡has_value_semantics]
 
 
 # Due a tracing issue this annotation needs to be


### PR DESCRIPTION
Got the following error without the changes.

> python exception: Failure while executing pass pipeline:
error: unknown: unsupported by backend contract: module initializers
note: unknown: see current operation: "torch.initialize.global_slots"(%4, %5, %6) {slotSymNames = [@_tensor_constant1, @_tensor_constant2, @_tensor_constant3]} : (!torch.tensor<[256,128],ui8>, !torch.tensor<[256,1,1],f32>, !torch.tensor<[256,1,1],f32>) -> ()
note: unknown: this is likely due to InlineGlobalSlots being unable to inline a global slot

Tested with the latest torch-mlir, no other changes required.