### PR TITLE
Fixes ConvNd usability and shape inference for qonnx export on Torch 2.0.1

### DIFF
--- a/src/brevitas/export/onnx/qonnx/function.py
+++ b/src/brevitas/export/onnx/qonnx/function.py
@@ -3,6 +3,7 @@
 
 import torch
 from torch.autograd import Function
+from torch.onnx.symbolic_helper import _get_tensor_sizes
 
 from brevitas.core.bit_width import BitWidthConst
 from brevitas.core.function_wrapper.clamp import TensorClamp
@@ -10,6 +11,7 @@ from brevitas.core.quant import IntQuant
 from brevitas.core.quant import TruncIntQuant
 from brevitas.function import binary_sign
 from brevitas.quant.solver.common import solve_float_to_int_impl_from_enum
+
 
 DOMAIN_STRING = "onnx.brevitas"
 
@@ -19,6 +21,7 @@ class BrevitasBinaryQuantFn(Function):
     @staticmethod
     def symbolic(g, x, scale, zero_point, bit_width, narrow_range, signed, rounding_mode):
         ret = g.op(f'{DOMAIN_STRING}::BipolarQuant', x, scale)
+        ret.setType(x.type().with_sizes(_get_tensor_sizes(x)))
         return ret
 
     @staticmethod
@@ -40,6 +43,7 @@ class BrevitasQuantFn(Function):
             rounding_mode_s=rounding_mode,
             signed_i=int(signed),
             narrow_i=int(narrow_range))
+        ret.setType(x.type().with_sizes(_get_tensor_sizes(x)))
         return ret
 
     @staticmethod

--- a/src/brevitas/export/onnx/qonnx/manager.py
+++ b/src/brevitas/export/onnx/qonnx/manager.py
@@ -12,6 +12,8 @@ from brevitas.export.manager import _set_recurrent_layer_export_handler
 from brevitas.export.manager import _set_recurrent_layer_export_mode
 from brevitas.export.onnx.debug import DebugMarkerFunction
 from brevitas.export.onnx.manager import ONNXBaseManager
+from brevitas.export.onnx.finn.function.parameter import QuantizedConvNdFn
+from brevitas.export.onnx.finn.handler.parameter import FINNQuantConvNdHandler
 
 from .function import BrevitasBinaryQuantFn
 from .function import BrevitasQuantFn
@@ -42,14 +44,16 @@ class QONNXManager(ONNXBaseManager):
         BrevitasDecoupledWeightQuantProxyHandler,
         BrevitasDecoupledWeightQuantWithInputProxyHandler,
         BrevitasTruncQuantProxyHandler,
-        BrevitasQuantLSTMLayerHandler]
+        BrevitasQuantLSTMLayerHandler,
+        FINNQuantConvNdHandler]
 
     custom_fns = [
         DebugMarkerFunction,
         BrevitasQuantFn,
         BrevitasBinaryQuantFn,
         BrevitasTruncFn,
-        BrevitasQuantLSTMCellFn]
+        BrevitasQuantLSTMCellFn,
+        QuantizedConvNdFn]
 
     @classmethod
     def set_export_mode(cls, model: Module, enabled: bool):


### PR DESCRIPTION
As mentioned in issue #449 when using Torch>=2.0.1, sometimes shape inference doesn't work properly when exporting to QONNX. In some cases it only produces warnings, but for some cases with Conv2D layers specifically the export won't work at all. This would fix both the warnings and errors, atleast regarding the ConvNd layer types. I tested the export on multiple example networks afterwards.