### PR TITLE
Fix (examples): adding bias_quant to final linear layer in resnet18

### DIFF
--- a/src/brevitas_examples/bnn_pynq/models/resnet.py
+++ b/src/brevitas_examples/bnn_pynq/models/resnet.py
@@ -10,6 +10,7 @@ import brevitas.nn as qnn
 from brevitas.quant import Int8WeightPerChannelFloat
 from brevitas.quant import Int8WeightPerTensorFloat
 from brevitas.quant import TruncTo8bit
+from brevitas.quant import IntBias
 from brevitas.quant_tensor import QuantTensor
 
 
@@ -120,6 +121,7 @@ class QuantResNet(nn.Module):
             act_bit_width=8,
             weight_bit_width=8,
             round_average_pool=False,
+            last_layer_bias_quant=IntBias,
             weight_quant=Int8WeightPerChannelFloat,
             first_layer_weight_quant=Int8WeightPerChannelFloat,
             last_layer_weight_quant=Int8WeightPerTensorFloat):
@@ -163,6 +165,7 @@ class QuantResNet(nn.Module):
             num_classes,
             weight_bit_width=8,
             bias=True,
+            bias_quant=last_layer_bias_quant,
             weight_quant=last_layer_weight_quant)
 
         for m in self.modules():
@@ -224,7 +227,8 @@ def quant_resnet18(cfg) -> QuantResNet:
     act_bit_width = cfg.getint('QUANT', 'ACT_BIT_WIDTH')
     num_classes = cfg.getint('MODEL', 'NUM_CLASSES')
     model = QuantResNet(
-        QuantBasicBlock, [2, 2, 2, 2],
+        block_impl=QuantBasicBlock,
+        num_blocks=[2, 2, 2, 2],
         num_classes=num_classes,
         weight_bit_width=weight_bit_width,
         act_bit_width=act_bit_width)

--- a/src/brevitas_examples/bnn_pynq/models/resnet.py
+++ b/src/brevitas_examples/bnn_pynq/models/resnet.py
@@ -9,8 +9,8 @@ import torch.nn as nn
 import brevitas.nn as qnn
 from brevitas.quant import Int8WeightPerChannelFloat
 from brevitas.quant import Int8WeightPerTensorFloat
-from brevitas.quant import TruncTo8bit
 from brevitas.quant import IntBias
+from brevitas.quant import TruncTo8bit
 from brevitas.quant_tensor import QuantTensor
 
 


### PR DESCRIPTION
Need to quantize the bias of the final layer to support streamlining in end-to-end FINN flow. Verified that this change does not impact accuracy on CIFAR10.

```shell
...
2023-10-11 16:06:12,585 Test: [97/100]  Model Time 0.109 (0.121)        Loss Time 0.000 (0.000) Loss 2.6345 (2.2591)    Prec@1 92.000 (92.592)  Prec@5 99.000 (99.694)
2023-10-11 16:06:12,690 Test: [98/100]  Model Time 0.094 (0.120)        Loss Time 0.011 (0.000) Loss 1.7418 (2.2538)    Prec@1 94.000 (92.606)  Prec@5 100.000 (99.697)
2023-10-11 16:06:12,790 Test: [99/100]  Model Time 0.100 (0.120)        Loss Time 0.000 (0.000) Loss 3.5667 (2.2670)    Prec@1 92.000 (92.600)  Prec@5 100.000 (99.700)
```