### PR TITLE
Gpfq/act order

### DIFF
--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
@@ -473,12 +473,12 @@ def apply_gptq(calib_loader, model, act_order=False):
                 gptq.update()
 
 
-def apply_gpfq(calib_loader, model, p=0.25):
+def apply_gpfq(calib_loader, model, act_order, p=0.25):
     model.eval()
     dtype = next(model.parameters()).dtype
     device = next(model.parameters()).device
     with torch.no_grad():
-        with gpfq_mode(model, p=p, use_quant_activations=True) as gpfq:
+        with gpfq_mode(model, p=p, use_quant_activations=True, act_order=act_order) as gpfq:
             gpfq_model = gpfq.model
             for i in tqdm(range(gpfq.num_layers)):
                 for i, (images, target) in enumerate(calib_loader):

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -79,9 +79,9 @@ parser.add_argument(
     help='Backend to target for quantization (default: fx)')
 parser.add_argument(
     '--scale-factor-type',
-    default='float',
-    choices=['float', 'po2'],
-    help='Type for scale factors (default: float)')
+    default='float_scale',
+    choices=['float_scale', 'po2_scale'],
+    help='Type for scale factors (default: float_scale)')
 parser.add_argument(
     '--act-bit-width', default=8, type=int, help='Activations bit width (default: 8)')
 parser.add_argument(
@@ -168,6 +168,34 @@ add_bool_arg(
     help='Narrow range for weight quantization (default: enabled)')
 parser.add_argument(
     '--gpfq-p', default=0.25, type=float, help='P parameter for GPFQ (default: 0.25)')
+parser.add_argument(
+    '--quant_format', default='int', choices=['int', 'float'],
+    help='Quantization format to use for weights and activations (default: int)'
+)
+parser.add_argument(
+    '--layerwise-first-last-mantissa-bit-width', default=4, type=int,
+    help='TODO' # @TODO: write helpful description for this
+)
+parser.add_argument(
+    '--layerwise-first-last-exponent-bit-width', default=3, type=int,
+    help='TODO' # @TODO: write helpful description for this
+)
+parser.add_argument(
+    '--weight-mantissa-bit-width', default=4, type=int,
+    help='TODO' # @TODO: write helpful description for this
+)
+parser.add_argument(
+    '--weight-exponent-bit-width', default=3, type=int,
+    help='TODO' # @TODO: write helpful description for this
+)
+parser.add_argument(
+    '--act-mantissa-bit-width', default=4, type=int,
+    help='TODO' # @TODO: write helpful description for this
+)
+parser.add_argument(
+    '--act-exponent-bit-width', default=3, type=int,
+    help='TODO' # @TODO: write helpful description for this
+)
 add_bool_arg(parser, 'gptq', default=True, help='GPTQ (default: enabled)')
 add_bool_arg(parser, 'gpfq', default=False, help='GPFQ (default: disabled)')
 add_bool_arg(
@@ -208,6 +236,7 @@ def main():
         f"{act_quant_calib_config}_"
         f"{args.weight_quant_calibration_type}_"
         f"{'bnc' if args.calibrate_bn else ''}")
+    # @TODO: include added options in configurations here
 
     print(
         f"Model: {args.model_name} - "
@@ -295,7 +324,14 @@ def main():
         act_bit_width=args.act_bit_width,
         act_param_method=args.act_quant_calibration_type,
         act_quant_percentile=args.act_quant_percentile,
-        act_quant_type=args.act_quant_type)
+        act_quant_type=args.act_quant_type,
+        quant_format=args.quant_format,
+        layerwise_first_last_mantissa_bit_width=args.layerwise_first_last_mantissa_bit_width,
+        layerwise_first_last_exponent_bit_width=args.layerwise_first_last_exponent_bit_width,
+        weight_mantissa_bit_width=args.weight_mantissa_bit_width,
+        weight_exponent_bit_width=args.weight_exponent_bit_width,
+        act_mantissa_bit_width=args.act_mantissa_bit_width,
+        act_exponent_bit_width=args.act_exponent_bit_width)
     # If available, use the selected GPU
     if args.gpu is not None:
         torch.cuda.set_device(args.gpu)

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -169,32 +169,45 @@ add_bool_arg(
 parser.add_argument(
     '--gpfq-p', default=0.25, type=float, help='P parameter for GPFQ (default: 0.25)')
 parser.add_argument(
-    '--quant_format', default='int', choices=['int', 'float'],
-    help='Quantization format to use for weights and activations (default: int)'
+    '--quant_format',
+    default='int',
+    choices=['int', 'float'],
+    help='Quantization format to use for weights and activations (default: int)')
+parser.add_argument(
+    '--layerwise-first-last-mantissa-bit-width',
+    default=4,
+    type=int,
+    help='TODO'  # @TODO: write helpful description
 )
 parser.add_argument(
-    '--layerwise-first-last-mantissa-bit-width', default=4, type=int,
-    help='TODO' # @TODO: write helpful description for this
+    '--layerwise-first-last-exponent-bit-width',
+    default=3,
+    type=int,
+    help='TODO'  # @TODO: write helpful description
 )
 parser.add_argument(
-    '--layerwise-first-last-exponent-bit-width', default=3, type=int,
-    help='TODO' # @TODO: write helpful description for this
+    '--weight-mantissa-bit-width',
+    default=4,
+    type=int,
+    help='TODO'  # @TODO: write helpful description
 )
 parser.add_argument(
-    '--weight-mantissa-bit-width', default=4, type=int,
-    help='TODO' # @TODO: write helpful description for this
+    '--weight-exponent-bit-width',
+    default=3,
+    type=int,
+    help='TODO'  # @TODO: write helpful description
 )
 parser.add_argument(
-    '--weight-exponent-bit-width', default=3, type=int,
-    help='TODO' # @TODO: write helpful description for this
+    '--act-mantissa-bit-width',
+    default=4,
+    type=int,
+    help='TODO'  # @TODO: write helpful description
 )
 parser.add_argument(
-    '--act-mantissa-bit-width', default=4, type=int,
-    help='TODO' # @TODO: write helpful description for this
-)
-parser.add_argument(
-    '--act-exponent-bit-width', default=3, type=int,
-    help='TODO' # @TODO: write helpful description for this
+    '--act-exponent-bit-width',
+    default=3,
+    type=int,
+    help='TODO'  # @TODO: write helpful description
 )
 add_bool_arg(parser, 'gptq', default=True, help='GPTQ (default: enabled)')
 add_bool_arg(parser, 'gpfq', default=False, help='GPFQ (default: disabled)')

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -177,38 +177,36 @@ parser.add_argument(
     '--layerwise-first-last-mantissa-bit-width',
     default=4,
     type=int,
-    help='TODO'  # @TODO: write helpful description
+    help=
+    'Mantissa bit width used with float layerwise quantization for first and last layer (default: 4)'
 )
 parser.add_argument(
     '--layerwise-first-last-exponent-bit-width',
     default=3,
     type=int,
-    help='TODO'  # @TODO: write helpful description
+    help=
+    'Exponent bit width used with float layerwise quantization for first and last layer (default: 3)'
 )
 parser.add_argument(
     '--weight-mantissa-bit-width',
     default=4,
     type=int,
-    help='TODO'  # @TODO: write helpful description
-)
+    help='Mantissa bit width used with float quantization for weights (default: 4)')
 parser.add_argument(
     '--weight-exponent-bit-width',
     default=3,
     type=int,
-    help='TODO'  # @TODO: write helpful description
-)
+    help='Exponent bit width used with float quantization for weights (default: 3)')
 parser.add_argument(
     '--act-mantissa-bit-width',
     default=4,
     type=int,
-    help='TODO'  # @TODO: write helpful description
-)
+    help='Mantissa bit width used with float quantization for activations (default: 4)')
 parser.add_argument(
     '--act-exponent-bit-width',
     default=3,
     type=int,
-    help='TODO'  # @TODO: write helpful description
-)
+    help='Exponent bit width used with float quantization for activations (default: 3)')
 add_bool_arg(parser, 'gptq', default=True, help='GPTQ (default: enabled)')
 add_bool_arg(parser, 'gpfq', default=False, help='GPFQ (default: disabled)')
 add_bool_arg(

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -211,6 +211,8 @@ add_bool_arg(parser, 'gptq', default=True, help='GPTQ (default: enabled)')
 add_bool_arg(parser, 'gpfq', default=False, help='GPFQ (default: disabled)')
 add_bool_arg(
     parser, 'gptq-act-order', default=False, help='GPTQ Act order heuristic (default: disabled)')
+add_bool_arg(
+    parser, 'gpfq-act-order', default=False, help='GPFQ Act order heuristic (default: disabled)')
 add_bool_arg(parser, 'learned-round', default=False, help='Learned round (default: disabled)')
 add_bool_arg(parser, 'calibrate-bn', default=False, help='Calibrate BN (default: disabled)')
 
@@ -263,6 +265,7 @@ def main():
         f"GPFQ: {args.gpfq} - "
         f"GPFQ P: {args.gpfq_p} - "
         f"GPTQ Act Order: {args.gptq_act_order} - "
+        f"GPFQ Act Order: {args.gpfq_act_order} - "
         f"Learned Round: {args.learned_round} - "
         f"Weight narrow range: {args.weight_narrow_range} - "
         f"Bias bit width: {args.bias_bit_width} - "
@@ -359,7 +362,7 @@ def main():
 
     if args.gpfq:
         print("Performing GPFQ:")
-        apply_gpfq(calib_loader, quant_model, p=args.gpfq_p)
+        apply_gpfq(calib_loader, quant_model, p=args.gpfq_p, act_order=args.gpfq_act_order)
 
     if args.gptq:
         print("Performing GPTQ:")

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -246,8 +246,12 @@ def main():
         f"{'mb_' if args.graph_eq_merge_bias else ''}"
         f"{act_quant_calib_config}_"
         f"{args.weight_quant_calibration_type}_"
-        f"{'bnc' if args.calibrate_bn else ''}")
-    # @TODO: include added options in configurations here
+        f"{'bnc' if args.calibrate_bn else ''}"
+        f"{args.quant_format}"
+        f"{args.weight_mantissa_bit_width if args.quant_format == 'float' else ''}"
+        f"{args.weight_exponent_bit_width if args.quant_format == 'float' else ''}"
+        f"{args.act_mantissa_bit_width if args.quant_format == 'float' else ''}"
+        f"{args.act_exponent_bit_width if args.quant_format == 'float' else ''}")
 
     print(
         f"Model: {args.model_name} - "

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -243,6 +243,7 @@ def main():
         f"{'gptq_' if args.gptq else ''}"
         f"{'gpfq_' if args.gpfq else ''}"
         f"{'gptq_act_order_' if args.gptq_act_order else ''}"
+        f"{'gpfq_act_order_' if args.gpfq_act_order else ''}"
         f"{'learned_round_' if args.learned_round else ''}"
         f"{'weight_narrow_range_' if args.weight_narrow_range else ''}"
         f"{args.bias_bit_width}bias_"

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -230,6 +230,11 @@ def main():
     config = (
         f"{args.model_name}_"
         f"{args.target_backend}_"
+        f"{args.quant_format}_"
+        f"{args.weight_mantissa_bit_width if args.quant_format == 'float' else ''}_"
+        f"{args.weight_exponent_bit_width if args.quant_format == 'float' else ''}_"
+        f"{args.act_mantissa_bit_width if args.quant_format == 'float' else ''}_"
+        f"{args.act_exponent_bit_width if args.quant_format == 'float' else ''}_"
         f"{args.scale_factor_type}_"
         f"a{args.act_bit_width}"
         f"w{args.weight_bit_width}_"
@@ -246,12 +251,7 @@ def main():
         f"{'mb_' if args.graph_eq_merge_bias else ''}"
         f"{act_quant_calib_config}_"
         f"{args.weight_quant_calibration_type}_"
-        f"{'bnc' if args.calibrate_bn else ''}"
-        f"{args.quant_format}"
-        f"{args.weight_mantissa_bit_width if args.quant_format == 'float' else ''}"
-        f"{args.weight_exponent_bit_width if args.quant_format == 'float' else ''}"
-        f"{args.act_mantissa_bit_width if args.quant_format == 'float' else ''}"
-        f"{args.act_exponent_bit_width if args.quant_format == 'float' else ''}")
+        f"{'bnc' if args.calibrate_bn else ''}")
 
     print(
         f"Model: {args.model_name} - "

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -169,7 +169,7 @@ add_bool_arg(
 parser.add_argument(
     '--gpfq-p', default=0.25, type=float, help='P parameter for GPFQ (default: 0.25)')
 parser.add_argument(
-    '--quant_format',
+    '--quant-format',
     default='int',
     choices=['int', 'float'],
     help='Quantization format to use for weights and activations (default: int)')
@@ -231,10 +231,10 @@ def main():
         f"{args.model_name}_"
         f"{args.target_backend}_"
         f"{args.quant_format}_"
-        f"{args.weight_mantissa_bit_width if args.quant_format == 'float' else ''}_"
-        f"{args.weight_exponent_bit_width if args.quant_format == 'float' else ''}_"
-        f"{args.act_mantissa_bit_width if args.quant_format == 'float' else ''}_"
-        f"{args.act_exponent_bit_width if args.quant_format == 'float' else ''}_"
+        f"{str(args.weight_mantissa_bit_width) + '_' if args.quant_format == 'float' else ''}"
+        f"{str(args.weight_exponent_bit_width) + '_' if args.quant_format == 'float' else ''}"
+        f"{str(args.act_mantissa_bit_width) + '_' if args.quant_format == 'float' else ''}"
+        f"{str(args.act_exponent_bit_width) + '_' if args.quant_format == 'float' else ''}"
         f"{args.scale_factor_type}_"
         f"a{args.act_bit_width}"
         f"w{args.weight_bit_width}_"


### PR DESCRIPTION
Adds `act_order` option for GPFQ. Hessian diagonal is computed by squaring and summing rows, avoiding `torch.bmm`, for speedup. 