### PR TITLE
Fixed no cuda error

### DIFF
--- a/src/brevitas_examples/bnn_pynq/README.md
+++ b/src/brevitas_examples/bnn_pynq/README.md
@@ -31,17 +31,17 @@ A few notes on training:
 
 To start training a model from scratch, e.g. LFC_1W1A, run:
  ```bash
-BREVITAS_JIT=1 brevitas_bnn_pynq_train --network LFC_1W1A --experiments /path/to/experiments
+BREVITAS_JIT=1 python bnn_pynq_train.py --network LFC_1W1A --experiments /path/to/experiments
  ```
 
 ## Evaluate
 
 To evaluate a pretrained model, e.g. LFC_1W1A, run:
  ```bash
-BREVITAS_JIT=1 brevitas_bnn_pynq_train --evaluate --network LFC_1W1A --pretrained
+BREVITAS_JIT=1 python bnn_pynq_train.py --evaluate --network LFC_1W1A --pretrained
  ```
 
 To evaluate your own checkpoint, of e.g. LFC_1W1A, run:
  ```bash
-BREVITAS_JIT=1 brevitas_bnn_pynq_train --evaluate --network LFC_1W1A --resume /path/to/checkpoint.tar
+BREVITAS_JIT=1 python bnn_pynq_train.py --evaluate --network LFC_1W1A --resume /path/to/checkpoint.tar
  ```

--- a/src/brevitas_examples/bnn_pynq/bnn_pynq_train.py
+++ b/src/brevitas_examples/bnn_pynq/bnn_pynq_train.py
@@ -52,7 +52,7 @@ def parse_args(args):
     add_bool_arg(parser, "detect_nan", default=False)
     # Compute resources
     parser.add_argument("--num_workers", default=4, type=int, help="Number of workers")
-    parser.add_argument("--gpus", type=none_or_str, default="0", help="Comma separated GPUs")
+    parser.add_argument("--gpus", type=none_or_str, default=None, help="Comma separated GPUs")
     # Optimizer hyperparams
     parser.add_argument("--batch_size", default=100, type=int, help="batch size")
     parser.add_argument("--lr", default=0.02, type=float, help="Learning rate")


### PR DESCRIPTION
The following error used to appear if you have cpu-only version of PyTorch:
`AssertionError: Torch not compiled with CUDA enabled`

This was due to the `gpus` argument check in the `Trainer.py` file, which checks for `None` as default/cpu option.

Some README.md updates as well