### PR TITLE
[quant_tensor] Fixed NaN is zero point calculation of `__truediv__`

### DIFF
--- a/src/brevitas/quant_tensor/__init__.py
+++ b/src/brevitas/quant_tensor/__init__.py
@@ -412,7 +412,7 @@ class QuantTensor(QuantTensorBase):
             output_signed = self.signed or other.signed
             output_training = self.training or other.training
             if self.is_zero_zero_point(self) and self.is_zero_zero_point(other):
-                output_zero_point = self.zero_point / other.zero_point
+                output_zero_point = self.zero_point * other.zero_point  # Output zero_point is a new, zero-valued tensor
             else:
                 output_zero_point = None  # TODO non-zero zero point
             output = QuantTensor(


### PR DESCRIPTION
Fix (for #767) in zero point calculation of `QuantTensor`'s `__truediv__` when the zero point of the input operands are both 0.