### PR TITLE
Feat: improve Brevitas compatibility with `torch.compile`

### DIFF
--- a/src/brevitas_examples/bnn_pynq/bnn_pynq_train.py
+++ b/src/brevitas_examples/bnn_pynq/bnn_pynq_train.py
@@ -69,6 +69,7 @@ def parse_args(args):
     parser.add_argument("--network", default="LFC_1W1A", type=str, help="neural network")
     parser.add_argument("--pretrained", action='store_true', help="Load pretrained model")
     parser.add_argument("--strict", action='store_true', help="Strict state dictionary loading")
+    parser.add_argument("--compile", action='store_true', help="Compile model with `torch.compile` (PyTorch version >=2 only)")
     parser.add_argument(
         "--state_dict_to_pth",
         action='store_true',

--- a/src/brevitas_examples/bnn_pynq/trainer.py
+++ b/src/brevitas_examples/bnn_pynq/trainer.py
@@ -24,6 +24,7 @@ from .logger import TrainingEpochMeters
 from .models import model_with_cfg
 from .models.losses import SqrHingeLoss
 
+TORCH_GEQ_200 = parse(torch.__version__) >= parse("2.0.0")
 
 class MirrorMNIST(MNIST):
 
@@ -64,6 +65,8 @@ class Trainer(object):
     def __init__(self, args):
 
         model, cfg = model_with_cfg(args.network, args.pretrained)
+        if args.compile and TORCH_GEQ_200:
+            model = torch.compile(model)
 
         # Init arguments
         self.args = args


### PR DESCRIPTION
Currently crashes occasionally occur when using `BREVITAS_JIT=1` & `torch.compile`, ideally these should interoperate without crashing until `TorchScript` is deprecated by upstream PyTorch.