### PR TITLE
Fix (optimum): Fix gptq and ONNX export

### DIFF
--- a/src/brevitas/export/manager.py
+++ b/src/brevitas/export/manager.py
@@ -160,7 +160,7 @@ def _restore_requires_grad(m: Module, previous_state):
 class BaseManager(ABC):
 
     target_name = None
-    handlers = []
+    handlers = set()
     _fn_to_cache = []
     _fn_cache = []
     _cached_io_handler_map = {}

--- a/src/brevitas/export/onnx/qonnx/manager.py
+++ b/src/brevitas/export/onnx/qonnx/manager.py
@@ -35,14 +35,14 @@ class QONNXManager(ONNXBaseManager):
         "extract_constant_to_initializer",  # remove unused graph inputs & initializers
         "eliminate_unused_initializer"]
 
-    handlers = [
+    handlers = {
         BrevitasActQuantProxyHandler,
         BrevitasBiasQuantProxyHandler,
         BrevitasWeightQuantProxyHandler,
         BrevitasDecoupledWeightQuantProxyHandler,
         BrevitasDecoupledWeightQuantWithInputProxyHandler,
         BrevitasTruncQuantProxyHandler,
-        BrevitasQuantLSTMLayerHandler]
+        BrevitasQuantLSTMLayerHandler}
 
     custom_fns = [
         DebugMarkerFunction,

--- a/src/brevitas/export/onnx/standard/qcdq/handler.py
+++ b/src/brevitas/export/onnx/standard/qcdq/handler.py
@@ -16,6 +16,7 @@ from brevitas.export.common.handler.qcdq import DynamicQDQCastActQuantProxyHandl
 from brevitas.export.common.handler.qcdq import DynamicQMixin
 from brevitas.export.common.handler.qcdq import QCDQCastActQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import QCDQCastTruncQuantProxyHandlerMixin
+from brevitas.export.common.handler.qcdq import QCDQCastWeightQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import QMixin
 from brevitas.export.onnx.handler import ONNXBaseHandler
 from brevitas.export.onnx.handler import QuantLSTMLayerHandler
@@ -112,6 +113,12 @@ class StdDynamicQDQCastONNXMixin(DynamicQMixin, StdDQCastONNXMixin, ABC):
 class StdCDQCastONNXWeightQuantProxyHandler(StdCDQCastONNXMixin,
                                             CDQCastWeightQuantProxyHandlerMixin,
                                             ONNXBaseHandler):
+    pass
+
+
+class StdQCDQCastONNXWeightQuantProxyHandler(StdQCDQCastONNXMixin,
+                                             QCDQCastWeightQuantProxyHandlerMixin,
+                                             ONNXBaseHandler):
     pass
 
 

--- a/src/brevitas/export/onnx/standard/qcdq/manager.py
+++ b/src/brevitas/export/onnx/standard/qcdq/manager.py
@@ -23,6 +23,7 @@ from .handler import StdDynamicQDQCastONNXActQuantProxyHandler
 from .handler import StdQCDQCastONNXActQuantProxyHandler
 from .handler import StdQCDQCastONNXQuantLSTMLayerHandler
 from .handler import StdQCDQCastONNXTruncQuantProxyHandler
+from .handler import StdQCDQCastONNXWeightQuantProxyHandler
 
 
 class StdQCDQONNXManager(StdONNXBaseManager):
@@ -34,7 +35,7 @@ class StdQCDQONNXManager(StdONNXBaseManager):
         "extract_constant_to_initializer",  # remove unused graph inputs & initializers
         "eliminate_unused_initializer"]
 
-    handlers = [
+    handlers = {
         StdCDQCastONNXWeightQuantProxyHandler,
         StdCDQCastONNXBiasQuantProxyHandler,
         StdQCDQCastONNXActQuantProxyHandler,
@@ -42,7 +43,7 @@ class StdQCDQONNXManager(StdONNXBaseManager):
         StdDynamicQDQCastONNXActQuantProxyHandler,
         StdQCDQCastONNXTruncQuantProxyHandler,
         StdCDQCastONNXDecoupledWeightQuantWithInputProxyHandler,
-        StdQCDQCastONNXQuantLSTMLayerHandler]
+        StdQCDQCastONNXQuantLSTMLayerHandler}
 
     custom_fns = [
         DebugMarkerFunction,
@@ -61,3 +62,12 @@ class StdQCDQONNXManager(StdONNXBaseManager):
     def set_export_handler(cls, module: Module):
         _set_proxy_export_handler(cls, module)
         _set_recurrent_layer_export_handler(cls, module)
+
+    @classmethod
+    def change_weight_handler(cls, export_quantize_node_weight: bool = False):
+        if export_quantize_node_weight:
+            cls.handler.discard(StdCDQCastONNXWeightQuantProxyHandler)
+            cls.handler.add(StdQCDQCastONNXWeightQuantProxyHandler)
+        else:
+            cls.handler.discard(StdQCDQCastONNXWeightQuantProxyHandler)
+            cls.handler.add(StdCDQCastONNXWeightQuantProxyHandler)

--- a/src/brevitas/export/onnx/standard/qoperator/manager.py
+++ b/src/brevitas/export/onnx/standard/qoperator/manager.py
@@ -45,7 +45,7 @@ class StdQOpONNXManager(StdONNXBaseManager):
         F.adaptive_max_pool2d,
         F.adaptive_max_pool3d,]
 
-    handlers = [
+    handlers = {
         StdQOpONNXQuantConv1dHandler,
         StdQOpONNXQuantConv2dHandler,
         StdQOpONNXQuantLinearHandler,
@@ -55,7 +55,7 @@ class StdQOpONNXManager(StdONNXBaseManager):
         StdQOpONNXQuantTanhHandler,
         StdQOpONNXQuantSigmoidHandler,
         StdQOpONNXQuantMaxPool1d,
-        StdQOpONNXQuantMaxPool2d]
+        StdQOpONNXQuantMaxPool2d}
 
     onnx_passes = [
         # remove unused graph inputs & initializers

--- a/src/brevitas/export/torch/qcdq/manager.py
+++ b/src/brevitas/export/torch/qcdq/manager.py
@@ -22,13 +22,13 @@ from .handler import TorchQCDQCastTruncQuantProxyHandler
 class TorchQCDQManager(BaseManager):
     target_name = 'torch'
 
-    handlers = [
+    handlers = {
         TorchCDQCastWeightQuantProxyHandler,
         TorchCDQCastDecoupledWeightQuantProxyHandler,
         TorchCDQCastDecoupledWeightQuantWithInputProxyHandler,
         TorchQCDQCastActQuantProxyHandler,
         TorchCDQCastBiasQuantProxyHandler,
-        TorchQCDQCastTruncQuantProxyHandler]
+        TorchQCDQCastTruncQuantProxyHandler}
 
     @classmethod
     def set_export_mode(cls, model: Module, enabled: bool):

--- a/src/brevitas/export/torch/qoperator/manager.py
+++ b/src/brevitas/export/torch/qoperator/manager.py
@@ -27,7 +27,7 @@ from .handler.pool import PytorchQuantMaxPool2d
 class TorchQOpManager(BaseManager):
     target_name = 'torch'
 
-    handlers = [
+    handlers = {
         PytorchQuantMaxPool1d,
         PytorchQuantMaxPool2d,
         PytorchQuantHardTanhHandler,
@@ -35,7 +35,7 @@ class TorchQOpManager(BaseManager):
         PytorchQuantReLUHandler,
         PytorchQuantConv1dHandler,
         PytorchQuantConv2dHandler,
-        PytorchQuantLinearHandler]
+        PytorchQuantLinearHandler}
 
     @classmethod
     def set_export_mode(cls, module: Module, enabled: bool):

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -126,7 +126,7 @@ class gpxq_mode(ABC):
             self.disable_quant_inference.disable_bias_quantization(
                 self.model, is_training=self.model.training)
 
-        self.num_layers = len(self.gpxq_layers)
+        self.num_layers = len(dict_of_layers)
         return self
 
     def __exit__(self, type, value, traceback):

--- a/src/brevitas_examples/llm/llm_quant/export.py
+++ b/src/brevitas_examples/llm/llm_quant/export.py
@@ -192,7 +192,7 @@ class LinearWeightBlockQuantHandler(WeightBlockQuantHandlerBase, ABC):
 
 class BlockQuantProxyLevelManager(BaseManager):
 
-    handlers = [WeightBlockQuantProxyHandler]
+    handlers = {WeightBlockQuantProxyHandler}
 
     @classmethod
     def set_export_handler(cls, module):
@@ -212,7 +212,7 @@ def block_quant_layer_level_manager(export_handlers):
 
 
 @contextmanager
-def brevitas_proxy_export_mode(model, export_manager=BlockQuantProxyLevelManager):
+def brevitas_proxy_export_mode(model, export_manager):
     is_training = model.training
     model.eval()
     model.apply(export_manager.set_export_handler)

--- a/src/brevitas_examples/llm/llm_quant/gptq.py
+++ b/src/brevitas_examples/llm/llm_quant/gptq.py
@@ -32,10 +32,11 @@ def gptq_iter(curr_layer, inps, outs, cached_values, act_order):
 
 
 @torch.no_grad()
-def apply_gptq(model, dataloader, forward_call, act_order=True):
+def apply_gptq(model, dataloader, forward_call, act_order=True, group_of_parallel_layers=None):
     model = offload_model(model)
     with gptq_mode(model,
                    use_quant_activations=False,
+                   group_of_parallel_layers=group_of_parallel_layers,
                    act_order=act_order,
                    create_weight_orig=False) as gptq:
         gptq_model = gptq.model

--- a/src/brevitas_examples/llm/llm_quant/sharded_mlir_group_export.py
+++ b/src/brevitas_examples/llm/llm_quant/sharded_mlir_group_export.py
@@ -404,7 +404,7 @@ def sharded_weight_group_export(model, no_custom_packed_export):
         export_context_manager = brevitas_layer_export_mode
         # generate an export_class with the handler declared above
         export_class = block_quant_layer_level_manager(
-            export_handlers=[LinearWeightBlockQuantHandlerFwd])
+            export_handlers={LinearWeightBlockQuantHandlerFwd})
 
     layers0 = [FirstVicunaLayer(layer) for layer in model.model.layers]
     mlirs0 = compile_to_vmfb(

--- a/src/brevitas_examples/optimum/example.py
+++ b/src/brevitas_examples/optimum/example.py
@@ -104,6 +104,11 @@ config = BrevitasQuantizationConfig(
     replace_mha_with_quantizable=args.replace_mha_with_quantizable)
 quantizer = BrevitasQuantizer(model, config)
 
+# To speed up GPTQ computation, we can look through the model to find layers that can be optimized in parallel
+# Because they do not depend on each other. A typical case is the input matrices of the attention layer.
+# We just need to specify the suffix of the layer, and they will be matched across the entire structure.
+# quantizer.find_groups_of_parallel_layers([['q_proj', 'k_proj', 'v_proj']]) # This is for base OPT
+
 calibration_dataloader = quantizer.get_calibration_dataloader(
     tokenizer, dataset_name='wikitext2-raw', num_samples=config.nsamples, seqlen=config.seqlen)
 

--- a/src/brevitas_examples/optimum/quantizer.py
+++ b/src/brevitas_examples/optimum/quantizer.py
@@ -145,6 +145,12 @@ class BrevitasQuantizer(OptimumQuantizer):
 
     def export(self, model, export_path):
         export_class = StdQCDQONNXManager
+
+        # When exporting large model, it is better to explicitly export the floating point weight
+        # followed by quantize-dequantize, instead of integer weights + dequantize.
+        # PyTorch ONNX export seems to run in some form of weight duplication with integer weights,
+        # causing the export to fail because the total model is over 2GB.
+        export_class.change_weight_handler(export_quantize_node_weight=True)
         # workaround for FX model
         extra_kwargs = {}
         if isinstance(self.model, (GraphModule, TorchGraphModule)):


### PR DESCRIPTION
The user can now specify the suffix of the layer names that can be run in parallel in GPTQ, to speed-up that computation.

This PR also fixed the export of ONNX files >2gb. The idea is that exporting the weight as integer causes the appearances of multiple parameters (the original FP weights, and the integer ones) in the model which are not handled correctly by pytorch during export.

This PR restores the possibility of exporting the FP weights + QDQ (instead of integer weight + DQ). In this way, having to handle only the original parameters of the model, everything seems to work fine.