### PR TITLE
Setup: pin pytest version

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,7 +1,7 @@
 hypothesis
 mock
 psutil
-pytest
+pytest==7.4.4 # TODO: Revert when pytest_cases is compatible with latest Pytest
 pytest-mock
 pytest-xdist
 pytest_cases


### PR DESCRIPTION
Pin pytest version to the latest release pre 8.0 because of compatibility issues with pytest_cases

https://github.com/smarie/python-pytest-cases/issues/330

Once pytest_cases is compatible, we can revert this.