### PR TITLE
Refactored per row quantization. JIT not working

### DIFF
--- a/src/brevitas/core/function_wrapper/shape.py
+++ b/src/brevitas/core/function_wrapper/shape.py
@@ -14,6 +14,7 @@ from brevitas.core.function_wrapper import Identity
 from brevitas.function.shape import over_batch_over_output_channels
 from brevitas.function.shape import over_batch_over_tensor
 from brevitas.function.shape import over_output_channels
+from brevitas.function.shape import over_output_features
 from brevitas.function.shape import over_tensor
 
 
@@ -123,6 +124,32 @@ class OverBatchOverOutputChannelView(brevitas.jit.ScriptModule):
     def forward(self, x: torch.Tensor):
         y = self.permute_impl(x)
         shape = over_batch_over_output_channels(y)
+        return y.reshape(shape)
+
+
+class OverOutputFeaturesView(brevitas.jit.ScriptModule):
+    """
+    ScriptModule to compute the :func:`~brevitas.function.shape.over_output_features`
+    view of an input tensor.
+
+    Examples:
+        >>> view_module = OverOutputFeaturesView()
+        >>> y = view_module(torch.empty(size=[8, 10, 25]))
+        >>> y.shape
+        torch.Size([80, 25])
+    """
+
+    def __init__(self, permute_dims: Optional[Tuple[int, ...]] = None) -> None:
+        super(OverOutputFeaturesView, self).__init__()
+        if permute_dims is not None:
+            self.permute_impl = PermuteDims(permute_dims)
+        else:
+            self.permute_impl = Identity()
+
+    @brevitas.jit.script_method
+    def forward(self, x: torch.Tensor):
+        y = self.permute_impl(x)
+        shape = over_output_features(y)
         return y.reshape(shape)
 
 

--- a/src/brevitas/function/shape.py
+++ b/src/brevitas/function/shape.py
@@ -93,3 +93,22 @@ def over_batch_over_output_channels(x: Tensor):
         (2, 3, -1)
     """
     return x.shape[0], x.shape[1], -1
+
+
+@brevitas.jit.script
+def over_output_features(x: Tensor):
+    """
+    Returns a shape s such that x.view(s) is a 2-dim tensor with batches
+    at dimension 0, output channels at dimension 1, and any other feature at dimension 2.
+
+    Args:
+        x (Tensor): Input tensor with batches at dimension 0 and output channels at dimension 1.
+
+    Returns:
+        A tuple containing the 2-dim shape.
+
+    Examples:
+        >>> over_batch_over_output_channels(torch.randn([2, 3, 4, 3]))
+        (2, 3, -1)
+    """
+    return -1, x.shape[-1]

--- a/src/brevitas/function/shape.py
+++ b/src/brevitas/function/shape.py
@@ -8,7 +8,6 @@ dimensions of a tensor.
 
 from typing import Tuple
 
-import torch
 from torch import Tensor
 
 import brevitas
@@ -17,6 +16,7 @@ __all__ = [
     'over_tensor',
     'over_output_channels',
     'over_batch_over_tensor',
+    'over_output_features',
     'over_batch_over_output_channels']
 
 
@@ -98,8 +98,8 @@ def over_batch_over_output_channels(x: Tensor):
 @brevitas.jit.script
 def over_output_features(x: Tensor):
     """
-    Returns a shape s such that x.view(s) is a 2-dim tensor with batches
-    at dimension 0, output channels at dimension 1, and any other feature at dimension 2.
+    Returns a shape s such that x.view(s) is a 2-dim tensor with all features except the last
+    one at dimension 0.
 
     Args:
         x (Tensor): Input tensor with batches at dimension 0 and output channels at dimension 1.
@@ -108,7 +108,7 @@ def over_output_features(x: Tensor):
         A tuple containing the 2-dim shape.
 
     Examples:
-        >>> over_batch_over_output_channels(torch.randn([2, 3, 4, 3]))
-        (2, 3, -1)
+        >>> over_output_features(torch.randn([2, 3, 4, 3]))
+        (24, 3)
     """
     return -1, x.shape[-1]

--- a/src/brevitas_examples/common/generative/quant_blocks.py
+++ b/src/brevitas_examples/common/generative/quant_blocks.py
@@ -89,7 +89,8 @@ class ExpandReshapeZeroPointWrapper(brevitas.jit.ScriptModule):
         return zero_point
 
 
-class RuntimeDynamicStatsScaling(brevitas.jit.ScriptModule):
+# TODO: restore JIT compatibility
+class RuntimeDynamicStatsScaling(nn.Module):
 
     def __init__(
             self,
@@ -101,7 +102,6 @@ class RuntimeDynamicStatsScaling(brevitas.jit.ScriptModule):
         self.stats_impl = scaling_stats_impl
         self.dynamic_scaling_broadcastable_fn = dynamic_scaling_broadcastable_fn
 
-    @brevitas.jit.script_method
     def forward(self, x) -> Tensor:
         shape = x.shape
         x = self.scaling_stats_input_view_shape_impl(x)
@@ -110,7 +110,8 @@ class RuntimeDynamicStatsScaling(brevitas.jit.ScriptModule):
         return x
 
 
-class RuntimeDynamicStatsZeroPoint(brevitas.jit.ScriptModule):
+# TODO: restore JIT compatibility
+class RuntimeDynamicStatsZeroPoint(nn.Module):
 
     def __init__(
             self,
@@ -125,7 +126,6 @@ class RuntimeDynamicStatsZeroPoint(brevitas.jit.ScriptModule):
         self.dynamic_scaling_broadcastable_fn = dynamic_scaling_broadcastable_fn
         self.scale_shift_zero_point = _ScaleShiftZeroPoint(int_quant, quantize_zero_point)
 
-    @brevitas.jit.script_method
     def forward(self, x, scale, bit_width) -> Tensor:
         shape = x.shape
         x = self.zero_point_stats_input_view_shape_impl(x)

--- a/src/brevitas_examples/common/generative/quant_blocks.py
+++ b/src/brevitas_examples/common/generative/quant_blocks.py
@@ -3,7 +3,7 @@ Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 """
 
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -90,47 +90,47 @@ class ExpandReshapeZeroPointWrapper(brevitas.jit.ScriptModule):
 
 
 class RuntimeDynamicStatsScaling(brevitas.jit.ScriptModule):
-    __constants__ = ['dynamic_scaling_broadcastable_shape']
 
     def __init__(
             self,
             scaling_stats_impl: nn.Module,
-            dynamic_scaling_broadcastable_shape: Tuple[int, ...],
+            dynamic_scaling_broadcastable_fn: Callable,
             scaling_stats_input_view_shape_impl: nn.Module) -> None:
         super(RuntimeDynamicStatsScaling, self).__init__()
         self.scaling_stats_input_view_shape_impl = scaling_stats_input_view_shape_impl
         self.stats_impl = scaling_stats_impl
-        self.dynamic_scaling_broadcastable_shape = dynamic_scaling_broadcastable_shape
+        self.dynamic_scaling_broadcastable_fn = dynamic_scaling_broadcastable_fn
 
     @brevitas.jit.script_method
     def forward(self, x) -> Tensor:
+        shape = x.shape
         x = self.scaling_stats_input_view_shape_impl(x)
         x = self.stats_impl(x)
-        x = x.view(self.dynamic_scaling_broadcastable_shape)
+        x = self.dynamic_scaling_broadcastable_fn(x, shape)
         return x
 
 
 class RuntimeDynamicStatsZeroPoint(brevitas.jit.ScriptModule):
-    __constants__ = ['dynamic_scaling_broadcastable_shape']
 
     def __init__(
             self,
             zero_point_stats_impl: nn.Module,
             int_quant: nn.Module,
             quantize_zero_point: bool,
-            dynamic_scaling_broadcastable_shape: Tuple[int, ...],
+            dynamic_scaling_broadcastable_fn: Callable,
             zero_point_stats_input_view_shape_impl: nn.Module) -> None:
         super(RuntimeDynamicStatsZeroPoint, self).__init__()
         self.zero_point_stats_input_view_shape_impl = zero_point_stats_input_view_shape_impl
         self.zero_point_stats_impl = zero_point_stats_impl
-        self.dynamic_scaling_broadcastable_shape = dynamic_scaling_broadcastable_shape
+        self.dynamic_scaling_broadcastable_fn = dynamic_scaling_broadcastable_fn
         self.scale_shift_zero_point = _ScaleShiftZeroPoint(int_quant, quantize_zero_point)
 
     @brevitas.jit.script_method
     def forward(self, x, scale, bit_width) -> Tensor:
+        shape = x.shape
         x = self.zero_point_stats_input_view_shape_impl(x)
         x = self.zero_point_stats_impl(x)
-        x = x.view(self.dynamic_scaling_broadcastable_shape)
+        x = self.dynamic_scaling_broadcastable_fn(x, shape)
         x = abs_binary_sign_grad(x)
         x = self.scale_shift_zero_point(x, scale, bit_width)
         return x
@@ -149,7 +149,8 @@ class RuntimeDynamicGroupStatsScaling(brevitas.jit.ScriptModule):
         tensor_shape = stats_input.shape
         tensor_shape_list = list(tensor_shape)
         tensor_shape_list[self.group_dim] = int(tensor_shape_list[self.group_dim] / self.group_size)
-        tensor_shape_list.insert(self.group_dim + 1, self.group_size)
+        block_dim = self.group_dim + 1 if self.group_dim != -1 else -1
+        tensor_shape_list.insert(block_dim, self.group_size)
         stats_input = stats_input.view(tensor_shape_list)
         return stats_input
 

--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -7,7 +7,6 @@ import re
 from torch import nn
 
 from brevitas import nn as qnn
-from brevitas.core.function_wrapper.shape import OverTensorView
 from brevitas.core.zero_point import ParameterFromStatsFromParameterZeroPoint
 from brevitas.graph.quantize import layerwise_quantize
 from brevitas.quant.experimental.float import Fp8e4m3Act
@@ -43,6 +42,7 @@ from brevitas_examples.common.generative.quantizers import Int8DynamicActPerTens
 from brevitas_examples.common.generative.quantizers import IntWeightSymmetricGroupQuant
 from brevitas_examples.common.generative.quantizers import ShiftedUint8ActPerRowFloat
 from brevitas_examples.common.generative.quantizers import ShiftedUint8ActPerRowFloatMSE
+from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerRowFloat
 from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerTensorFloat
 from brevitas_examples.common.generative.quantizers import ShiftedUintWeightAsymmetricGroupQuant
 
@@ -113,7 +113,8 @@ INPUT_QUANT_MAP = {
                         'sym': Int8DynamicActPerTensorFloat,
                         'asym': ShiftedUint8DynamicActPerTensorFloat},
                     'per_row': {
-                        'sym': Int8DynamicActPerRowFloat},
+                        'sym': Int8DynamicActPerRowFloat,
+                        'asym': ShiftedUint8DynamicActPerRowFloat},
                     'per_group': {
                         'sym': Int8DynamicActPerGroupFloat},}}}},
     'float': {
@@ -147,8 +148,7 @@ def quantize_model(
         input_quant_granularity=None,
         input_group_size=None,
         quantize_input_zero_point=False,
-        quantize_embedding=False,
-        seqlen=None):
+        quantize_embedding=False):
     """
     Replace float layers with quant layers in the target model
     """
@@ -173,7 +173,7 @@ def quantize_model(
     weight_quant = WEIGHT_QUANT_MAP[weight_quant_format][weight_scale_precision][
         weight_param_method][weight_quant_granularity][weight_quant_type]
     if input_bit_width is not None and input_scale_type == 'no_scale':
-        input_quant = sym_input_quant = linear_2d_input_quant = INPUT_QUANT_MAP[input_quant_format][
+        input_quant = sym_input_quant = linear_input_quant = INPUT_QUANT_MAP[input_quant_format][
             input_scale_type][input_quant_type]
     elif input_bit_width is not None:
         input_quant = INPUT_QUANT_MAP[input_quant_format][input_scale_type][input_scale_precision][
@@ -181,17 +181,13 @@ def quantize_model(
         # Some activations in MHA should always be symmetric
         sym_input_quant = INPUT_QUANT_MAP[input_quant_format][input_scale_type][
             input_scale_precision][input_param_method][input_quant_granularity]['sym']
-        # Linear layers with 2d input should always be per tensor or per group, as there is no row dimension
-        if input_quant_granularity == 'per_tensor' or input_quant_granularity == 'per_row':
-            linear_2d_input_quant = INPUT_QUANT_MAP[input_quant_format][input_scale_type][
-                input_scale_precision][input_param_method]['per_tensor'][input_quant_type]
-        else:
-            assert input_quant_granularity == 'per_group'
-            linear_2d_input_quant = input_quant
+        linear_input_quant = INPUT_QUANT_MAP[input_quant_format][input_scale_type][
+            input_scale_precision][input_param_method][input_quant_granularity][input_quant_type]
+
     else:
         input_quant = None
         sym_input_quant = None
-        linear_2d_input_quant = None
+        linear_input_quant = None
 
     # Modify the weight quantizer based on the arguments passed in
     weight_quant = weight_quant.let(
@@ -218,19 +214,13 @@ def quantize_model(
                 'quantize_zero_point': quantize_input_zero_point,
                 'dtype': dtype,},
             **input_float_format)
-        if input_scale_type == 'static' and input_quant_granularity == 'per_row':
-            # QuantMHA internally always uses Seq, B, E
-            input_quant = input_quant.let(
-                **{
-                    'per_channel_broadcastable_shape': (seqlen, 1, 1),
-                    'scaling_stats_permute_dims': (0, 1, 2)})
-        elif input_scale_type == 'dynamic':
+        if input_scale_type == 'dynamic':
             if input_quant_granularity == 'per_row':
                 input_quant = input_quant.let(
                     **{
-                        'dynamic_scaling_broadcastable_shape': (seqlen, -1, 1),
-                        'permute_dims': (1, 0, 2),
-                        'stats_reduce_dim': 2})
+                        'dynamic_scaling_broadcastable_fn': lambda x,
+                                                            shape: x.view(*shape[:-1], 1),
+                        'stats_reduce_dim': 1})
             elif input_quant_granularity == 'per_group':
                 input_quant = input_quant.let(**{'group_dim': 2, 'group_size': input_group_size})
     if sym_input_quant is not None:
@@ -240,32 +230,25 @@ def quantize_model(
                 'quantize_zero_point': quantize_input_zero_point,
                 'dtype': dtype},
             **input_float_format)
-        if input_scale_type == 'static' and input_quant_granularity == 'per_row':
-            q_scaled_quant = sym_input_quant.let(
-                **{
-                    'per_channel_broadcastable_shape': (1, seqlen, 1),
-                    'scaling_stats_permute_dims': (1, 0, 2)})
-            k_transposed_quant = sym_input_quant.let(
-                **{
-                    'per_channel_broadcastable_shape': (1, 1, seqlen),
-                    'scaling_stats_permute_dims': (2, 0, 1)})
-            v_quant = q_scaled_quant
-            attn_output_weights_quant = q_scaled_quant
-        elif input_scale_type == 'dynamic':
+        if input_scale_type == 'dynamic':
             if input_quant_granularity == 'per_tensor':
                 q_scaled_quant = sym_input_quant
                 k_transposed_quant = sym_input_quant
             elif input_quant_granularity == 'per_row':
                 q_scaled_quant = sym_input_quant.let(
                     **{
-                        'dynamic_scaling_broadcastable_shape': (-1, seqlen, 1),
-                        'permute_dims': None,
-                        'stats_reduce_dim': 2})
-                k_transposed_quant = sym_input_quant.let(
-                    **{
-                        'dynamic_scaling_broadcastable_shape': (-1, 1, seqlen),
+                        'dynamic_scaling_broadcastable_fn': lambda x,
+                                                            shape: x.view(*shape[:-1], 1),
                         'permute_dims': None,
                         'stats_reduce_dim': 1})
+                k_transposed_quant = sym_input_quant.let(
+                    **{
+                        'dynamic_scaling_broadcastable_fn':
+                            lambda x,
+                            shape: x.view(shape[0], 1, shape[-1]),
+                        'permute_dims': (0, 2, 1),
+                        'stats_reduce_dim':
+                            1})
             elif input_quant_granularity == 'per_group':
                 q_scaled_quant = sym_input_quant.let(
                     **{
@@ -279,21 +262,28 @@ def quantize_model(
             q_scaled_quant = v_quant = k_transposed_quant = attn_output_weights_quant = sym_input_quant
     else:
         q_scaled_quant = v_quant = k_transposed_quant = attn_output_weights_quant = None
-    if linear_2d_input_quant is not None:
-        linear_2d_input_quant = linear_2d_input_quant.let(
+    if linear_input_quant is not None:
+        linear_input_quant = linear_input_quant.let(
             **{
                 'bit_width': input_bit_width,
                 'quantize_zero_point': quantize_input_zero_point,
                 'dtype': dtype},
             **input_float_format)
         if input_scale_type == 'dynamic':
-            if input_quant_granularity == 'per_group':
-                linear_2d_input_quant = linear_2d_input_quant.let(
+            if input_quant_granularity == 'per_row':
+                linear_input_quant = linear_input_quant.let(
                     **{
-                        'group_dim': 1, 'group_size': input_group_size})
+                        'dynamic_scaling_broadcastable_fn': lambda x,
+                                                            shape: x.view(*shape[:-1], 1),
+                        'permute_dims': None,
+                        'stats_reduce_dim': 1})
+            elif input_quant_granularity == 'per_group':
+                linear_input_quant = linear_input_quant.let(
+                    **{
+                        'group_dim': -1, 'group_size': input_group_size})
 
     quant_linear_kwargs = {
-        'input_quant': linear_2d_input_quant, 'weight_quant': weight_quant, 'dtype': dtype}
+        'input_quant': linear_input_quant, 'weight_quant': weight_quant, 'dtype': dtype}
     quant_conv_kwargs = {'input_quant': input_quant, 'weight_quant': weight_quant, 'dtype': dtype}
 
     quant_mha_kwargs = {

--- a/src/brevitas_examples/optimum/config.py
+++ b/src/brevitas_examples/optimum/config.py
@@ -4,7 +4,6 @@ from typing import Literal, Optional
 
 @dataclass
 class BrevitasQuantizationConfig:
-    quantization_format: Literal['eager_mode', 'graph_mode'] = 'eager_mode'
     replace_mha_with_quantizable: bool = False
     seqlen: int = 2048
     nsamples: int = 128

--- a/src/brevitas_examples/optimum/example.py
+++ b/src/brevitas_examples/optimum/example.py
@@ -129,4 +129,4 @@ print("Model export...")
 remove_hooks(model)
 
 ## Export still WIP
-quantizer.export(model, 'model_export')
+# quantizer.export(model, 'model_export')

--- a/src/brevitas_examples/optimum/example.py
+++ b/src/brevitas_examples/optimum/example.py
@@ -129,4 +129,4 @@ print("Model export...")
 remove_hooks(model)
 
 ## Export still WIP
-# quantizer.export(model, 'model_export')
+quantizer.export(model, 'model_export')

--- a/src/brevitas_examples/optimum/quantizer.py
+++ b/src/brevitas_examples/optimum/quantizer.py
@@ -54,11 +54,6 @@ class BrevitasQuantizer(OptimumQuantizer):
         dtype = next(iter(self.model.parameters()))
         if dtype == torch.bfloat16 and self.qconfig.replace_mha_with_quantizable:
             raise RuntimeError("Scaled_dot_product does not support bfloat16 and cuda")
-        if self.qconfig.input_quant_granularity == 'per_row' and not self.qconfig.replace_mha_with_quantizable:
-            raise RuntimeError(
-                "Per-row act quant requires setting replace_mha_with_quantizable to True")
-        if self.qconfig.quantization_format == 'graph_mode':
-            raise RuntimeError("FX quantization not yet compatible with accelerate")
 
     def find_groups_of_parallel_layers(self, names_of_groups_of_parallel_layers):
         names = [name for name, _ in self.model.named_modules()]
@@ -125,8 +120,7 @@ class BrevitasQuantizer(OptimumQuantizer):
             input_scale_type=self.qconfig.input_scale_type,
             input_quant_granularity=self.qconfig.input_quant_granularity,
             input_group_size=self.qconfig.input_group_size,
-            quantize_input_zero_point=self.qconfig.quantize_zero_point,
-            seqlen=self.qconfig.seqlen)
+            quantize_input_zero_point=self.qconfig.quantize_zero_point)
 
         # Perform a single inference pass to generate the correct state_dict
         with torch.no_grad():


### PR DESCRIPTION
Unfortunately the JIT is not compatible with this implementation.

We need a way to deal with variable shaped inputs (e.g., 2D and 3D), so we can't have static shapes.
With the previous implementation, we did not have support for per-row quantization without replacing MHA with our own quantizable version.

I am happy to revisit this at a later moment.

cc @nickfraser 