### PR TITLE
Fix (examples/llm): set `group_size` only for groupwise quantization

### DIFF
--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -187,9 +187,12 @@ def quantize_model(
         **{
             'bit_width': weight_bit_width,
             'narrow_range': False,
-            'group_size': weight_group_size,
             'quantize_zero_point': quantize_weight_zero_point},
         **weight_float_format)
+
+    # Set the group_size is we're doing groupwise quantization
+    if weight_quant_granularity == 'per_group':
+        weight_quant = weight_quant.let(**{'group_size': weight_group_size})
     # weight scale is converted to a standalone parameter
     # This is done already by default in the per_group quantizer
     if weight_quant_granularity != 'per_group':


### PR DESCRIPTION
Avoid bug that can occur in checking for groupwise quantization when entering the ONNX export context manager.