### PR TITLE
Enhance: Importing quantized models after bias correction

### DIFF
--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -113,9 +113,9 @@ class allow_unexpected_bias_keys:
 
 class bias_correction_mode:
 
-    def __init__(self, model, enabled=True):
+    def __init__(self, model, enabled=True, only_layers_with_bias=False):
         self.model = model
-        self.bias_correction = _BiasCorrection()
+        self.bias_correction = _BiasCorrection(only_layers_with_bias=only_layers_with_bias)
         self.enabled = enabled
         self.hooks = []
 
@@ -235,7 +235,7 @@ class _BiasCorrection(DisableEnableQuantization):
 
     LAYERS = (QuantWBIOL,)
 
-    def __init__(self, layers=LAYERS):
+    def __init__(self, layers=LAYERS, only_layers_with_bias=False):
         super(_BiasCorrection, self).__init__()
         self.layers = layers
         self.iterations = {}
@@ -243,6 +243,7 @@ class _BiasCorrection(DisableEnableQuantization):
         self.float_mean_map = {}
         self.collect_float_mean_hooks = []
         self.correct_bias_hooks = []
+        self.only_layers_with_bias = only_layers_with_bias
 
     def compute_mean(self, inp, transpose_dim):
         inp = inp.transpose(0, transpose_dim)
@@ -274,7 +275,7 @@ class _BiasCorrection(DisableEnableQuantization):
                 correction = self.correction_map[name] / self.iterations[name]
                 if module.bias is not None:
                     module.bias.data += correction
-                else:
+                elif self.only_layers_with_bias is False:
                     module.register_parameter(
                         'bias', nn.Parameter(correction).to(module.weight.device))
 

--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -24,7 +24,11 @@ from brevitas.quant_tensor import QuantTensor
 from .base import Transform
 
 __all__ = [
-    'ClipFloatWeights', 'DisableEnableQuantization', 'bias_correction_mode', 'calibration_mode']
+    'ClipFloatWeights',
+    'DisableEnableQuantization',
+    'bias_correction_mode',
+    'calibration_mode',
+    'allow_unexpected_bias_keys']
 
 _PARAM_PROXIES = (WeightQuantProxyFromInjector, BiasQuantProxyFromInjector)
 

--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -93,9 +93,9 @@ class load_quant_model:
 
     def __init__(self, model):
         self.model = model
+        self.tracked_modules = []
 
     def __enter__(self):
-        self.tracked_modules = []
         for module in self.model.modules():
             if issubclass(type(module), QuantWBIOL):
                 if module.bias is None:

--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -28,7 +28,7 @@ __all__ = [
     'DisableEnableQuantization',
     'bias_correction_mode',
     'calibration_mode',
-    'allow_unexpected_bias_keys']
+    'load_quant_model']
 
 _PARAM_PROXIES = (WeightQuantProxyFromInjector, BiasQuantProxyFromInjector)
 
@@ -89,7 +89,7 @@ class calibration_mode:
             self.model, is_training=self.previous_training_state, quantization_enabled=True)
 
 
-class allow_unexpected_bias_keys:
+class load_quant_model:
 
     def __init__(self, model):
         self.model = model

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -8,9 +8,9 @@ from pytest_cases import fixture
 import torch
 import torch.nn as nn
 
-from brevitas.graph.calibrate import allow_unexpected_bias_keys
 from brevitas.graph.calibrate import bias_correction_mode
 from brevitas.graph.calibrate import calibration_mode
+from brevitas.graph.calibrate import load_quant_model
 import brevitas.nn as qnn
 from brevitas.quant import Int8ActPerTensorFixedPoint
 from tests.brevitas.hyp_helper import float_tensor_random_size_st
@@ -211,7 +211,7 @@ def test_import_bias_correction():
             assert m.bias is not None
 
     new_model = SimpleQuantLinearNet()
-    with allow_unexpected_bias_keys(new_model):
+    with load_quant_model(new_model):
         new_model.load_state_dict(model.state_dict())
 
     for m in new_model.modules():

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -8,6 +8,7 @@ from pytest_cases import fixture
 import torch
 import torch.nn as nn
 
+from brevitas.graph.calibrate import allow_unexpected_bias_keys
 from brevitas.graph.calibrate import bias_correction_mode
 from brevitas.graph.calibrate import calibration_mode
 import brevitas.nn as qnn
@@ -210,7 +211,8 @@ def test_import_bias_correction():
             assert m.bias is not None
 
     new_model = SimpleQuantLinearNet()
-    new_model.load_state_dict(model.state_dict())
+    with allow_unexpected_bias_keys(new_model):
+        new_model.load_state_dict(model.state_dict())
 
     for m in new_model.modules():
         if isinstance(m, qnn.QuantLinear):

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -232,7 +232,7 @@ def test_bias_correction_flag():
 
     model = SimpleQuantLinearNet()
 
-    with bias_correction_mode(model, only_layers_with_bias=True):
+    with bias_correction_mode(model, skip_if_no_bias=True):
         model(torch.randn((1, IN_CH)))
 
     for m in model.modules():

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -217,3 +217,24 @@ def test_import_bias_correction():
     for m in new_model.modules():
         if isinstance(m, qnn.QuantLinear):
             assert m.bias is not None
+
+
+def test_bias_correction_flag():
+
+    class SimpleQuantLinearNet(nn.Module):
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.net = nn.Sequential(qnn.QuantLinear(IN_CH, OUT_CH, bias=False))
+
+        def forward(self, inp):
+            return self.net(inp)
+
+    model = SimpleQuantLinearNet()
+
+    with bias_correction_mode(model, only_layers_with_bias=True):
+        model(torch.randn((1, IN_CH)))
+
+    for m in model.modules():
+        if isinstance(m, qnn.QuantLinear):
+            assert m.bias is None


### PR DESCRIPTION
## Issue
Implements https://github.com/Xilinx/brevitas/issues/827

## Details

- Adds new context manager **_load_quant_model_** that silently adds (and removes if unused) biases to help load any state dictionary that may have had biases unexpectedly added via use of the **_bias_correction_mode_** context manager prior to saving
- Adds flag to **_bias_correction_mode_** and **__BiasCorrection_** to disable the adding of corrections to layers that don't have a bias, default behaviour is the same as before so without modifying the flag, correction will still be applied
- Adds two tests for the above changes