### PR TITLE
Fix QCDQDecoupledWeightQuantProxyHandlerMixin return args

### DIFF
--- a/src/brevitas/export/common/handler/qcdq.py
+++ b/src/brevitas/export/common/handler/qcdq.py
@@ -236,7 +236,8 @@ class QCDQCastDecoupledWeightQuantProxyHandlerMixin(QCDQCastWeightQuantProxyHand
     def symbolic_execution(self, x: Tensor):
         out, scale, zero_point, bit_width = super().symbolic_execution(x)
         # Return post-rounding scale and zero-point in place of pre-rounding as a placeholder
-        return out, scale, zero_point, scale, zero_point, bit_width
+        # The order of arguments must match the order in the forward method of DecoupledRescalingIntQuant
+        return out, scale, zero_point, bit_width, scale, zero_point
 
 
 class QCDQCastDecoupledWeightQuantWithInputProxyHandlerMixin(


### PR DESCRIPTION
## Issue
https://github.com/Xilinx/brevitas/issues/747

## What
bit_width return argument must match the order in DecoupledRescalingIntQuant https://github.com/Xilinx/brevitas/blob/513ab4dac112d16abfd17e7c8952e4c46ff14368/src/brevitas/core/quant/int.py#L191