### PR TITLE
Fix (GPFQ): use max/mean to avoid running out of memory

### DIFF
--- a/src/brevitas/graph/gpfq.py
+++ b/src/brevitas/graph/gpfq.py
@@ -220,12 +220,18 @@ class GPFQ(GPxQ):
             if self.float_input is None:
                 self.float_input = inp_processed
             else:
-                self.float_input = torch.cat([self.float_input, inp_processed], dim=1)
+                self.float_input = torch.max(self.float_input, inp_processed)
+                # self.float_input = torch.stack([self.float_input, inp_processed])
+                # self.float_input = self.float_input.mean(dim=0)
+                # self.float_input = torch.cat([self.float_input, inp_processed], dim=1)
         else:
             if self.quantized_input is None:
                 self.quantized_input = inp_processed
             else:
-                self.quantized_input = torch.cat([self.quantized_input, inp_processed], dim=1)
+                self.quantized_input = torch.max(self.quantized_input, inp_processed)
+                # self.quantized_input = torch.stack([self.quantized_input, inp_processed])
+                # self.quantized_input = self.quantized_input.mean(dim=0)
+                # self.quantized_input = torch.cat([self.quantized_input, inp_processed], dim=1)
         # If we are executing GPFQ with group of parallel layers, we keep track of how many forward
         # we executed. Once we executed as many as the number of parallel_layers, we raise
         # StopFwdException


### PR DESCRIPTION
For the GPFQ algorithm, larger models lead to an OutOfMemory error. This is because the GPFQ algorithm uses all calibration data provided. Instead of iteratively concatenating the new input to all previous ones, we could use a running average, or always select the max of the new input and the previous ones.