### PR TITLE
Fix (ptq): expose uint_sym_act flag and fix issue with minifloat sign

### DIFF
--- a/src/brevitas_examples/imagenet_classification/ptq/README.md
+++ b/src/brevitas_examples/imagenet_classification/ptq/README.md
@@ -110,6 +110,7 @@ usage: ptq_evaluate.py [-h] --calibration-dir CALIBRATION_DIR --validation-dir
                        [--calibrate-bn | --no-calibrate-bn]
                        [--channel-splitting-split-input | --no-channel-splitting-split-input]
                        [--merge-bn | --no-merge-bn]
+                       [--uint_sym_act_for_unsigned_values | --no-uint_sym_act_for_unsigned_values]
 
 PyTorch ImageNet PTQ Validation
 
@@ -269,6 +270,12 @@ options:
                         (default: enabled)
   --no-merge-bn         Disable Merge BN layers before quantizing the model
                         (default: enabled)
+  --uint_sym_act_for_unsigned_values
+                        Enable Use unsigned act quant when possible (default:
+                        enabled)
+  --no-uint_sym_act_for_unsigned_values
+                        Disable Use unsigned act quant when possible (default:
+                        enabled)
 
 ```
 

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
@@ -377,7 +377,7 @@ def create_quant_maps(
     quant_act_kwargs = {'act_quant': act_quant, 'return_quant_tensor': True}
     # For potentially unsigned activations, we create a separate dict
     unsigned_quant_act_kwargs = quant_act_kwargs.copy()
-    if uint_sym_act_for_unsigned_values:
+    if uint_sym_act_for_unsigned_values and act_quant_format != 'float':
         # In case we support unsigned activation, the output of softmax can be unsigned
         quant_mha_kwargs['attn_output_weights_signed'] = False
         unsigned_quant_act_kwargs['signed'] = False

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -251,6 +251,11 @@ add_bool_arg(
     'merge-bn',
     default=True,
     help='Merge BN layers before quantizing the model (default: enabled)')
+add_bool_arg(
+    parser,
+    'uint_sym_act_for_unsigned_values',
+    default=True,
+    help='Use unsigned act quant when possible (default: enabled)')
 
 
 def main():
@@ -405,7 +410,8 @@ def main():
         weight_mantissa_bit_width=args.weight_mantissa_bit_width,
         weight_exponent_bit_width=args.weight_exponent_bit_width,
         act_mantissa_bit_width=args.act_mantissa_bit_width,
-        act_exponent_bit_width=args.act_exponent_bit_width)
+        act_exponent_bit_width=args.act_exponent_bit_width,
+        uint_sym_act_for_unsigned_values=args.uint_sym_act_for_unsigned_values)
 
     # Calibrate the quant_model on the calibration dataloader
     print("Starting activation calibration:")


### PR DESCRIPTION
So far, the `ptq_evaluate` in the imagenet ptq example didn't expose the `uint_sym_act_for_unsigned_values` flag, which makes act quantizers unsigned in order to use full bit width. However, this doesn't work with minifloat configurations, so a check is introduced for the `act_quant_format` and the `uint_sym_act_for_unsigned_values` flag is further exposed to the user running the `ptq_evaluate.py` file. 