### PR TITLE
Remove: Remove original_cat workaround

### DIFF
--- a/src/brevitas/quant_tensor/torch_handler.py
+++ b/src/brevitas/quant_tensor/torch_handler.py
@@ -44,7 +44,7 @@ def transpose_handler(inp, *args, **kwargs):
     return inp.transpose(*args, **kwargs)
 
 
-@implements(brevitas.original_cat)
+@implements(torch.cat)
 def cat_handler(*args, **kwargs):
     from brevitas.quant_tensor import QuantTensor
     return QuantTensor.cat(*args, **kwargs)


### PR DESCRIPTION
## Reason for this PR

<!--
The "why" -
Provide a short summary to answer "Why are these changes needed?".
Include links to relevant Issues, and links to any background information or discussion.
Help reviewers, and people in the future, understand the context behind this work.
-->

https://github.com/Xilinx/brevitas/issues/726

original_cat was added as a workaround for an issue in a now unsupported version of PyTorch.

## Changes Made in this PR

<!--
The "what" -
Provide a short summary of specific changes made in this pull request.
The "how" -
Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.
Detail any notable implementation details.
-->

Removed original_cat and its references.

Effectively reversed the changes made in these two commits:
https://github.com/Xilinx/brevitas/commit/e80dadf640cc4aa8d939d00188a56abce37b1894
https://github.com/Xilinx/brevitas/commit/de5702668b755d249820427ba105793b7125010a

Revert wasn't used due to merge conflicts and the code was simple to manually excise.


## Testing Summary

<!--
Briefly explain how you tested and verified your work.
e.g.
- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

Relying on automated testing, no local testing was done as the code should only become active if the torch version is below 1.7

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [x] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

Will reintroduce the issue the workaround fixed if old version of PyTorch used although I would imagine other things would be broken in that scenario.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.

## Future Work
