### PR TITLE
Export minifloat

### DIFF
--- a/src/brevitas/export/common/handler/base.py
+++ b/src/brevitas/export/common/handler/base.py
@@ -115,18 +115,19 @@ class ScaleHandlerMixin(ABC):
 class ZeroPointHandlerMixin(ABC):
 
     @classmethod
-    def zero_point_with_dtype(cls, signed, bit_width, zero_point):
+    def zero_point_with_dtype(cls, signed, dtype, zero_point):
         if not signed:
             if (zero_point < 0).any():
                 raise RuntimeError("Zero points have to be positive under unsigned quantization")
-            if bit_width > 8:
-                raise RuntimeError("Unsigned zero-point with bit-width > 8 not supported.")
-            return zero_point.type(torch.uint8)
-        else:
-            if bit_width <= 8:
-                return zero_point.type(torch.int8)
-            else:
-                return zero_point.type(torch.int32)
+        return zero_point.type(dtype)
+        #     if bit_width > 8:
+        #         raise RuntimeError("Unsigned zero-point with bit-width > 8 not supported.")
+        #     return zero_point.type(torch.uint8)
+        # else:
+        #     if bit_width <= 8:
+        #         return zero_point.type(torch.int8)
+        #     else:
+        #         return zero_point.type(torch.int32)
 
     @classmethod
     def quant_input_zero_point(cls, module):

--- a/src/brevitas/export/common/handler/base.py
+++ b/src/brevitas/export/common/handler/base.py
@@ -76,6 +76,37 @@ class QuantDtypeMixin(ABC):
         pass
 
 
+class QuantFloatDtypeMixin(ABC):
+
+    @classmethod
+    def e4m3_dtype(cls):
+        return torch.float8_e4m3fn
+
+    @classmethod
+    def e5m2_dtype(cls):
+        return torch.float8_e5m2
+
+    @classmethod
+    def float32_dtype(cls):
+        return torch.float32
+
+    @classmethod
+    def signed_dtype(cls, mantissa_bit_width, exponent_bit_width):
+        if mantissa_bit_width is None or exponent_bit_width is None:
+            return None
+        if exponent_bit_width == 5 and mantissa_bit_width == 2:
+            dtype = cls.e5m2_dtype()
+        elif exponent_bit_width == 4 and mantissa_bit_width == 3:
+            dtype = cls.e4m3_dtype()
+        else:
+            dtype = cls.float32_dtype()
+        return dtype
+
+    @classmethod
+    def signed_quant_dtype(cls, bit_width, is_signed):
+        return cls.signed_dtype(bit_width, is_signed)
+
+
 class ClipMixin(ABC):
 
     @classmethod

--- a/src/brevitas/export/common/handler/base.py
+++ b/src/brevitas/export/common/handler/base.py
@@ -70,6 +70,11 @@ class QuantDtypeMixin(ABC):
                 "Unsigned quantization > 8b not supported for export, switch to signed.")
         return dtype
 
+    @classmethod
+    @abstractmethod
+    def signed_quant_dtype(cls, bit_width, is_signed):
+        pass
+
 
 class ClipMixin(ABC):
 

--- a/src/brevitas/export/common/handler/base.py
+++ b/src/brevitas/export/common/handler/base.py
@@ -38,6 +38,39 @@ class QuantAxisMixin(ABC):
         return None
 
 
+class QuantDtypeMixin(ABC):
+
+    @classmethod
+    @abstractmethod
+    def uint8_dtype(cls):
+        pass
+
+    @classmethod
+    @abstractmethod
+    def int8_dtype(cls):
+        pass
+
+    @classmethod
+    @abstractmethod
+    def int32_dtype(cls):
+        pass
+
+    @classmethod
+    def signed_dtype(cls, bit_width, is_signed):
+        if bit_width is None:
+            return None
+        if is_signed and bit_width <= 8:
+            dtype = cls.int8_dtype()
+        elif not is_signed and bit_width <= 8:
+            dtype = cls.uint8_dtype()
+        elif is_signed and bit_width > 8:
+            dtype = cls.int32_dtype()
+        else:
+            raise RuntimeError(
+                "Unsigned quantization > 8b not supported for export, switch to signed.")
+        return dtype
+
+
 class ClipMixin(ABC):
 
     @classmethod
@@ -130,22 +163,22 @@ class ZeroPointHandlerMixin(ABC):
         #         return zero_point.type(torch.int32)
 
     @classmethod
-    def quant_input_zero_point(cls, module):
+    def quant_input_zero_point(cls, module, dtype):
         signed = module.is_quant_input_signed
         zero_point = module.quant_input_zero_point()
         bit_width = module.quant_input_bit_width()
-        return cls.zero_point_with_dtype(signed, bit_width, zero_point)
+        return cls.zero_point_with_dtype(signed, dtype, zero_point)
 
     @classmethod
-    def quant_weight_zero_point(cls, module):
+    def quant_weight_zero_point(cls, module, dtype):
         signed = module.is_quant_weight_signed
         zero_point = module.quant_weight_zero_point()
         bit_width = module.quant_weight_bit_width()
-        return cls.zero_point_with_dtype(signed, bit_width, zero_point)
+        return cls.zero_point_with_dtype(signed, dtype, zero_point)
 
     @classmethod
-    def quant_output_zero_point(cls, module):
+    def quant_output_zero_point(cls, module, dtype):
         signed = module.is_quant_output_signed
         zero_point = module.quant_output_zero_point()
         bit_width = module.quant_output_bit_width()
-        return cls.zero_point_with_dtype(signed, bit_width, zero_point)
+        return cls.zero_point_with_dtype(signed, dtype, zero_point)

--- a/src/brevitas/export/common/handler/qcdq.py
+++ b/src/brevitas/export/common/handler/qcdq.py
@@ -263,7 +263,7 @@ class QCDQCastWeightIntQuantProxyHandlerMixin(QCDQCastWeightQuantProxyHandlerMix
 
     def prepare_for_export(self, module):
         if module.is_quant_enabled:
-            super(QCDQCastWeightQuantProxyHandlerMixin).prepare_for_export(module)
+            QCDQCastWeightQuantProxyHandlerMixin.prepare_for_export(self, module)
             # Get the first quant weight as representative
             quant_weight = module.tracked_module_list[0].quant_weight()
 
@@ -326,12 +326,8 @@ class QCDQCastWeightFloatQuantProxyHandlerMixin(QCDQCastWeightQuantProxyHandlerM
 
     def prepare_for_export(self, module):
         if module.is_quant_enabled:
-            self.validate(module)
-            if self._export_q_node:
-                self.prepare_quantize_from_floating_point(module)
-            else:
-                self.prepare_quantize_from_quantized(module)
-            # Get the first quant weight as representative
+            QCDQCastWeightQuantProxyHandlerMixin.prepare_for_export(self, module)
+
             quant_weight = module.tracked_module_list[0].quant_weight()
             mantissa_bit_width = module.mantissa_bit_width()
             exponent_bit_width = module.exponent_bit_width()

--- a/src/brevitas/export/onnx/standard/qcdq/handler.py
+++ b/src/brevitas/export/onnx/standard/qcdq/handler.py
@@ -5,8 +5,6 @@ from abc import ABC
 
 import torch
 
-from brevitas.export.common.handler.base import ABCQuantDtypeMixin
-from brevitas.export.common.handler.base import QuantDtypeMixin
 from brevitas.export.common.handler.qcdq import CDQCastBiasQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import CDQCastMixin
 from brevitas.export.common.handler.qcdq import DQCastMixin

--- a/src/brevitas/export/onnx/standard/qcdq/handler.py
+++ b/src/brevitas/export/onnx/standard/qcdq/handler.py
@@ -5,6 +5,7 @@ from abc import ABC
 
 import torch
 
+from brevitas.export.common.handler.base import QuantDtypeMixin
 from brevitas.export.common.handler.qcdq import CDQCastBiasQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import CDQCastMixin
 from brevitas.export.common.handler.qcdq import DQCastMixin
@@ -54,7 +55,23 @@ class StdCDQCastONNXMixin(CDQCastMixin, StdDQCastONNXMixin, ABC):
         return IntClipFn.apply(x, min_val, max_val)
 
 
-class StdQCDQCastONNXMixin(QMixin, StdCDQCastONNXMixin, ABC):
+class StdQCDQCastONNXMixin(QMixin, StdCDQCastONNXMixin, QuantDtypeMixin, ABC):
+
+    @classmethod
+    def int8_dtype(cls):
+        return torch.int8
+
+    @classmethod
+    def uint8_dtype(cls):
+        return torch.uint8
+
+    @classmethod
+    def int32_dtype(cls):
+        return torch.int32
+
+    @classmethod
+    def signed_quant_dtype(cls, bit_width, is_signed):
+        return cls.signed_dtype(bit_width, is_signed)
 
     def validate(self, module):
         super().validate(module)

--- a/src/brevitas/export/onnx/standard/qcdq/handler.py
+++ b/src/brevitas/export/onnx/standard/qcdq/handler.py
@@ -5,6 +5,7 @@ from abc import ABC
 
 import torch
 
+from brevitas.export.common.handler.base import QuantDtypeMixin
 from brevitas.export.common.handler.qcdq import CDQCastBiasQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import CDQCastMixin
 from brevitas.export.common.handler.qcdq import DQCastMixin
@@ -28,7 +29,19 @@ from ..function import IntClipFn
 from ..function import QuantizeLinearFn
 
 
-class StdDQCastONNXMixin(DQCastMixin, ABC):
+class StdDQCastONNXMixin(DQCastMixin, QuantDtypeMixin, ABC):
+
+    @classmethod
+    def int8_dtype(cls):
+        return torch.int8
+
+    @classmethod
+    def uint8_dtype(cls):
+        return torch.uint8
+
+    @classmethod
+    def int32_dtype(cls):
+        return torch.int32
 
     def dequantize_fn(self, x, scale, zero_point, axis):
         return DequantizeLinearFn.apply(x, scale, zero_point, axis)
@@ -55,18 +68,6 @@ class StdCDQCastONNXMixin(CDQCastMixin, StdDQCastONNXMixin, ABC):
 
 
 class StdQCDQCastONNXMixin(QMixin, StdCDQCastONNXMixin, ABC):
-
-    @classmethod
-    def int8_dtype(cls):
-        return torch.int8
-
-    @classmethod
-    def uint8_dtype(cls):
-        return torch.uint8
-
-    @classmethod
-    def int32_dtype(cls):
-        return torch.int32
 
     def validate(self, module):
         super().validate(module)

--- a/src/brevitas/export/onnx/standard/qcdq/handler.py
+++ b/src/brevitas/export/onnx/standard/qcdq/handler.py
@@ -43,6 +43,10 @@ class StdDQCastONNXMixin(DQCastMixin, QuantDtypeMixin, ABC):
     def int32_dtype(cls):
         return torch.int32
 
+    @classmethod
+    def signed_quant_dtype(cls, bit_width, is_signed):
+        return cls.signed_dtype(bit_width, is_signed)
+
     def dequantize_fn(self, x, scale, zero_point, axis):
         return DequantizeLinearFn.apply(x, scale, zero_point, axis)
 

--- a/src/brevitas/export/onnx/standard/qcdq/handler.py
+++ b/src/brevitas/export/onnx/standard/qcdq/handler.py
@@ -5,6 +5,7 @@ from abc import ABC
 
 import torch
 
+from brevitas.export.common.handler.base import ABCQuantDtypeMixin
 from brevitas.export.common.handler.base import QuantDtypeMixin
 from brevitas.export.common.handler.qcdq import CDQCastBiasQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import CDQCastMixin
@@ -17,7 +18,7 @@ from brevitas.export.common.handler.qcdq import \
     QCDQCastDecoupledWeightQuantWithInputProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import QCDQCastTruncQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import QCDQCastWeightFloatQuantProxyHandlerMixin
-from brevitas.export.common.handler.qcdq import QCDQCastWeightQuantProxyHandlerMixin
+from brevitas.export.common.handler.qcdq import QCDQCastWeightIntQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import QMixin
 from brevitas.export.onnx.handler import ONNXBaseHandler
 from brevitas.export.onnx.handler import QuantLSTMLayerHandler
@@ -29,23 +30,7 @@ from ..function import IntClipFn
 from ..function import QuantizeLinearFn
 
 
-class StdDQCastONNXMixin(DQCastMixin, QuantDtypeMixin, ABC):
-
-    @classmethod
-    def int8_dtype(cls):
-        return torch.int8
-
-    @classmethod
-    def uint8_dtype(cls):
-        return torch.uint8
-
-    @classmethod
-    def int32_dtype(cls):
-        return torch.int32
-
-    @classmethod
-    def signed_quant_dtype(cls, bit_width, is_signed):
-        return cls.signed_dtype(bit_width, is_signed)
+class StdDQCastONNXMixin(DQCastMixin, ABC):
 
     def dequantize_fn(self, x, scale, zero_point, axis):
         return DequantizeLinearFn.apply(x, scale, zero_point, axis)
@@ -135,7 +120,7 @@ class StdDynamicQDQCastONNXMixin(DynamicQMixin, StdDQCastONNXMixin, ABC):
 
 
 class StdQCDQCastONNXWeightQuantProxyHandler(StdQCDQCastONNXMixin,
-                                             QCDQCastWeightQuantProxyHandlerMixin,
+                                             QCDQCastWeightIntQuantProxyHandlerMixin,
                                              ONNXBaseHandler):
     _export_q_node = False
 
@@ -143,7 +128,7 @@ class StdQCDQCastONNXWeightQuantProxyHandler(StdQCDQCastONNXMixin,
 class StdQCDQCastONNXWeightFloatQuantProxyHandler(StdFloatQCDQCastONNXMixin,
                                                   QCDQCastWeightFloatQuantProxyHandlerMixin,
                                                   ONNXBaseHandler):
-    _export_q_node = False
+    _export_q_node = True
 
 
 class StdQCDQCastONNXDecoupledWeightQuantProxyHandler(StdQCDQCastONNXMixin,

--- a/src/brevitas/export/onnx/standard/qcdq/manager.py
+++ b/src/brevitas/export/onnx/standard/qcdq/manager.py
@@ -22,6 +22,7 @@ from .handler import StdQCDQCastONNXDecoupledWeightQuantProxyHandler
 from .handler import StdQCDQCastONNXDecoupledWeightQuantWithInputProxyHandler
 from .handler import StdQCDQCastONNXQuantLSTMLayerHandler
 from .handler import StdQCDQCastONNXTruncQuantProxyHandler
+from .handler import StdQCDQCastONNXWeightFloatQuantProxyHandler
 from .handler import StdQCDQCastONNXWeightQuantProxyHandler
 
 
@@ -35,14 +36,16 @@ class StdQCDQONNXManager(StdONNXBaseManager):
         "eliminate_unused_initializer"]
 
     handlers = [
+        StdQCDQCastONNXWeightFloatQuantProxyHandler,
         StdQCDQCastONNXWeightQuantProxyHandler,
-        StdCDQCastONNXBiasQuantProxyHandler,
-        StdQCDQCastONNXActQuantProxyHandler,
-        StdQCDQCastONNXDecoupledWeightQuantProxyHandler,
-        StdDynamicQDQCastONNXActQuantProxyHandler,
-        StdQCDQCastONNXTruncQuantProxyHandler,
-        StdQCDQCastONNXDecoupledWeightQuantWithInputProxyHandler,
-        StdQCDQCastONNXQuantLSTMLayerHandler]
+        # StdCDQCastONNXBiasQuantProxyHandler,
+        # StdQCDQCastONNXActQuantProxyHandler,
+        # StdQCDQCastONNXDecoupledWeightQuantProxyHandler,
+        # StdDynamicQDQCastONNXActQuantProxyHandler,
+        # StdQCDQCastONNXTruncQuantProxyHandler,
+        # StdQCDQCastONNXDecoupledWeightQuantWithInputProxyHandler,
+        # StdQCDQCastONNXQuantLSTMLayerHandler
+    ]
 
     custom_fns = [
         DebugMarkerFunction,

--- a/src/brevitas/export/onnx/standard/qoperator/handler/base.py
+++ b/src/brevitas/export/onnx/standard/qoperator/handler/base.py
@@ -50,6 +50,10 @@ class StdQOpONNXQuantLayerHandler(ONNXBaseHandler,
         raise NotImplementedError  # This should not be needed for QOp
 
     @classmethod
+    def signed_quant_dtype(cls, bit_width, is_signed):
+        raise NotImplementedError  # This should not be needed for QOp
+
+    @classmethod
     def op_symbolic_kwargs(cls, module):
         raise NotImplementedError  # optional method
 

--- a/src/brevitas/export/onnx/standard/qoperator/handler/base.py
+++ b/src/brevitas/export/onnx/standard/qoperator/handler/base.py
@@ -38,6 +38,14 @@ class StdQOpONNXQuantLayerHandler(ONNXBaseHandler,
         pass
 
     @classmethod
+    def int8_dtype(cls):
+        return torch.int8
+
+    @classmethod
+    def uint8_dtype(cls):
+        return torch.uint8
+
+    @classmethod
     def int32_dtype(cls):
         raise NotImplementedError  # This should not be needed for QOp
 

--- a/src/brevitas/export/onnx/standard/qoperator/handler/base.py
+++ b/src/brevitas/export/onnx/standard/qoperator/handler/base.py
@@ -38,14 +38,6 @@ class StdQOpONNXQuantLayerHandler(ONNXBaseHandler,
         pass
 
     @classmethod
-    def int8_dtype(cls):
-        return torch.int8
-
-    @classmethod
-    def uint8_dtype(cls):
-        return torch.uint8
-
-    @classmethod
     def int32_dtype(cls):
         raise NotImplementedError  # This should not be needed for QOp
 

--- a/src/brevitas/export/torch/qcdq/handler.py
+++ b/src/brevitas/export/torch/qcdq/handler.py
@@ -15,8 +15,10 @@ from brevitas.export.common.handler.qcdq import QCDQCastDecoupledWeightQuantProx
 from brevitas.export.common.handler.qcdq import \
     QCDQCastDecoupledWeightQuantWithInputProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import QCDQCastTruncQuantProxyHandlerMixin
+from brevitas.export.common.handler.qcdq import QCDQCastWeightIntQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import QCDQCastWeightQuantProxyHandlerMixin
 from brevitas.export.common.handler.qcdq import QMixin
+from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjector
 
 
 def _itemize_clip_bounds(clip_args):
@@ -105,7 +107,7 @@ class TorchQCDQHandler(BaseHandler):
 
 
 class TorchQCDQCastWeightQuantProxyHandler(TorchQCDQCastMixin,
-                                           QCDQCastWeightQuantProxyHandlerMixin,
+                                           QCDQCastWeightIntQuantProxyHandlerMixin,
                                            TorchQCDQHandler):
     _export_q_node = False
 

--- a/src/brevitas/export/torch/qcdq/handler.py
+++ b/src/brevitas/export/torch/qcdq/handler.py
@@ -34,20 +34,21 @@ class TorchDQCastMixin(DQCastMixin, QuantDtypeMixin, ABC):
 
     @classmethod
     def int8_dtype(cls):
-        return torch.qint8
+        return torch.int8
 
     @classmethod
     def uint8_dtype(cls):
-        return torch.quint8
+        return torch.uint8
 
     @classmethod
     def int32_dtype(cls):
-        return torch.qint32
+        return torch.int32
 
     @classmethod
-    def qint_to_int(cls, qint):
-        mapping = {torch.quint8: torch.uint8, torch.qint8: torch.int8, torch.qint32: torch.int32}
-        return mapping[qint]
+    def signed_quant_dtype(cls, bit_width, is_signed):
+        signed_dtype = cls.signed_dtype(bit_width, is_signed)
+        mapping = {torch.uint8: torch.quint8, torch.int8: torch.qint8, torch.int32: torch.qint32}
+        return mapping[signed_dtype]
 
     def dequantize_fn(self, x, scale, zero_point, axis):
         # cast zero_point to float, otherwise if both x

--- a/src/brevitas/export/torch/qoperator/handler/base.py
+++ b/src/brevitas/export/torch/qoperator/handler/base.py
@@ -41,6 +41,14 @@ class PytorchQuantLayerHandler(BaseHandler,
         pass
 
     @classmethod
+    def int8_dtype(cls):
+        return torch.int8
+
+    @classmethod
+    def uint8_dtype(cls):
+        return torch.uint8
+
+    @classmethod
     def int32_dtype(cls):
         raise NotImplementedError  # This should not be needed for QOp
 

--- a/src/brevitas/export/torch/qoperator/handler/base.py
+++ b/src/brevitas/export/torch/qoperator/handler/base.py
@@ -53,6 +53,10 @@ class PytorchQuantLayerHandler(BaseHandler,
         raise NotImplementedError  # This should not be needed for QOp
 
     @classmethod
+    def signed_quant_dtype(cls, bit_width, is_signed):
+        raise NotImplementedError  # This should not be needed for QOp
+
+    @classmethod
     def gen_quant_impl_kwargs(
             cls, scale: Tensor, zero_point: Tensor, signed: bool, include_dtype=True):
         if _is_scalar(scale):

--- a/src/brevitas/export/torch/qoperator/handler/base.py
+++ b/src/brevitas/export/torch/qoperator/handler/base.py
@@ -41,14 +41,6 @@ class PytorchQuantLayerHandler(BaseHandler,
         pass
 
     @classmethod
-    def int8_dtype(cls):
-        return torch.int8
-
-    @classmethod
-    def uint8_dtype(cls):
-        return torch.uint8
-
-    @classmethod
     def int32_dtype(cls):
         raise NotImplementedError  # This should not be needed for QOp
 

--- a/src/brevitas/export/torch/qoperator/handler/parameter.py
+++ b/src/brevitas/export/torch/qoperator/handler/parameter.py
@@ -49,11 +49,12 @@ class PytorchQuantWBIOLHandler(PytorchQuantLayerHandler):
 
     @classmethod
     def prepare_weight_quant(cls, module: QuantWBIOL):
+        dtype = cls.signed_dtype(module.quant_weight_bit_width(), module.is_quant_weight_signed)
         cls.validate_bit_width(module.quant_weight_bit_width(), 7, le_then=True)
         cls.validate_8b_bit_width(module.quant_input_bit_width(), le_then=False)
         cls.validate_8b_bit_width(module.quant_output_bit_width(), le_then=False)
         scale = module.quant_weight_scale()
-        zero_point = cls.quant_weight_zero_point(module)
+        zero_point = cls.quant_weight_zero_point(module, dtype)
         signed = module.is_quant_weight_signed
         weight = module.weight.detach()
         quant_impl, quant_kwargs = cls.gen_quant_impl_kwargs(scale, zero_point, signed)

--- a/src/brevitas/proxy/experimental/base_float_quant.py
+++ b/src/brevitas/proxy/experimental/base_float_quant.py
@@ -1,0 +1,36 @@
+from brevitas.proxy.quant_proxy import QuantProxyFromInjector
+
+
+class QuantFloatProxyFromInjector(QuantProxyFromInjector):
+
+    def mantissa_bit_width(self):
+        return self.quant_injector.mantissa_bit_width
+
+    def exponent_bit_width(self):
+        return self.quant_injector.exponent_bit_width
+
+    def saturate(self):
+        return self.quant_injector.saturate
+
+    def nan_values(self):
+        if 'nan_values' in self.quant_injector:
+            return self.quant_injector.nan_values
+        return None
+
+    def inf_values(self):
+        if 'inf_values' in self.quant_injector:
+            return self.quant_injector.inf_values
+        return None
+
+    @property
+    def is_ocp(self):
+        is_e4m3 = self.mantissa_bit_width() == 3 and self.exponent_bit_width() == 4
+
+        is_ocp_e4m3 = is_e4m3 and self.inf_values is None and self.nan_values == (('111',))
+
+        is_e5m2 = self.mantissa_bit_width() == 5 and self.exponent_bit_width() == 2
+
+        is_ocp_e5m2 = is_e5m2 and self.inf_values == (
+            ('00',)) and self.nan_values == ('01', '11', '10')
+
+        return is_ocp_e4m3 or is_ocp_e5m2

--- a/src/brevitas/proxy/experimental/parameter_float_quant.py
+++ b/src/brevitas/proxy/experimental/parameter_float_quant.py
@@ -1,0 +1,11 @@
+from brevitas.proxy.experimental.base_float_quant import QuantFloatProxyFromInjector
+from brevitas.proxy.parameter_quant import BiasQuantProxyFromInjector
+from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjector
+
+
+class WeightFloatQuantProxyFromInjector(WeightQuantProxyFromInjector, QuantFloatProxyFromInjector):
+    pass
+
+
+class BiasFloatQuantProxyFromInjector(BiasQuantProxyFromInjector, QuantFloatProxyFromInjector):
+    pass

--- a/src/brevitas/proxy/experimental/parameter_float_quant.py
+++ b/src/brevitas/proxy/experimental/parameter_float_quant.py
@@ -1,10 +1,51 @@
+from typing import Union
+
+import torch
+from torch import Tensor
+
 from brevitas.proxy.experimental.base_float_quant import QuantFloatProxyFromInjector
 from brevitas.proxy.parameter_quant import BiasQuantProxyFromInjector
+from brevitas.proxy.parameter_quant import ParameterQuantProxyFromInjector
 from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjector
+from brevitas.quant_tensor import QuantTensor
 
 
-class WeightFloatQuantProxyFromInjector(WeightQuantProxyFromInjector, QuantFloatProxyFromInjector):
-    pass
+class WeightFloatQuantProxyFromInjector(ParameterQuantProxyFromInjector,
+                                        QuantFloatProxyFromInjector):
+
+    @property
+    def tracked_parameter_list(self):
+        return [m.weight for m in self.tracked_module_list if m.weight is not None]
+
+    @property
+    def requires_quant_input(self):
+        return False
+
+    def scale(self):
+        if not self.is_quant_enabled:
+            return None
+        scale = self.__call__(self.tracked_parameter_list[0]).scale
+        return scale
+
+    def zero_point(self):
+        if not self.is_quant_enabled:
+            return None
+        zero_point = self.__call__(self.tracked_parameter_list[0]).zero_point
+        return zero_point
+
+    def bit_width(self):
+        if not self.is_quant_enabled:
+            return None
+        bit_width = self.__call__(self.tracked_parameter_list[0]).bit_width
+        return bit_width
+
+    def forward(self, x: torch.Tensor) -> Union[Tensor, QuantTensor]:
+        if self.is_quant_enabled:
+            impl = self.export_handler if self.export_mode else self.tensor_quant
+            out, scale, zero_point, bit_width = impl(x)
+            return QuantTensor(out, scale, zero_point, bit_width, self.is_signed, self.training)
+        else:  # quantization disabled
+            return x
 
 
 class BiasFloatQuantProxyFromInjector(BiasQuantProxyFromInjector, QuantFloatProxyFromInjector):

--- a/src/brevitas/proxy/experimental/runtime_float_quant.py
+++ b/src/brevitas/proxy/experimental/runtime_float_quant.py
@@ -1,0 +1,6 @@
+from brevitas.proxy.experimental.base_float_quant import QuantFloatProxyFromInjector
+from brevitas.proxy.runtime_quant import ActQuantProxyFromInjector
+
+
+class ActFloatQuantProxyFromInjector(ActQuantProxyFromInjector, QuantFloatProxyFromInjector):
+    pass

--- a/src/brevitas/quant/experimental/float_base.py
+++ b/src/brevitas/quant/experimental/float_base.py
@@ -7,6 +7,7 @@ from brevitas.core.quant.float import FloatQuant
 from brevitas.core.scaling.float_scaling import FloatScaling
 from brevitas.inject import ExtendedInjector
 from brevitas.inject import value
+from brevitas.proxy.experimental.parameter_float_quant import WeightFloatQuantProxyFromInjector
 from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjector
 from brevitas.proxy.runtime_quant import ActQuantProxyFromInjector
 from brevitas.quant.solver import ActQuantSolver
@@ -45,7 +46,7 @@ class FloatBase(SolveTensorQuantFloatToIntImplFromEnum):
 
 
 class FloatWeightBase(FloatBase):
-    proxy_class = WeightQuantProxyFromInjector
+    proxy_class = WeightFloatQuantProxyFromInjector
 
 
 class FloatActBase(FloatBase):


### PR DESCRIPTION
PR to enable export of minifloat. **This is just a prototype.** 
The full implementation will require a specific QuantTensor format.

The idea is to extend our current export flow to handle minifloat case.

To do:

- [ ] Decouple Integer data types and Float data types when necessary
- [ ] Clipping for minifloat: Questions about exponent bias, as well as how/if ONNX supports clipping for fp8_e4m3
- [ ] Make sure that the inheritance hierarchy is consistent and coherent
- [ ] Improve validation checks (e.g. `validate` function), check for specific bitwidths and formats
- [ ] Export quantized minifloat directly as we do for integer weights
-----------------------------------------------------------------------
- [ ] Extend to activation quantization
- [ ] Extend to bias quantization
- [ ] Improve proxy to better support export interface
- [ ] Implement Fp8 caching within new proxys
-----------------------------------------------------------------------
- [ ] Add tests in brevitas_ort

