### PR TITLE
Fix/remove-numel - Remove numel is zero check from context manager exit method

### DIFF
--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -119,14 +119,11 @@ class load_quant_model:
                 if module.bias is None:
                     module.register_parameter(
                         'bias',
-                        nn.Parameter(torch.empty(module.weight.shape[0])).to(module.weight.device))
+                        nn.Parameter(torch.zeros(module.weight.shape[0])).to(module.weight.device))
                     self.tracked_modules.append(module)
 
     def __exit__(self, type, value, traceback):
-        for module in self.tracked_modules:
-            # empty tensor has a numel result of 0
-            if torch.numel(module.bias) == 0:
-                module.bias = None
+        pass
 
 
 class bias_correction_mode:

--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -135,7 +135,7 @@ class load_quant_model_mode:
             if issubclass(type(module), QuantWBIOL):
                 module._quant_load_model_mode = True
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, *args, **kwargs):
         for module in self.model.modules():
             if issubclass(type(module), QuantWBIOL):
                 module._quant_load_model_mode = False

--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -24,11 +24,7 @@ from brevitas.quant_tensor import QuantTensor
 from .base import Transform
 
 __all__ = [
-    'ClipFloatWeights',
-    'DisableEnableQuantization',
-    'bias_correction_mode',
-    'calibration_mode',
-    'load_quant_model']
+    'ClipFloatWeights', 'DisableEnableQuantization', 'bias_correction_mode', 'calibration_mode']
 
 _PARAM_PROXIES = (WeightQuantProxyFromInjector, BiasQuantProxyFromInjector)
 
@@ -105,25 +101,6 @@ class calibration_mode:
         self.disable_quant_inference.apply(
             self.model, is_training=self.previous_training_state, quantization_enabled=True)
         restore_return_quant_tensor(self.model, self.return_quant_tensor_state)
-
-
-class load_quant_model:
-
-    def __init__(self, model):
-        self.model = model
-        self.tracked_modules = []
-
-    def __enter__(self):
-        for module in self.model.modules():
-            if issubclass(type(module), QuantWBIOL):
-                if module.bias is None:
-                    module.register_parameter(
-                        'bias',
-                        nn.Parameter(torch.zeros(module.weight.shape[0])).to(module.weight.device))
-                    self.tracked_modules.append(module)
-
-    def __exit__(self, type, value, traceback):
-        pass
 
 
 class bias_correction_mode:

--- a/src/brevitas/nn/quant_layer.py
+++ b/src/brevitas/nn/quant_layer.py
@@ -264,6 +264,7 @@ class QuantWeightBiasInputOutputLayer(QuantBiasMixin, QuantWeightMixin, QuantInp
             **kwargs)
         QuantWeightMixin.__init__(self, weight_quant, **kwargs)
         QuantBiasMixin.__init__(self, bias_quant, **kwargs)
+        self._quant_load_model_mode = False
 
     @abstractmethod
     def inner_forward_impl(self, x: Tensor, quant_weight: Tensor, quant_bias: Optional[Tensor]):
@@ -381,7 +382,7 @@ class QuantWeightBiasInputOutputLayer(QuantBiasMixin, QuantWeightMixin, QuantInp
         bias_key = prefix + 'bias'
         # If the state dict has a bias and the module does not, bias correction was used
         # We add a bias module to prevent failing during the load of the state dict
-        if bias_key in state_dict and self.bias is None:
+        if bias_key in state_dict and self.bias is None and self._quant_load_model_mode:
             self.register_parameter(
                 'bias', torch.nn.Parameter(torch.zeros(self.out_channels)).to(self.weight.device))
         super(QuantWeightBiasInputOutputLayer, self)._load_from_state_dict(

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -10,7 +10,6 @@ import torch.nn as nn
 
 from brevitas.graph.calibrate import bias_correction_mode
 from brevitas.graph.calibrate import calibration_mode
-from brevitas.graph.calibrate import load_quant_model
 import brevitas.nn as qnn
 from brevitas.quant import Int8ActPerTensorFixedPoint
 # Use custom implementation of kthvalue as work around to (b)float16 kernel limitations
@@ -213,8 +212,8 @@ def test_import_bias_correction():
             assert m.bias is not None
 
     new_model = SimpleQuantLinearNet()
-    with load_quant_model(new_model):
-        new_model.load_state_dict(model.state_dict())
+
+    new_model.load_state_dict(model.state_dict())
 
     for m in new_model.modules():
         if isinstance(m, qnn.QuantLinear):

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -214,7 +214,7 @@ def test_import_bias_correction():
 
     new_model = SimpleQuantLinearNet()
 
-    with load_quant_model_mode(model):
+    with load_quant_model_mode(new_model):
         new_model.load_state_dict(model.state_dict())
 
     for m in new_model.modules():

--- a/tests/brevitas/graph/test_calibration.py
+++ b/tests/brevitas/graph/test_calibration.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 
 from brevitas.graph.calibrate import bias_correction_mode
 from brevitas.graph.calibrate import calibration_mode
+from brevitas.graph.calibrate import load_quant_model_mode
 import brevitas.nn as qnn
 from brevitas.quant import Int8ActPerTensorFixedPoint
 # Use custom implementation of kthvalue as work around to (b)float16 kernel limitations
@@ -213,7 +214,8 @@ def test_import_bias_correction():
 
     new_model = SimpleQuantLinearNet()
 
-    new_model.load_state_dict(model.state_dict())
+    with load_quant_model_mode(model):
+        new_model.load_state_dict(model.state_dict())
 
     for m in new_model.modules():
         if isinstance(m, qnn.QuantLinear):


### PR DESCRIPTION
## Reason for this PR

<!--
The "why" -
Provide a short summary to answer "Why are these changes needed?".
Include links to relevant Issues, and links to any background information or discussion.
Help reviewers, and people in the future, understand the context behind this work.
-->

torch.empty and torch.numel don't work as originally expected although this code path was unlikely to be triggered in the original scenario this context manager was added to resolve

## Changes Made in this PR

<!--
The "what" -
Provide a short summary of specific changes made in this pull request.
The "how" -
Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.
Detail any notable implementation details.
-->

Removed the contents of the exit method in the load_quant_model context manager as the method to detect if the newly added biases were corrected won't work as intended.

Also replaced empty with zeros so the bias layer won't affect anything if unused.

## Testing Summary

<!--
Briefly explain how you tested and verified your work.
e.g.
- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.


## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.

## Future Work
