### PR TITLE
Setup: pin ONNX to 1.15 due to ORT incompatibility

### DIFF
--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,2 +1,2 @@
-onnx
+onnx==1.15
 onnxoptimizer

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -1,5 +1,5 @@
 bitstring
-onnx
+onnx==1.15
 onnxoptimizer
 onnxruntime>=1.15.0
 qonnx

--- a/requirements/requirements-ort-integration.txt
+++ b/requirements/requirements-ort-integration.txt
@@ -1,4 +1,4 @@
-onnx
+onnx==1.15
 onnxoptimizer
 onnxruntime>=1.15.0
 qonnx


### PR DESCRIPTION
This seems to be related to:
https://github.com/onnx/onnx/issues/6040

Where ORT fails because of an incompatible ir_version.
More investigation is needed to understand if it's something we need to fix or it involves ONNX/ORT compatibility.