### PR TITLE
Assert all ptq-common bit widths are positive integers

### DIFF
--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
@@ -155,7 +155,7 @@ def quantize_model(
     act_scale_type = scale_factor_type
 
     # We check all of the provided values are positive integers
-    check_bit_widths(
+    check_positive_int(
         weight_bit_width,
         act_bit_width,
         bias_bit_width,
@@ -551,7 +551,7 @@ def apply_learned_round_learning(
                 "loss = {:.4f}, rec_loss = {:.4f}, round_loss = {:.4f}, b = {:.4f}".format(
                     loss, rec_loss, round_loss, b))
 
-def check_bit_widths(*args):
+def check_positive_int(*args):
     """
     We check that every inputted value is positive, and an integer.
     """

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
@@ -3,6 +3,7 @@
 
 from copy import deepcopy
 
+import math
 import torch
 import torch.backends.cudnn as cudnn
 from tqdm import tqdm
@@ -152,6 +153,20 @@ def quantize_model(
     quantize_fn = QUANTIZE_MAP[backend]
     weight_scale_type = scale_factor_type
     act_scale_type = scale_factor_type
+
+    # We check all of the provided values are positive integers
+    check_bit_widths(
+        weight_bit_width,
+        act_bit_width,
+        bias_bit_width,
+        layerwise_first_last_bit_width,
+        layerwise_first_last_mantissa_bit_width,
+        layerwise_first_last_exponent_bit_width,
+        weight_mantissa_bit_width,
+        weight_exponent_bit_width,
+        act_mantissa_bit_width,
+        act_exponent_bit_width,
+    )
 
     weight_quant_format = quant_format
     act_quant_format = quant_format
@@ -535,3 +550,11 @@ def apply_learned_round_learning(
             pbar.set_description(
                 "loss = {:.4f}, rec_loss = {:.4f}, round_loss = {:.4f}, b = {:.4f}".format(
                     loss, rec_loss, round_loss, b))
+
+def check_bit_widths(*args):
+    """
+    We check that every inputted value is positive, and an integer.
+    """
+    for arg in args:
+        assert arg > 0.0
+        assert math.isclose(arg % 1, 0.0)

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from copy import deepcopy
-
 import math
+
 import torch
 import torch.backends.cudnn as cudnn
 from tqdm import tqdm
@@ -550,6 +550,7 @@ def apply_learned_round_learning(
             pbar.set_description(
                 "loss = {:.4f}, rec_loss = {:.4f}, round_loss = {:.4f}, b = {:.4f}".format(
                     loss, rec_loss, round_loss, b))
+
 
 def check_positive_int(*args):
     """


### PR DESCRIPTION
In [testing](https://github.com/Xilinx/brevitas/issues/908) I found that `ptq_common.py` `quantize_model` bit widths can take negative and zero values. In the case of zero values, the model outputs NaNs, and in the case of negative values it is a bit more complicated (real values get outputted), but it is still undesired behavior.

This PR adds a constraint that all 'ptq_common/quantize_model' bit widths should be positive integers.