### PR TITLE
Feat (proxy): scale computation delegated to bias proxy

### DIFF
--- a/src/brevitas/nn/mixin/base.py
+++ b/src/brevitas/nn/mixin/base.py
@@ -147,14 +147,9 @@ class QuantRecurrentLayerMixin(ExportMixin):
 
     @staticmethod
     def gate_params_fwd(gate, quant_input):
-        acc_scale = None
         quant_weight_ih = gate.input_weight()
         quant_weight_hh = gate.hidden_weight()
-        if isinstance(quant_input, QuantTensor) and isinstance(quant_weight_ih, QuantTensor):
-            acc_scale_shape = compute_channel_view_shape(quant_input.value, channel_dim=1)
-            acc_scale = quant_weight_ih.scale.view(acc_scale_shape)
-            acc_scale = acc_scale * quant_input.scale.view(acc_scale_shape)
-        quant_bias = gate.bias_quant(gate.bias, acc_scale)
+        quant_bias = gate.bias_quant(gate.bias, quant_input, quant_weight_ih)
         return quant_weight_ih, quant_weight_hh, quant_bias
 
     def reset_parameters(self) -> None:

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -261,7 +261,7 @@ class BiasQuantProxyFromInjector(ParameterQuantProxyFromInjector, BiasQuantProxy
             self,
             x: Tensor,
             input: Optional[Union[Tensor, QuantTensor]] = None,
-            weight: Union[Tensor, QuantTensor] = None) -> Union[Tensor, QuantTensor]:
+            weight: Optional[Union[Tensor, QuantTensor]] = None) -> Union[Tensor, QuantTensor]:
         out = x
         input_scale = self.compute_bias_scale(input, weight)
         if self.is_quant_enabled:

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -236,14 +236,17 @@ class BiasQuantProxyFromInjector(ParameterQuantProxyFromInjector, BiasQuantProxy
         return bit_width
 
     def quant_output_scale_impl(
-            self, input: QuantTensor, weight: QuantTensor, module: torch.nn.Module):
+            self, input: QuantTensor, weight: QuantTensor, module: torch.nn.Module) -> Tensor:
         channel_dim = -1 if isinstance(module, torch.nn.Linear) else 1
         output_scale_shape = compute_channel_view_shape(input, channel_dim=channel_dim)
         output_scale = weight.scale.view(output_scale_shape)
         output_scale = output_scale * input.scale.view(output_scale_shape)
         return output_scale
 
-    def compute_bias_scale(self, input, weight):
+    def compute_bias_scale(
+            self,
+            input: Optional[Union[Tensor, QuantTensor]],
+            weight: Optional[Union[Tensor, QuantTensor]]) -> Optional[Tensor]:
         if self.requires_input_scale:
             return None
         if not isinstance(input, QuantTensor) or not isinstance(weight, QuantTensor):

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -247,7 +247,7 @@ class BiasQuantProxyFromInjector(ParameterQuantProxyFromInjector, BiasQuantProxy
             self,
             input: Optional[Union[Tensor, QuantTensor]],
             weight: Optional[Union[Tensor, QuantTensor]]) -> Optional[Tensor]:
-        if self.requires_input_scale:
+        if not self.requires_input_scale:
             return None
         if not isinstance(input, QuantTensor) or not isinstance(weight, QuantTensor):
             return None

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -250,7 +250,7 @@ class BiasQuantProxyFromInjector(ParameterQuantProxyFromInjector, BiasQuantProxy
             return None
         if len(self.tracked_module_list) > 1:
             if not all(
-                    type[self.tracked_module_list[0]] == type[x] for x in self.tracked_module_list):
+                [type[self.tracked_module_list[0]] == type[x] for x in self.tracked_module_list]):
                 raise RuntimeError(
                     "Bias quantizer shared across different type of layers with external scale is not supported."
                 )


### PR DESCRIPTION
As part of decoupling QuantLayers and QuantTensor, the computation of output scale for bias quantization is now delegated to the underlying proxy, who takes as input the possibly quantized input and weights, and internally defines the output scale.

Compared to our current setup, the main change would happen in the case where:
- bias quantizer is shared across multiple layers
- These layers are of different types (e.g., Linear and Conv)

Our current setup would have no issue with this case, while after this PR, the user would be required to use internally scaled bias and not externally defined.
I believe this to be a edge case that can be safely ignored.