### PR TITLE
Dev quant squeeze

### DIFF
--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -214,12 +214,18 @@ class QuantTensor(QuantTensorBase):
 
     def squeeze(self, *args, **kwargs):
         one_dims = [idx for idx, dim in enumerate(self.value.shape) if dim == 1]
-        arg_dims = list(range(len(self.value.shape)))
-        if len(args) != 0:
-            arg_dims = [args[0]] if isinstance(args[0], int) else list(args[0])
-        elif "dim" in kwargs:
-            arg_dims = [kwargs["dim"]] if isinstance(kwargs["dim"], int) else list(kwargs["dim"])
-        sorted_target_dims = sorted(list(set(one_dims) & set(arg_dims)), reverse=True)
+        if len(args) == 0 and "dim" not in kwargs:
+            sorted_target_dims = sorted(one_dims, reverse=True)
+        else:
+            if len(args) != 0:
+                arg_dims = [args[0]] if isinstance(args[0], int) else list(args[0])
+            elif "dim" in kwargs:
+                arg_dims = [kwargs["dim"]] if isinstance(kwargs["dim"], int) else list(
+                    kwargs["dim"])
+            else:
+                raise RuntimeError("no dim specified")
+            arg_dims = [dim if dim >= 0 else dim + len(self.value.shape) for dim in arg_dims]
+            sorted_target_dims = sorted(list(set(one_dims) & set(arg_dims)), reverse=True)
         value = self.value
         for dim in sorted_target_dims:
             value = value.squeeze(dim)

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -225,7 +225,9 @@ class QuantTensor(QuantTensorBase):
             'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
         for k, tm in tensor_meta.items():
             if tm is not None and len(value.shape) == len(tm.shape) - len(target_dims):
-                tensor_meta[k] = tm.squeeze(dim=target_dims)
+                for dim in sorted(target_dims, reverse=True):
+                    tm = tm.squeeze(dim)
+                tensor_meta[k] = tm
         return self.set(value=value, **tensor_meta)
 
     def unsqueeze(self, *args, **kwargs):

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -217,9 +217,9 @@ class QuantTensor(QuantTensorBase):
         one_dims = [idx for idx, dim in enumerate(self.value.shape) if dim == 1]
         arg_dims = list(range(len(self.value.shape)))
         if len(args) != 0:
-            arg_dims = args[0]
+            arg_dims = [args[0]] if isinstance(args[0], int) else list(args[0])
         elif "dim" in kwargs:
-            arg_dims = kwargs["dim"]
+            arg_dims = [kwargs["dim"]] if isinstance(kwargs["dim"], int) else list(kwargs["dim"])
         target_dims = list(set(one_dims) & set(arg_dims))
         tensor_meta = {
             'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -219,15 +219,15 @@ class QuantTensor(QuantTensorBase):
             arg_dims = [args[0]] if isinstance(args[0], int) else list(args[0])
         elif "dim" in kwargs:
             arg_dims = [kwargs["dim"]] if isinstance(kwargs["dim"], int) else list(kwargs["dim"])
-        target_dims = list(set(one_dims) & set(arg_dims))
+        sorted_target_dims = sorted(list(set(one_dims) & set(arg_dims)), reverse=True)
         value = self.value
-        for dim in sorted(target_dims, reverse=True):
+        for dim in sorted_target_dims:
             value = value.squeeze(dim)
         tensor_meta = {
             'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
         for k, tm in tensor_meta.items():
-            if tm is not None and len(value.shape) == len(tm.shape) - len(target_dims):
-                for dim in sorted(target_dims, reverse=True):
+            if tm is not None and len(value.shape) == len(tm.shape) - len(sorted_target_dims):
+                for dim in sorted_target_dims:
                     tm = tm.squeeze(dim)
                 tensor_meta[k] = tm
         return self.set(value=value, **tensor_meta)

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -214,10 +214,13 @@ class QuantTensor(QuantTensorBase):
     
     def squeeze(self, *args, **kwargs):
         value = self.value.squeeze(*args, **kwargs)
-        if len(args) != 0 or "dim" in kwargs:
-            target_dims = args[0] if len(args) != 0 else kwargs["dim"]
-        else:
-            target_dims = [idx for idx, dim in enumerate(self.value.shape) if dim == 1]
+        one_dims = [idx for idx, dim in enumerate(self.value.shape) if dim == 1]
+        arg_dims = list(range(len(self.value.shape)))
+        if len(args) != 0:
+            arg_dims = args[0]
+        elif "dim" in kwargs:
+            arg_dims = kwargs["dim"]
+        target_dims = list(set(one_dims) & set(arg_dims))
         tensor_meta = {
             'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
         for k, tm in tensor_meta.items():

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -213,7 +213,6 @@ class QuantTensor(QuantTensorBase):
         return self.set(value=value, **tensor_meta)
 
     def squeeze(self, *args, **kwargs):
-        value = self.value.squeeze(*args, **kwargs)
         one_dims = [idx for idx, dim in enumerate(self.value.shape) if dim == 1]
         arg_dims = list(range(len(self.value.shape)))
         if len(args) != 0:
@@ -221,6 +220,9 @@ class QuantTensor(QuantTensorBase):
         elif "dim" in kwargs:
             arg_dims = [kwargs["dim"]] if isinstance(kwargs["dim"], int) else list(kwargs["dim"])
         target_dims = list(set(one_dims) & set(arg_dims))
+        value = self.value
+        for dim in sorted(target_dims, reverse=True):
+            value = value.squeeze(dim)
         tensor_meta = {
             'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
         for k, tm in tensor_meta.items():

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -211,6 +211,14 @@ class QuantTensor(QuantTensorBase):
             if tm is not None and len(value.shape) == len(tm.shape):
                 tensor_meta[k] = tm.permute(*args, **kwargs)
         return self.set(value=value, **tensor_meta)
+    
+    def squeeze(self, *args, **kwargs):
+        pass
+        # TODO
+    
+    def unsqueeze(self, *args, **kwargs):
+        pass
+        # TODO
 
     def size(self, *args, **kwargs):
         return self.value.size(*args, **kwargs)

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -211,7 +211,7 @@ class QuantTensor(QuantTensorBase):
             if tm is not None and len(value.shape) == len(tm.shape):
                 tensor_meta[k] = tm.permute(*args, **kwargs)
         return self.set(value=value, **tensor_meta)
-    
+
     def squeeze(self, *args, **kwargs):
         value = self.value.squeeze(*args, **kwargs)
         one_dims = [idx for idx, dim in enumerate(self.value.shape) if dim == 1]
@@ -225,9 +225,9 @@ class QuantTensor(QuantTensorBase):
             'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
         for k, tm in tensor_meta.items():
             if tm is not None and len(value.shape) == len(tm.shape) - len(target_dims):
-                tensor_meta[k] = tm.squeeze(target_dims)
+                tensor_meta[k] = tm.squeeze(dim=target_dims)
         return self.set(value=value, **tensor_meta)
-    
+
     def unsqueeze(self, *args, **kwargs):
         value = self.value.unsqueeze(*args, **kwargs)
         tensor_meta = {

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -232,6 +232,7 @@ class QuantTensor(QuantTensorBase):
         for k, tm in tensor_meta.items():
             if tm is not None and len(value.shape) == len(tm.shape):
                 tensor_meta[k] = tm.unsqueeze(*args, **kwargs)
+        return self.set(value=value, **tensor_meta)
 
     def size(self, *args, **kwargs):
         return self.value.size(*args, **kwargs)

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -221,7 +221,7 @@ class QuantTensor(QuantTensorBase):
         tensor_meta = {
             'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
         for k, tm in tensor_meta.items():
-            if tm is not None and len(value.shape) == len(tm.shape):
+            if tm is not None and len(value.shape) == len(tm.shape) - len(target_dims):
                 tensor_meta[k] = tm.squeeze(target_dims)
         return self.set(value=value, **tensor_meta)
     
@@ -230,7 +230,7 @@ class QuantTensor(QuantTensorBase):
         tensor_meta = {
             'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
         for k, tm in tensor_meta.items():
-            if tm is not None and len(value.shape) == len(tm.shape):
+            if tm is not None and len(value.shape) == len(tm.shape) + 1:
                 tensor_meta[k] = tm.unsqueeze(*args, **kwargs)
         return self.set(value=value, **tensor_meta)
 

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -213,12 +213,25 @@ class QuantTensor(QuantTensorBase):
         return self.set(value=value, **tensor_meta)
     
     def squeeze(self, *args, **kwargs):
-        pass
-        # TODO
+        value = self.value.squeeze(*args, **kwargs)
+        if len(args) != 0 or "dim" in kwargs:
+            target_dims = args[0] if len(args) != 0 else kwargs["dim"]
+        else:
+            target_dims = [idx for idx, dim in enumerate(self.value.shape) if dim == 1]
+        tensor_meta = {
+            'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
+        for k, tm in tensor_meta.items():
+            if tm is not None and len(value.shape) == len(tm.shape):
+                tensor_meta[k] = tm.squeeze(target_dims)
+        return self.set(value=value, **tensor_meta)
     
     def unsqueeze(self, *args, **kwargs):
-        pass
-        # TODO
+        value = self.value.unsqueeze(*args, **kwargs)
+        tensor_meta = {
+            'scale': self.scale, 'zero_point': self.zero_point, 'bit_width': self.bit_width}
+        for k, tm in tensor_meta.items():
+            if tm is not None and len(value.shape) == len(tm.shape):
+                tensor_meta[k] = tm.unsqueeze(*args, **kwargs)
 
     def size(self, *args, **kwargs):
         return self.value.size(*args, **kwargs)

--- a/src/brevitas/quant_tensor/torch_handler.py
+++ b/src/brevitas/quant_tensor/torch_handler.py
@@ -45,17 +45,21 @@ def reshape_handler(inp, *args, **kwargs):
 def transpose_handler(inp, *args, **kwargs):
     return inp.transpose(*args, **kwargs)
 
+
 @implements(torch.permute)
 def permute_handler(inp, *args, **kwargs):
     return inp.permute(*args, **kwargs)
+
 
 @implements(torch.squeeze)
 def squeeze_handler(inp, *args, **kwargs):
     return inp.squeeze(*args, **kwargs)
 
+
 @implements(torch.unsqueeze)
 def unsqueeze_handler(inp, *args, **kwargs):
     return inp.unsqueeze(*args, **kwargs)
+
 
 @implements(torch.cat)
 def cat_handler(*args, **kwargs):

--- a/src/brevitas/quant_tensor/torch_handler.py
+++ b/src/brevitas/quant_tensor/torch_handler.py
@@ -45,6 +45,17 @@ def reshape_handler(inp, *args, **kwargs):
 def transpose_handler(inp, *args, **kwargs):
     return inp.transpose(*args, **kwargs)
 
+@implements(torch.permute)
+def permute_handler(inp, *args, **kwargs):
+    return inp.permute(*args, **kwargs)
+
+@implements(torch.squeeze)
+def squeeze_handler(inp, *args, **kwargs):
+    return inp.squeeze(*args, **kwargs)
+
+@implements(torch.unsqueeze)
+def unsqueeze_handler(inp, *args, **kwargs):
+    return inp.unsqueeze(*args, **kwargs)
 
 @implements(torch.cat)
 def cat_handler(*args, **kwargs):

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -87,7 +87,6 @@ def test_quant_tensor_div_by_fraction():
     assert torch.allclose(a / b, torch.ones(4, 4) * 2, atol=0.1)
 
 
-# TODO: need to deal with quant metadata
 def test_quant_tensor_transpose():
     x = torch.ones(4, 4).tril()
     a = x.clone()

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -101,53 +101,57 @@ def test_quant_tensor_div_by_fraction():
 def test_quant_tensor_transpose():
     x = torch.ones(4, 4).tril()
     a = x.clone()
+    a_transposed = a.transpose(0, 1)
     b = to_quant_tensor(x)
     b_transposed = b.transpose(0, 1)
     assert b_transposed.is_valid
-    assert torch.allclose(a.transpose(0, 1), b_transposed, atol=0.01)
+    assert torch.allclose(a_transposed, b_transposed, atol=0.01)
     c = to_quant_tensor_per_channel(x)
     c_transposed = c.transpose(0, 1)
     assert c_transposed.is_valid
-    assert torch.allclose(a.transpose(0, 1), c_transposed, atol=0.01)
+    assert torch.allclose(a_transposed, c_transposed, atol=0.01)
 
 
 def test_quant_tensor_permute():
     x = torch.rand(4, 4, 4)
     a = x.clone()
+    a_permuted = a.permute(1, 0, 2)
     b = to_quant_tensor(x)
     b_permuted = b.permute(1, 0, 2)
     assert b_permuted.is_valid
-    assert torch.allclose(a.permute(1, 0, 2), b_permuted, atol=0.01)
+    assert torch.allclose(a_permuted, b_permuted, atol=0.01)
     c = to_quant_tensor_per_channel(x)
     c_permuted = c.permute(1, 0, 2)
     assert c_permuted.is_valid
-    assert torch.allclose(a.permute(1, 0, 2), c_permuted, atol=0.01)
+    assert torch.allclose(a_permuted, c_permuted, atol=0.01)
 
 
 def test_quant_tensor_squeeze():
     x = torch.rand(4, 1, 4, 1)
     a = x.clone()
+    a_squeezed = a.squeeze()
     b = to_quant_tensor(x)
     b_squeezed = b.squeeze()
     assert b_squeezed.is_valid
-    assert torch.allclose(a.squeeze(), b_squeezed, atol=0.01)
+    assert torch.allclose(a_squeezed, b_squeezed, atol=0.01)
     c = to_quant_tensor_per_channel(x)
     c_squeezed = c.squeeze()
     assert c_squeezed.is_valid
-    assert torch.allclose(a.squeeze(), c_squeezed, atol=0.01)
+    assert torch.allclose(a_squeezed, c_squeezed, atol=0.01)
 
 
 def test_quant_tensor_unsqueeze():
     x = torch.rand(4, 4)
     a = x.clone()
+    a_unsqueezed = a.unsqueeze(1)
     b = to_quant_tensor(x)
     b_unsqueezed = b.unsqueeze(1)
     assert b_unsqueezed.is_valid
-    assert torch.allclose(a.unsqueeze(1), b_unsqueezed, atol=0.01)
+    assert torch.allclose(a_unsqueezed, b_unsqueezed, atol=0.01)
     c = to_quant_tensor_per_channel(x)
     c_unsqueezed = c.unsqueeze(1)
     assert c_unsqueezed.is_valid
-    assert torch.allclose(a.unsqueeze(1), c_unsqueezed, atol=0.01)
+    assert torch.allclose(a_unsqueezed, c_unsqueezed, atol=0.01)
 
 
 # TODO: need to deal with quant metadata

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -94,6 +94,27 @@ def test_quant_tensor_transpose():
     assert torch.allclose(a.transpose(0, 1), b.transpose(0, 1), atol=0.01)
 
 
+def test_quant_tensor_permute():
+    x = torch.rand(4, 4, 4)
+    a = x.clone()
+    b = to_quant_tensor(x)
+    assert torch.allclose(a.permute(1, 0, 2), b.permute(1, 0, 2), atol=0.01)
+
+
+def test_quant_tensor_squeeze():
+    x = torch.rand(4, 1, 4, 1)
+    a = x.clone()
+    b = to_quant_tensor(x)
+    assert torch.allclose(a.squeeze(), b.squeeze(), atol=0.01)
+
+
+def test_quant_tensor_unsqueeze():
+    x = torch.rand(4, 4)
+    a = x.clone()
+    b = to_quant_tensor(x)
+    assert torch.allclose(a.unsqueeze(1), b.unsqueeze(1), atol=0.01)
+
+
 # TODO: need to deal with quant metadata
 def test_quant_tensor_view():
     x = torch.ones(4, 4)

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -102,36 +102,52 @@ def test_quant_tensor_transpose():
     x = torch.ones(4, 4).tril()
     a = x.clone()
     b = to_quant_tensor(x)
-    assert torch.allclose(a.transpose(0, 1), b.transpose(0, 1), atol=0.01)
+    b_transposed = b.transpose(0, 1)
+    assert b_transposed.is_valid
+    assert torch.allclose(a.transpose(0, 1), b_transposed, atol=0.01)
     c = to_quant_tensor_per_channel(x)
-    assert torch.allclose(a.transpose(0, 1), c.transpose(0, 1), atol=0.01)
+    c_transposed = c.transpose(0, 1)
+    assert c_transposed.is_valid
+    assert torch.allclose(a.transpose(0, 1), c_transposed, atol=0.01)
 
 
 def test_quant_tensor_permute():
     x = torch.rand(4, 4, 4)
     a = x.clone()
     b = to_quant_tensor(x)
-    assert torch.allclose(a.permute(1, 0, 2), b.permute(1, 0, 2), atol=0.01)
+    b_permuted = b.permute(1, 0, 2)
+    assert b_permuted.is_valid
+    assert torch.allclose(a.permute(1, 0, 2), b_permuted, atol=0.01)
     c = to_quant_tensor_per_channel(x)
-    assert torch.allclose(a.permute(1, 0, 2), c.permute(1, 0, 2), atol=0.01)
+    c_permuted = c.permute(1, 0, 2)
+    assert c_permuted.is_valid
+    assert torch.allclose(a.permute(1, 0, 2), c_permuted, atol=0.01)
 
 
 def test_quant_tensor_squeeze():
     x = torch.rand(4, 1, 4, 1)
     a = x.clone()
     b = to_quant_tensor(x)
-    assert torch.allclose(a.squeeze(), b.squeeze(), atol=0.01)
+    b_squeezed = b.squeeze()
+    assert b_squeezed.is_valid
+    assert torch.allclose(a.squeeze(), b_squeezed, atol=0.01)
     c = to_quant_tensor_per_channel(x)
-    assert torch.allclose(a.squeeze(), c.squeeze(), atol=0.01)
+    c_squeezed = c.squeeze()
+    assert c_squeezed.is_valid
+    assert torch.allclose(a.squeeze(), c_squeezed, atol=0.01)
 
 
 def test_quant_tensor_unsqueeze():
     x = torch.rand(4, 4)
     a = x.clone()
     b = to_quant_tensor(x)
-    assert torch.allclose(a.unsqueeze(1), b.unsqueeze(1), atol=0.01)
+    b_unsqueezed = b.unsqueeze(1)
+    assert b_unsqueezed.is_valid
+    assert torch.allclose(a.unsqueeze(1), b_unsqueezed, atol=0.01)
     c = to_quant_tensor_per_channel(x)
-    assert torch.allclose(a.unsqueeze(1), c.unsqueeze(1), atol=0.01)
+    c_unsqueezed = c.unsqueeze(1)
+    assert c_unsqueezed.is_valid
+    assert torch.allclose(a.unsqueeze(1), c_unsqueezed, atol=0.01)
 
 
 # TODO: need to deal with quant metadata


### PR DESCRIPTION
The PR was submitted to add the Squeeze/Unsqueeze operation to QuantTensor. Issue: #891

**Changes**
* [x] Add Squeeze/Unsqueeze operation to QuantTensor.
* [x] For meta-data sensitive operations in QuantTensor (e.g., reshape, flatten, transpose, permute, squeeze, unsqueeze), add per-channel granularity test cases.

See more discussions in #891 #728.