### PR TITLE
Fix bullet formatting in getting started guide

### DIFF
--- a/docsrc/source/getting_started.rst
+++ b/docsrc/source/getting_started.rst
@@ -186,6 +186,7 @@ Weights, activations, biases quantization
 ..
 
 Compared to the previous scenario:
+
 - We now set ``return_quant_tensor=True`` in every quantized activations to propagate a ``QuantTensor`` to the next layer. This informs each ``QuantLinear`` or ``QuantConv2d`` of how the input passed in has been quantized.
 - A ``QuantTensor`` is just a tensor-like data structure providing metadata about how a tensor has been quantized, similar to a `torch.qint` dtype, but training friendly. Setting ``return_quant_tensor=True`` does not affect the way quantization is performed, it only changes the way the output is represented.
 - We enable bias quantization by setting the `Int32Bias` quantizer. What it does is to perform bias quantization with ```bias_scale = input_scale * weight_scale``, as it commonly done across inference toolchains. This is why we have to set ``return_quant_tensor=True``: each layer with ``Int32Bias`` can read the input scale from the ``QuantTensor`` passed in and use for bias quantization.


### PR DESCRIPTION
Fixes a small formatting error due to missing newline, wherein the subsequent bullets do not get rendered.

<img width="1064" alt="Screenshot 2024-05-04 at 19 31 33" src="https://github.com/Xilinx/brevitas/assets/3105306/d46b5a4e-c012-4268-a2ff-2288f37fe497">
