### PR TITLE
Feat (gpfq): separate float and quant forward pass for speedup

### DIFF
--- a/src/brevitas/graph/gpfq.py
+++ b/src/brevitas/graph/gpfq.py
@@ -62,7 +62,12 @@ class gpfq_mode(gpxq_mode):
 
     Example:
         >>> with torch.no_grad():
-        >>>     with gpfq_mode(model) as gpfq:
+        >>>     with gpfq_mode(model, collect_float_first) as gpfq:
+        >>>         if collect_float_first:
+        >>>             for img, t in calib_loader:
+        >>>                 img = img.cuda()
+        >>>                 gpfq.orig_forward(img)
+        >>>             gpfq.finalize_float_collection()
         >>>         gpfq_model = gpfq.model
         >>>         for i in tqdm(range(gpfq.num_layers)):
         >>>             for img, t in calib_loader:

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -76,6 +76,10 @@ class gptq_mode(gpxq_mode):
         # How many subblock to use during GPTQ for each layer
         self.num_blocks = num_blocks
 
+    def __enter__(self):
+        self.setup_gpxq_layers()
+        return self.setup_gpxq_hooks()
+
     def catch_stopfwd(self, *args, **kwargs):
         try:
             self.orig_forward(*args, **kwargs)

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -99,12 +99,6 @@ class gpxq_mode(ABC):
         self.group_of_parallel_layers = group_of_parallel_layers
         self.return_forward_output = return_forward_output
 
-        self.orig_forward = self.model.forward
-        if isinstance(self.model, (GraphModule, TorchGraphModule)):
-            self.model.__class__.forward = self.catch_stopfwd
-        else:
-            self.model.forward = self.catch_stopfwd
-
     def _is_module_supported(self, module):
         if isinstance(module, SUPPORTED_CONV_OP):
             return True

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_common.py
@@ -557,15 +557,15 @@ def apply_gpfq(
                        accumulator_bit_width=accumulator_bit_width,
                        compression_rate=compression_rate,
                        collect_float_first=collect_float_first) as gpfq:
+            gpfq_model = gpfq.model
             if collect_float_first:
                 print('Collecting float input first...')
                 for i, (images, target) in tqdm(enumerate(calib_loader)):
                     images = images.to(device)
                     images = images.to(dtype)
-                    gpfq.orig_forward(images)
+                    gpfq_model(images)
                 gpfq.finalize_float_collection()
 
-            gpfq_model = gpfq.model
             for i in tqdm(range(gpfq.num_layers)):
                 for i, (images, target) in enumerate(calib_loader):
                     images = images.to(device)

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -245,6 +245,11 @@ parser.add_argument(
     type=float,
     help='Specify compression rate < 1.0 for random projection. Default is 0.0 and does not use RP.'
 )
+add_bool_arg(
+    parser,
+    'collect-float-first',
+    default=False,
+    help='In GPFQ, separate float and quant forward pass for speed up. (default: False)')
 add_bool_arg(parser, 'gptq', default=False, help='GPTQ (default: disabled)')
 add_bool_arg(parser, 'gpfq', default=False, help='GPFQ (default: disabled)')
 add_bool_arg(parser, 'gpfa2q', default=False, help='GPFA2Q (default: disabled)')
@@ -437,7 +442,8 @@ def main():
             quant_model,
             p=args.gpfq_p,
             act_order=args.gpxq_act_order,
-            compression_rate=args.compression_rate)
+            compression_rate=args.compression_rate,
+            collect_float_first=args.collect_float_first)
 
     if args.gpfa2q:
         print("Performing GPFA2Q:")
@@ -448,7 +454,8 @@ def main():
             act_order=args.gpxq_act_order,
             use_gpfa2q=args.gpfa2q,
             accumulator_bit_width=args.accumulator_bit_width,
-            compression_rate=args.compression_rate)
+            compression_rate=args.compression_rate,
+            collect_float_first=args.collect_float_first)
 
     if args.gptq:
         print("Performing GPTQ:")


### PR DESCRIPTION
Speeding up GPFQ with separate forward passes for quantized and float input. I avoided offloading the float input to disc and instead saved them under an attribute for GPFQ and simply moved them off the GPU when collected.
