### PR TITLE
[DO NOT MERGE] Feat (tests/actions): Updated tests to use `python=3.10` instead of `python=3.8`

### DIFF
--- a/.github/workflows/develop_install.yml
+++ b/.github/workflows/develop_install.yml
@@ -15,10 +15,14 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.9', '3.10']
         pytorch_version: ['1.9.1', '1.10.1', '1.11.0', '1.12.1', '1.13.0', '2.0.1', '2.1.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
+
+        exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
 
 
 

--- a/.github/workflows/develop_install.yml
+++ b/.github/workflows/develop_install.yml
@@ -27,6 +27,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
 
 
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/develop_install.yml
+++ b/.github/workflows/develop_install.yml
@@ -21,6 +21,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -15,12 +15,15 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.9', '3.10']
         pytorch_version: ['1.9.1', '1.10.1', '1.11.0', '1.12.1', '1.13.0', '2.0.1', '2.1.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
+
           - platform: 'windows-latest'
 
 

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -27,6 +27,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
           - platform: 'windows-latest'
 
 

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -21,6 +21,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/examples_pytest.yml
+++ b/.github/workflows/examples_pytest.yml
@@ -22,6 +22,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/examples_pytest.yml
+++ b/.github/workflows/examples_pytest.yml
@@ -15,13 +15,16 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.9', '3.10']
         pytorch_version: ['1.9.1', '1.10.1', '1.11.0', '1.12.1', '1.13.0', '2.0.1', '2.1.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled', 'jit_enabled']
 
 
         exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
+
           - pytorch_version: '1.9.1'
             jit_status: 'jit_enabled'
 

--- a/.github/workflows/examples_pytest.yml
+++ b/.github/workflows/examples_pytest.yml
@@ -28,6 +28,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
           - pytorch_version: '1.9.1'
             jit_status: 'jit_enabled'
 

--- a/.github/workflows/finn_integration.yml
+++ b/.github/workflows/finn_integration.yml
@@ -15,10 +15,14 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.9', '3.10']
         pytorch_version: ['1.9.1', '1.10.1', '1.11.0', '1.12.1', '1.13.0', '2.0.1', '2.1.0']
         platform: ['windows-latest', 'ubuntu-latest']
 
+
+        exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
 
 
 

--- a/.github/workflows/finn_integration.yml
+++ b/.github/workflows/finn_integration.yml
@@ -27,6 +27,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
 
 
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/finn_integration.yml
+++ b/.github/workflows/finn_integration.yml
@@ -21,6 +21,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -45,8 +45,8 @@ FINN_PLATFORM_LIST = ['windows-latest', 'ubuntu-latest']
 STRATEGY = od([('fail-fast', 'false')])
 
 EXCLUDE_LIST = generate_exclusion_list([[['python_version', ['3.10']],
-                                             ['pytorch_version', [
-                                                 '1.9.1',]]]])
+                                         ['pytorch_version', [
+                                             '1.9.1',]]]])
 
 JIT_EXCLUDE_LIST = generate_exclusion_list([[['pytorch_version', ['1.9.1']],
                                              ['jit_status', [

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -47,7 +47,7 @@ STRATEGY = od([('fail-fast', 'false')])
 EXCLUDE_LIST = generate_exclusion_list([[['pytorch_version', ['1.9.1']],
                                          ['platform', ['macos-latest']]],
                                         [['python_version', ['3.10']],
-                                         ['pytorch_version', ['1.9.1']]]])
+                                         ['pytorch_version', ['1.9.1', '1.10.1']]]])
 
 JIT_EXCLUDE_LIST = generate_exclusion_list([[['pytorch_version', ['1.9.1']],
                                              ['jit_status', [

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -15,7 +15,7 @@ NOTEBOOK_YML = 'notebook.yml'
 ENDTOEND_YML = 'end_to_end.yml'
 
 # Reduced Test for PRs, except when a review is requested
-PYTHON_VERSIONS_REDUCED = ('3.8',)
+PYTHON_VERSIONS_REDUCED = ('3.9',)
 
 PYTORCH_LIST_REDUCED = ["1.9.1", "1.13.0", "2.1.0"]
 
@@ -33,7 +33,7 @@ PYTEST_MATRIX_EXTRA_REDUCED = od([('jit_status', [
     'jit_disabled',])])
 
 # Data shared betwen Nox sessions and Github Actions, formatted as tuples
-PYTHON_VERSIONS = ('3.8', '3.9')
+PYTHON_VERSIONS = ('3.9', '3.10')
 
 PYTORCH_VERSIONS = ('1.9.1', '1.10.1', '1.11.0', '1.12.1', '1.13.0', '2.0.1', '2.1.0')
 JIT_STATUSES = ('jit_disabled', 'jit_enabled')

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -44,7 +44,9 @@ FINN_PLATFORM_LIST = ['windows-latest', 'ubuntu-latest']
 
 STRATEGY = od([('fail-fast', 'false')])
 
-EXCLUDE_LIST = []
+EXCLUDE_LIST = generate_exclusion_list([[['python_version', ['3.10']],
+                                             ['pytorch_version', [
+                                                 '1.9.1',]]]])
 
 JIT_EXCLUDE_LIST = generate_exclusion_list([[['pytorch_version', ['1.9.1']],
                                              ['jit_status', [

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -44,9 +44,10 @@ FINN_PLATFORM_LIST = ['windows-latest', 'ubuntu-latest']
 
 STRATEGY = od([('fail-fast', 'false')])
 
-EXCLUDE_LIST = generate_exclusion_list([[['python_version', ['3.10']],
-                                         ['pytorch_version', [
-                                             '1.9.1',]]]])
+EXCLUDE_LIST = generate_exclusion_list([[['pytorch_version', ['1.9.1']],
+                                         ['platform', ['macos-latest']]],
+                                        [['python_version', ['3.10']],
+                                         ['pytorch_version', ['1.9.1']]]])
 
 JIT_EXCLUDE_LIST = generate_exclusion_list([[['pytorch_version', ['1.9.1']],
                                              ['jit_status', [

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -15,12 +15,15 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.9', '3.10']
         pytorch_version: ['1.9.1', '1.10.1', '1.11.0', '1.12.1', '1.13.0', '2.0.1', '2.1.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
+
           - platform: 'macos-latest'
 
 

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -27,6 +27,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
           - platform: 'macos-latest'
 
 

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -21,6 +21,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/ort_integration.yml
+++ b/.github/workflows/ort_integration.yml
@@ -15,10 +15,14 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.9', '3.10']
         pytorch_version: ['1.9.1', '1.10.1', '1.11.0', '1.12.1', '1.13.0', '2.0.1', '2.1.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
+
+        exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
 
 
 

--- a/.github/workflows/ort_integration.yml
+++ b/.github/workflows/ort_integration.yml
@@ -27,6 +27,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
 
 
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/ort_integration.yml
+++ b/.github/workflows/ort_integration.yml
@@ -21,6 +21,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,6 +22,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,13 +15,16 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.9', '3.10']
         pytorch_version: ['1.9.1', '1.10.1', '1.11.0', '1.12.1', '1.13.0', '2.0.1', '2.1.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled', 'jit_enabled']
 
 
         exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
+
           - pytorch_version: '1.9.1'
             jit_status: 'jit_enabled'
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,6 +28,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
           - pytorch_version: '1.9.1'
             jit_status: 'jit_enabled'
 

--- a/.github/workflows/reduced_develop_install.yml
+++ b/.github/workflows/reduced_develop_install.yml
@@ -29,6 +29,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
 
 
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/reduced_develop_install.yml
+++ b/.github/workflows/reduced_develop_install.yml
@@ -23,6 +23,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/reduced_develop_install.yml
+++ b/.github/workflows/reduced_develop_install.yml
@@ -17,10 +17,14 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8']
+        python_version: ['3.9']
         pytorch_version: ['1.9.1', '1.13.0', '2.1.0']
         platform: ['ubuntu-latest']
 
+
+        exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
 
 
 

--- a/.github/workflows/reduced_end_to_end.yml
+++ b/.github/workflows/reduced_end_to_end.yml
@@ -23,6 +23,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/reduced_end_to_end.yml
+++ b/.github/workflows/reduced_end_to_end.yml
@@ -17,12 +17,15 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8']
+        python_version: ['3.9']
         pytorch_version: ['1.9.1', '1.13.0', '2.1.0']
         platform: ['ubuntu-latest']
 
 
         exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
+
           - platform: 'windows-latest'
 
 

--- a/.github/workflows/reduced_end_to_end.yml
+++ b/.github/workflows/reduced_end_to_end.yml
@@ -29,6 +29,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
           - platform: 'windows-latest'
 
 

--- a/.github/workflows/reduced_examples_pytest.yml
+++ b/.github/workflows/reduced_examples_pytest.yml
@@ -17,11 +17,15 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8']
+        python_version: ['3.9']
         pytorch_version: ['1.9.1', '1.13.0', '2.1.0']
         platform: ['ubuntu-latest']
         jit_status: ['jit_disabled']
 
+
+        exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
 
 
 

--- a/.github/workflows/reduced_examples_pytest.yml
+++ b/.github/workflows/reduced_examples_pytest.yml
@@ -24,6 +24,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/reduced_examples_pytest.yml
+++ b/.github/workflows/reduced_examples_pytest.yml
@@ -30,6 +30,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
 
 
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/reduced_finn_integration.yml
+++ b/.github/workflows/reduced_finn_integration.yml
@@ -29,6 +29,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
 
 
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/reduced_finn_integration.yml
+++ b/.github/workflows/reduced_finn_integration.yml
@@ -23,6 +23,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/reduced_finn_integration.yml
+++ b/.github/workflows/reduced_finn_integration.yml
@@ -17,10 +17,14 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8']
+        python_version: ['3.9']
         pytorch_version: ['1.9.1', '1.13.0', '2.1.0']
         platform: ['ubuntu-latest']
 
+
+        exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
 
 
 

--- a/.github/workflows/reduced_notebook.yml
+++ b/.github/workflows/reduced_notebook.yml
@@ -23,6 +23,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/reduced_notebook.yml
+++ b/.github/workflows/reduced_notebook.yml
@@ -29,6 +29,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
           - platform: 'macos-latest'
 
 

--- a/.github/workflows/reduced_notebook.yml
+++ b/.github/workflows/reduced_notebook.yml
@@ -17,12 +17,15 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8']
+        python_version: ['3.9']
         pytorch_version: ['1.9.1', '1.13.0', '2.1.0']
         platform: ['ubuntu-latest']
 
 
         exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
+
           - platform: 'macos-latest'
 
 

--- a/.github/workflows/reduced_ort_integration.yml
+++ b/.github/workflows/reduced_ort_integration.yml
@@ -29,6 +29,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
 
 
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/reduced_ort_integration.yml
+++ b/.github/workflows/reduced_ort_integration.yml
@@ -23,6 +23,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/reduced_ort_integration.yml
+++ b/.github/workflows/reduced_ort_integration.yml
@@ -17,10 +17,14 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8']
+        python_version: ['3.9']
         pytorch_version: ['1.9.1', '1.13.0', '2.1.0']
         platform: ['ubuntu-latest']
 
+
+        exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
 
 
 

--- a/.github/workflows/reduced_pytest.yml
+++ b/.github/workflows/reduced_pytest.yml
@@ -17,11 +17,15 @@ jobs:
 
 
       matrix:
-        python_version: ['3.8']
+        python_version: ['3.9']
         pytorch_version: ['1.9.1', '1.13.0', '2.1.0']
         platform: ['ubuntu-latest']
         jit_status: ['jit_disabled']
 
+
+        exclude:
+          - python_version: '3.10'
+            pytorch_version: '1.9.1'
 
 
 

--- a/.github/workflows/reduced_pytest.yml
+++ b/.github/workflows/reduced_pytest.yml
@@ -24,6 +24,9 @@ jobs:
 
 
         exclude:
+          - pytorch_version: '1.9.1'
+            platform: 'macos-latest'
+
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 

--- a/.github/workflows/reduced_pytest.yml
+++ b/.github/workflows/reduced_pytest.yml
@@ -30,6 +30,9 @@ jobs:
           - python_version: '3.10'
             pytorch_version: '1.9.1'
 
+          - python_version: '3.10'
+            pytorch_version: '1.10.1'
+
 
 
     if: ${{ !github.event.pull_request.draft }}


### PR DESCRIPTION
Addressing issues in #906, #958 by simply removing `python=3.8` from tests and adding `python=3.10`.