### PR TITLE
Fix (requirements/setuptools): Set maximum requirement for `setuptools`

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 dependencies==2.0.1
 packaging
-setuptools>=0.70
+setuptools<70.0
 sympy
 torch>=1.9.1
 typing-extensions>=3.7.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 dependencies==2.0.1
 packaging
-setuptools
+setuptools>=0.70
 sympy
 torch>=1.9.1
 typing-extensions>=3.7.4


### PR DESCRIPTION
Fix issue with new version of setuptools:
```
ImportError: cannot import name 'packaging' from 'pkg_resources'
```

Which occurs on `setuptools==70.0.0`. Seems similar to [#15863](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15863)