### PR TITLE
Feat (tests): extended minifloat unit tests

### DIFF
--- a/tests/brevitas/core/minifloat_fixtures.py
+++ b/tests/brevitas/core/minifloat_fixtures.py
@@ -4,6 +4,9 @@
 import pytest_cases
 from pytest_cases import fixture_union
 
+from brevitas.inject import ExtendedInjector
+from brevitas.inject import value
+from brevitas.quant.experimental.float_base import FloatWeightBase
 from brevitas.quant.experimental.float_quant_ocp import Fp8e4m3OCPWeight
 from brevitas.quant.experimental.float_quant_ocp import Fp8e5m2OCPWeight
 
@@ -32,6 +35,51 @@ def fp8e5m2(sat):
     return Fp8e5m2
 
 
-list_of_fixtures = ['fp8e4m3', 'fp8e5m2']
+class Fp8CustomMixin(ExtendedInjector):
+    bit_width = 8
+    saturating = True
+
+    hypothesis_internal_is_this_a_mock_check = True
+
+    @value
+    def mantissa_bit_width(bit_width, exponent_bit_width):
+        return bit_width - exponent_bit_width - 1  # Sign bit
+
+
+class Fp8e7m0Weight(Fp8CustomMixin, FloatWeightBase):
+    exponent_bit_width = 7
+
+
+class Fp8e6m1Weight(Fp8CustomMixin, FloatWeightBase):
+    exponent_bit_width = 6
+
+
+class Fp8e3m4Weight(Fp8CustomMixin, FloatWeightBase):
+    exponent_bit_width = 3
+
+
+class Fp8e2m5Weight(Fp8CustomMixin, FloatWeightBase):
+    exponent_bit_width = 2
+
+
+class Fp8e1m6Weight(Fp8CustomMixin, FloatWeightBase):
+    exponent_bit_width = 1
+
+
+@pytest_cases.fixture
+@pytest_cases.parametrize('exponent_bit_width', [1, 2, 3, 6, 7])  # at least 1 exponent bit
+def fp8Custom(exponent_bit_width):
+
+    custom_exponents = {
+        1: Fp8e1m6Weight,
+        2: Fp8e2m5Weight,
+        3: Fp8e3m4Weight,
+        6: Fp8e6m1Weight,
+        7: Fp8e7m0Weight,}
+
+    return custom_exponents[exponent_bit_width]
+
+
+list_of_fixtures = ['fp8e4m3', 'fp8e5m2', 'fp8Custom']
 
 fp8_clamp = fixture_union('fp8_clamp', list_of_fixtures, ids=list_of_fixtures)

--- a/tests/brevitas/core/test_clamp.py
+++ b/tests/brevitas/core/test_clamp.py
@@ -8,15 +8,41 @@ import torch
 from brevitas.function.ops import max_float
 from brevitas.quant.experimental.float import Fp8e4m3Weight
 from brevitas.quant.experimental.float import Fp8e5m2Weight
+from brevitas.quant.experimental.float_quant_fnuz import Fp8e4m3FNUZWeight
+from brevitas.quant.experimental.float_quant_fnuz import Fp8e5m2FNUZWeight
 from brevitas.quant.experimental.float_quant_ocp import Fp8e4m3OCPWeight
 from brevitas.quant.experimental.float_quant_ocp import Fp8e5m2OCPWeight
 from brevitas.utils.float_quant_utils import get_max_available_float
+from brevitas.utils.float_quant_utils import get_min_available_float
 from tests.brevitas.hyp_helper import float_tensor_random_shape_st
 
 from .minifloat_fixtures import *
 
 FORMAT_MAXVAL_MAP = {
-    Fp8e5m2OCPWeight: 57344., Fp8e4m3OCPWeight: 448., Fp8e4m3Weight: 480., Fp8e5m2Weight: 114688.}
+    Fp8e5m2OCPWeight: 57344.,
+    Fp8e4m3OCPWeight: 448.,
+    Fp8e4m3Weight: 480.,
+    Fp8e5m2Weight: 114688.,
+    Fp8e4m3FNUZWeight: 240.,
+    Fp8e5m2FNUZWeight: 57344.,
+    Fp8e7m0Weight: 2.0 ** 64,  # Custom exponent_bit_width
+    Fp8e6m1Weight: 6442450944.0,
+    Fp8e3m4Weight: 31.0,
+    Fp8e2m5Weight: 7.875,
+    Fp8e1m6Weight: 3.96875}
+
+FORMAT_MINVAL_MAP = {
+    Fp8e5m2OCPWeight: 2.0 ** -16,
+    Fp8e4m3OCPWeight: 2.0 ** -9,
+    Fp8e4m3Weight: 2.0 ** -9,
+    Fp8e5m2Weight: 2.0 ** -16,
+    Fp8e4m3FNUZWeight: 2.0 ** -10,
+    Fp8e5m2FNUZWeight: 2.0 ** -17,
+    Fp8e7m0Weight: 2.0 ** -63,  # Custom exponent_bit_width
+    Fp8e6m1Weight: 2.0 ** -31,
+    Fp8e3m4Weight: 2.0 ** -6,
+    Fp8e2m5Weight: 2.0 ** -5,
+    Fp8e1m6Weight: 2.0 ** -5}
 
 
 @pytest.mark.parametrize(
@@ -38,6 +64,19 @@ def test_max_value(minifloat, expected_max_val):
     max_val = torch.min(max_val, max_available_float)
 
     assert expected_max_val == max_val
+
+
+@pytest.mark.parametrize(
+    'minifloat, expected_min_val',
+    ((format, min_val) for format, min_val in FORMAT_MINVAL_MAP.items()))
+def test_min_value(minifloat, expected_min_val):
+    min_val = get_min_available_float(
+        minifloat.exponent_bit_width,
+        minifloat.mantissa_bit_width,
+        minifloat.exponent_bias,
+    )
+
+    assert expected_min_val == min_val
 
 
 @given(inp=float_tensor_random_shape_st())


### PR DESCRIPTION
Adds the following changes in reference to Issue #975:

- Updated type hints for `get_max_available_float`
- Expanded `test_max_value` for FNUZ minifloat format and for minifloats with custom exponent bit-widths
- Added `test_min_value` which tests a minifloat's minimum subnormal value for correctness