### PR TITLE
Feat: Update LLM entry-point

### DIFF
--- a/src/brevitas_examples/llm/llm_quant/bias_corr.py
+++ b/src/brevitas_examples/llm/llm_quant/bias_corr.py
@@ -4,6 +4,7 @@ Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 """
 
 import torch
+from tqdm import tqdm
 
 from brevitas.graph.calibrate import bias_correction_mode
 
@@ -11,5 +12,5 @@ from brevitas.graph.calibrate import bias_correction_mode
 @torch.no_grad()
 def apply_bias_correction(model, dataloader):
     with bias_correction_mode(model):
-        for inps in dataloader:
+        for inps in tqdm(dataloader):
             model(**inps)

--- a/src/brevitas_examples/llm/llm_quant/data_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/data_utils.py
@@ -85,8 +85,8 @@ def get_dataset_for_model(
         for sample in data:
             sample["past_key_values"] = tuple(
                 (
-                    torch.zeros(1, num_kv_heads, 0, head_dim, device=sample["input_ids"].device),
-                    torch.zeros(1, num_kv_heads, 0, head_dim, device=sample["input_ids"].device),
+                    torch.zeros(1, num_kv_heads, 0, head_dim, device=sample["input_ids"].device, dtype=sample["input_ids"].dtype),
+                    torch.zeros(1, num_kv_heads, 0, head_dim, device=sample["input_ids"].device, dtype=sample["input_ids"].dtype),
                 )
                 for _ in range(num_layers)
             )

--- a/src/brevitas_examples/llm/llm_quant/data_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/data_utils.py
@@ -1,0 +1,96 @@
+"""
+Adapted from https://github.com/huggingface/optimum-amd, released under the following LICENSE:
+
+MIT License
+
+Copyright (c) 2023 Hugging Face
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from typing import Any, Optional, Union
+import random
+
+import numpy as np
+import torch
+
+from optimum.utils.normalized_config import NormalizedConfigManager
+from transformers import AutoConfig
+
+from optimum.amd.brevitas.data_utils import get_wikitext2
+from optimum.amd.brevitas.data_utils import get_c4
+from optimum.amd.brevitas.data_utils import DatasetToDevice
+
+
+def get_dataset_for_model(
+    model_name_or_path: str,
+    dataset_name: str,
+    tokenizer: Any,
+    nsamples: int = 128,
+    seqlen: int = 2048,
+    seed: int = 0,
+    split: str = "train",
+    fuse_sequences: bool = True,
+    require_fx: bool = False,
+    device: Optional[Union[str, torch.device]] = None,
+):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.random.manual_seed(seed)
+    get_dataset_map = {
+        "wikitext2": get_wikitext2,
+        "c4": get_c4,
+    }
+    if split not in ["train", "validation"]:
+        raise ValueError(f"The split need to be 'train' or 'validation' but found {split}")
+    if dataset_name not in get_dataset_map:
+        raise ValueError(f"Expected a value in {list(get_dataset_map.keys())} but found {dataset_name}")
+    get_dataset_fn = get_dataset_map[dataset_name]
+
+    data = get_dataset_fn(
+        tokenizer=tokenizer, nsamples=nsamples, seqlen=seqlen, split=split, fuse_sequences=fuse_sequences, seed=seed
+    )
+
+    # In case the dataset is loaded to be used with an fx.GraphModule, we need to add empty past_key_values inputs in the dataset.
+    if require_fx:
+        config = AutoConfig.from_pretrained(model_name_or_path)
+
+        normalized_config_class = NormalizedConfigManager.get_normalized_config_class(config.model_type)
+        normalized_config = normalized_config_class(config)
+
+        num_heads = normalized_config.num_attention_heads
+        if hasattr(normalized_config, "num_key_value_heads"):
+            num_kv_heads = normalized_config.num_key_value_heads
+        else:
+            num_kv_heads = num_heads
+        head_dim = normalized_config.hidden_size // num_heads
+        num_layers = normalized_config.num_layers
+
+        for sample in data:
+            sample["past_key_values"] = tuple(
+                (
+                    torch.zeros(1, num_kv_heads, 0, head_dim, device=sample["input_ids"].device),
+                    torch.zeros(1, num_kv_heads, 0, head_dim, device=sample["input_ids"].device),
+                )
+                for _ in range(num_layers)
+            )
+
+    data = DatasetToDevice(data, device=device)
+
+    return data

--- a/src/brevitas_examples/llm/llm_quant/eval.py
+++ b/src/brevitas_examples/llm/llm_quant/eval.py
@@ -34,12 +34,12 @@ def create_validation_dataloader(data, seqlen, device):
 @torch.no_grad()
 def model_eval(model, valenc, seqlen):
     nsamples = len(valenc)
-    dev = next(iter(model.parameters())).device
     with torch.no_grad():
         nlls = []
         for inps in valenc:
             lm_logits = model(**inps)['logits']
             shift_logits = lm_logits[:, :-1, :].contiguous()
+            dev = shift_logits.device
             shift_labels = inps['input_ids'][:, 1:].to(dev)
             loss_fct = nn.CrossEntropyLoss()
             loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -6,7 +6,6 @@ SPDX-License-Identifier: MIT
 import torch
 from torch import nn
 
-from brevitas.fx import value_trace
 from brevitas.graph.equalize import _is_reshaping_op
 from brevitas.graph.equalize import _is_scale_invariant_module
 from brevitas.graph.utils import get_module
@@ -84,9 +83,8 @@ def merge_layernorm_affine_params(graph_model):
 
 
 @torch.no_grad()
-def apply_layernorm_affine_merge(model, dtype, ref_kwargs):
+def apply_layernorm_affine_merge(graph_model, dtype):
     # We can't do fp16 tracing on CPU as many kernels are not implemented
     # So we have to cast to fp32 first, trace, apply merging, and then cast back
-    with cast_to_float32(model, dtype):
-        graph_model = value_trace(model, value_args=ref_kwargs)
+    with cast_to_float32(graph_model, dtype):
         merge_layernorm_affine_params(graph_model)

--- a/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
+++ b/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
@@ -1,5 +1,7 @@
 import warnings
 
+import torch
+
 from transformers.models.opt.modeling_opt import OPTAttention
 
 from brevitas.graph import ModuleToModuleByClass

--- a/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
+++ b/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
@@ -21,3 +21,17 @@ def replace_mha_with_quantizable_layers(model, dtype):
     for rewriter in rewriters:
         model = rewriter.apply(model)
     return model
+
+
+@torch.no_grad()
+def add_zero_bias_to_linear(model: torch.nn.Module) -> torch.nn.Module:
+    for name, module in model.named_modules():
+        if type(module) == torch.nn.Linear:
+            if module.bias is None:
+                module.register_parameter(
+                    "bias",
+                    torch.nn.Parameter(
+                        torch.zeros((module.weight.shape[0],), device=module.weight.device, dtype=module.weight.dtype)
+                    ),
+                )
+    return model

--- a/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
+++ b/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
@@ -1,7 +1,6 @@
 import warnings
 
 import torch
-
 from transformers.models.opt.modeling_opt import OPTAttention
 
 from brevitas.graph import ModuleToModuleByClass
@@ -33,7 +32,8 @@ def add_zero_bias_to_linear(model: torch.nn.Module) -> torch.nn.Module:
                 module.register_parameter(
                     "bias",
                     torch.nn.Parameter(
-                        torch.zeros((module.weight.shape[0],), device=module.weight.device, dtype=module.weight.dtype)
-                    ),
+                        torch.zeros((module.weight.shape[0],),
+                                    device=module.weight.device,
+                                    dtype=module.weight.dtype)),
                 )
     return model

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -406,7 +406,8 @@ def main():
             quantize_embedding=args.quantize_embedding)
         if not args.quantize_last_layer:
             name_blacklist += ["lm_head"]
-        model = layerwise_quantize(model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
+        model = layerwise_quantize(
+            model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
         # Tie back first/last layer weights in case they got untied
         print("Model quantization applied.")
 

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -31,8 +31,8 @@ from brevitas_examples.llm.llm_quant.export import BlockQuantProxyLevelManager
 from brevitas_examples.llm.llm_quant.export import brevitas_proxy_export_mode
 from brevitas_examples.llm.llm_quant.gptq import apply_gptq
 from brevitas_examples.llm.llm_quant.ln_affine_merge import apply_layernorm_affine_merge
-from brevitas_examples.llm.llm_quant.prepare_for_quantize import replace_mha_with_quantizable_layers
 from brevitas_examples.llm.llm_quant.prepare_for_quantize import add_zero_bias_to_linear
+from brevitas_examples.llm.llm_quant.prepare_for_quantize import replace_mha_with_quantizable_layers
 from brevitas_examples.llm.llm_quant.run_utils import cast_to_float32
 from brevitas_examples.llm.llm_quant.run_utils import CastFloat16ToFloat32
 from brevitas_examples.llm.llm_quant.run_utils import get_fx
@@ -50,7 +50,12 @@ parser.add_argument(
     '--nsamples', type=int, default=128, help='Number of calibration data samples. Default: 128.')
 parser.add_argument('--seqlen', type=int, default=2048, help='Sequence length. Default: 2048.')
 parser.add_argument('--eval', action='store_true', help='Eval model PPL on the chosen Dataset.')
-parser.add_argument('--dataset', type=str, choices=['wikitext2', 'c4'], default='wikitext2', help='Dataset to use for quantization (default: %(default)s)')
+parser.add_argument(
+    '--dataset',
+    type=str,
+    choices=['wikitext2', 'c4'],
+    default='wikitext2',
+    help='Dataset to use for quantization (default: %(default)s)')
 parser.add_argument('--weight-bit-width', type=int, default=8, help='Weight bit width. Default: 8.')
 parser.add_argument(
     '--weight-param-method',
@@ -177,17 +182,15 @@ parser.add_argument(
         'sharded_torchmlir_group_weight',
         'sharded_packed_torchmlir_group_weight'],
     help='Model export.')
-parser.add_argument('--checkpoint-name', type=str, default=None, help="Filename to save checkpoint. If `None`, no checkpoint is saved (default: %(default)s)")
+parser.add_argument(
+    '--checkpoint-name',
+    type=str,
+    default=None,
+    help="Filename to save checkpoint. If `None`, no checkpoint is saved (default: %(default)s)")
 add_bool_arg(
-    parser,
-    'use-ocp',
-    default=False,
-    help='Use OCP format for float quantization. Default: False')
+    parser, 'use-ocp', default=False, help='Use OCP format for float quantization. Default: False')
 add_bool_arg(
-    parser,
-    'use-fnuz',
-    default=True,
-    help='Use FNUZ format for float quantization. Default: True')
+    parser, 'use-fnuz', default=True, help='Use FNUZ format for float quantization. Default: True')
 
 
 def set_seed(seed):
@@ -324,7 +327,8 @@ def main():
     if args.eval:
         print("Float model eval...")
         model = offload_model(model)
-        ppl = compute_perplexity(model, validation_loader, context_length=args.seqlen // 2, tokenizer=tokenizer)
+        ppl = compute_perplexity(
+            model, validation_loader, context_length=args.seqlen // 2, tokenizer=tokenizer)
         remove_hooks(model)
         print(f"Float perplexity ({args.dataset}): {ppl}")
 
@@ -417,7 +421,8 @@ def main():
 
     if args.eval:
         print("Model eval...")
-        ppl = compute_perplexity(model, validation_loader, context_length=args.seqlen // 2, tokenizer=tokenizer)
+        ppl = compute_perplexity(
+            model, validation_loader, context_length=args.seqlen // 2, tokenizer=tokenizer)
         print(f"Quantized perplexity ({args.dataset}): {ppl}")
     remove_hooks(model)
 

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -327,6 +327,7 @@ def main():
     print("Data loaded.")
 
     if args.eval:
+        assert args.export_target != 'torch_qcdq', "TorchScript QCDQ export and Evaluation simultaneously"
         print("Float model eval...")
         model = offload_model(model)
         ppl = compute_perplexity(

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -179,7 +179,7 @@ add_bool_arg(
     parser,
     'use-ocp',
     default=False,
-    help='Use OCP format for float quantization. Default: True')
+    help='Use OCP format for float quantization. Default: False')
 add_bool_arg(
     parser,
     'use-fnuz',

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -363,9 +363,6 @@ def main():
     if args.act_equalization is None and not args.weight_equalization:
         model.tie_weights()
 
-    with cast_to_float32(model, dtype):
-        model(**calibration_loader[0])
-
     if args.bias_corr:
         model = add_zero_bias_to_linear(model)
 

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -146,8 +146,6 @@ parser.add_argument(
 parser.add_argument(
     '--quantize-input-zero-point', action='store_true', help='Quantize input zero-point.')
 parser.add_argument(
-    '--quantize-embedding', action='store_true', help='Quantize first nn.Embedding layer.')
-parser.add_argument(
     '--quantize-last-layer', action='store_true', help='Quantize last nn.Linear layer.')
 parser.add_argument('--gptq', action='store_true', help='Apply GPTQ.')
 parser.add_argument('--act-calibration', action='store_true', help='Apply activation calibration.')
@@ -403,7 +401,7 @@ def main():
             dtype=dtype,
             device=device,
             input_quant_format=args.input_quant_format,
-            quantize_embedding=args.quantize_embedding)
+            quantize_embedding=False)
         if not args.quantize_last_layer:
             name_blacklist += ["lm_head"]
         model = layerwise_quantize(

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -17,6 +17,7 @@ from transformers import AutoTokenizer
 from brevitas.export import export_torch_qcdq
 from brevitas.export.onnx.standard.qcdq.manager import StdQCDQONNXManager
 from brevitas_examples.common.generative.quantize import quantize_model
+from brevitas_examples.common.parse_utils import add_bool_arg
 from brevitas_examples.common.parse_utils import quant_format_validator
 from brevitas_examples.llm.llm_quant.bias_corr import apply_bias_correction
 from brevitas_examples.llm.llm_quant.calibrate import apply_calibration
@@ -174,6 +175,16 @@ parser.add_argument(
         'sharded_torchmlir_group_weight',
         'sharded_packed_torchmlir_group_weight'],
     help='Model export.')
+add_bool_arg(
+    parser,
+    'use-ocp',
+    default=False,
+    help='Use OCP format for float quantization. Default: True')
+add_bool_arg(
+    parser,
+    'use-fnuz',
+    default=True,
+    help='Use FNUZ format for float quantization. Default: True')
 
 
 def set_seed(seed):
@@ -338,7 +349,10 @@ def main():
             input_quant_granularity=args.input_quant_granularity,
             input_group_size=args.input_group_size,
             quantize_input_zero_point=args.quantize_input_zero_point,
-            quantize_embedding=args.quantize_embedding)
+            quantize_embedding=args.quantize_embedding,
+            use_ocp=args.use_ocp,
+            use_fnuz=args.use_fnuz,
+        )
         # Tie back first/last layer weights in case they got untied
         print("Model quantization applied.")
 

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -32,6 +32,7 @@ from brevitas_examples.llm.llm_quant.export import brevitas_proxy_export_mode
 from brevitas_examples.llm.llm_quant.gptq import apply_gptq
 from brevitas_examples.llm.llm_quant.ln_affine_merge import apply_layernorm_affine_merge
 from brevitas_examples.llm.llm_quant.prepare_for_quantize import replace_mha_with_quantizable_layers
+from brevitas_examples.llm.llm_quant.prepare_for_quantize import add_zero_bias_to_linear
 from brevitas_examples.llm.llm_quant.run_utils import cast_to_float32
 from brevitas_examples.llm.llm_quant.run_utils import CastFloat16ToFloat32
 from brevitas_examples.llm.llm_quant.run_utils import get_fx
@@ -364,6 +365,10 @@ def main():
 
     with cast_to_float32(model, dtype):
         model(**calibration_loader[0])
+
+    if args.bias_corr:
+        model = add_zero_bias_to_linear(model)
+
     model = offload_model(model)
 
     if args.act_calibration:

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -368,6 +368,7 @@ def main():
         remove_hooks(model)
 
     if not args.no_quantize:
+        name_blacklist = []
         print("Applying model quantization...")
         linear_input_quant, weight_quant, input_quant, q_scaled_quant, k_transposed_quant, v_quant, attn_output_weights_quant = generate_quantizers(
             dtype=dtype,
@@ -403,7 +404,9 @@ def main():
             device=device,
             input_quant_format=args.input_quant_format,
             quantize_embedding=args.quantize_embedding)
-        model = layerwise_quantize(model=model, compute_layer_map=layer_map, name_blacklist=None)
+        if not args.quantize_last_layer:
+            name_blacklist += ["lm_head"]
+        model = layerwise_quantize(model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
         # Tie back first/last layer weights in case they got untied
         print("Model quantization applied.")
 


### PR DESCRIPTION
Addresses #889. Updated entry-point to leverage many features of our optimum-amd integration effort, as well as update the example to use available quantizers. ~Builds on #977~ Now merged.

Todo:
 - [x] Use dataset utils from optimum-amd
 - [x] ~Update to use fx tracing method from optimum-amd~ Not necessary, already implemented
 - [x] Decompose quantizer generation and model quantization (like SDXL example)
 - [x] Test and fix all pre-quantization and PTQ techniques:
   - [x] `--ln-affine-merge` **fails**
   - [x] `--weight-equalization`
   - [x] `--act-equalization layerwise`
   - [x] `--act-equalization fx`
   - [x] `--bias-corr`
   - [x] `--act-calibration`
   - [x] `--gptq`
 - [x] Test `--replace-mha`
 - [ ] Update interface and add MX datatypes (depends on #971)
 - [ ] ~Allow optional quantization of first (embedded) layer~ Disabled, see [comment](https://github.com/Xilinx/brevitas/pull/987#issuecomment-2296316074)
 - [x] Allow optional quantization of the last layer
 - [x] Test various export flows:
   - [x] ONNX QCDQ
   - [x] torch QCDQ
   - [ ] ~torchmlir~ fails, won't fix in this PR
   - [ ] ~torchmlir (packed weights)~ fails, won't fix in this PR