### PR TITLE
Feat (mx): gptq compatibility and quant tests

### DIFF
--- a/src/brevitas/core/function_wrapper/shape.py
+++ b/src/brevitas/core/function_wrapper/shape.py
@@ -166,7 +166,7 @@ class OverSubChannelBlockView(brevitas.jit.ScriptModule):
     @brevitas.jit.script_method
     def forward(self, x: torch.Tensor):
         y = torch.nn.functional.pad(
-            x, padding(x, self.group_size, self.group_dim), mode='constant', value=0)
+            x, padding(x, self.group_size, self.group_dim), mode='constant', value=0.)
         y = y.view(self.expanded_groupwise_shape)
         return y
 
@@ -186,7 +186,7 @@ class DynamicOverSubChannelBlockView(brevitas.jit.ScriptModule):
         tensor_shape_list = list(tensor_shape)
         pad = padding(x, self.group_size, self.group_dim)
 
-        x = torch.nn.functional.pad(x, pad, mode='constant', value=0)
+        x = torch.nn.functional.pad(x, pad, mode='constant', value=0.)
 
         tensor_shape = x.shape
         tensor_shape_list = list(tensor_shape)

--- a/src/brevitas/core/function_wrapper/shape.py
+++ b/src/brevitas/core/function_wrapper/shape.py
@@ -154,11 +154,11 @@ class OverOutputFeaturesView(brevitas.jit.ScriptModule):
 
 
 class OverSubChannelBlockView(brevitas.jit.ScriptModule):
-    __constants__ = ['expanded_scaling_shape', 'group_size', 'group_dim']
+    __constants__ = ['expanded_groupwise_shape', 'group_size', 'group_dim']
 
-    def __init__(self, expanded_scaling_shape, group_size, group_dim) -> None:
+    def __init__(self, expanded_groupwise_shape, group_size, group_dim) -> None:
         super(OverSubChannelBlockView, self).__init__()
-        self.expanded_scaling_shape = expanded_scaling_shape
+        self.expanded_groupwise_shape = expanded_groupwise_shape
         self.group_dim = group_dim
         self.group_size = group_size
 
@@ -173,7 +173,7 @@ class OverSubChannelBlockView(brevitas.jit.ScriptModule):
     @brevitas.jit.script_method
     def forward(self, x: torch.Tensor):
         y = torch.nn.functional.pad(x, self.padding(x), mode='constant', value=0)
-        y = y.view(self.expanded_scaling_shape)
+        y = y.view(self.expanded_groupwise_shape)
         return y
 
 

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -189,7 +189,7 @@ def min_int(signed: bool, narrow_range: bool, bit_width: Tensor) -> Tensor:
     return value
 
 
-@brevitas.jit.script
+@brevitas.jit.ignore
 def max_float(exponent_bit_width: Tensor, mantissa_bit_width: Tensor, exponent_bias: Tensor):
     max_exponent = (2. ** exponent_bit_width) - 1. - exponent_bias
     max_mantissa = torch.sum((

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -238,8 +238,7 @@ class GPxQ(ABC):
         if isinstance(inp, IntQuantTensor):
             if is_quant_enabled and self.quant_metadata is None:
                 self.quant_metadata = _CachedIO(inp, metadata_only=True)
-            if isinstance(inp, QuantTensor):
-                inp = inp.value
+            inp = inp.value
 
         # If input is unbatched, add batch_size = 1
         if len(inp.shape) == 1:

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -204,7 +204,7 @@ class GPxQ(ABC):
             self.layer.in_channels = weight.shape[1] if is_conv_transposed(
                 self.layer) else weight.shape[0]
 
-        weight_shape = list(layer.weight.shape)
+        weight_shape = torch.tensor(layer.weight.shape)
 
         if create_weight_orig and not hasattr(self.layer, 'weight_orig'):
             self.layer.register_buffer('weight_orig', layer.weight.detach().clone())

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -11,14 +11,17 @@ from operator import attrgetter
 from typing import List, Optional, Set
 import warnings
 
+import torch
 from torch.fx import GraphModule as TorchGraphModule
 
 from brevitas.fx import GraphModule
 from brevitas.graph.calibrate import disable_return_quant_tensor
 from brevitas.graph.calibrate import DisableEnableQuantization
 from brevitas.graph.calibrate import restore_return_quant_tensor
+from brevitas.graph.utils import is_conv_transposed
 import brevitas.nn as qnn
 from brevitas.quant_tensor import IntQuantTensor
+from brevitas.quant_tensor.base_quant_tensor import QuantTensor
 from brevitas.utils.quant_utils import _CachedIO
 
 SUPPORTED_CONV_OP = (
@@ -194,8 +197,14 @@ class GPxQ(ABC):
         self.layer = layer
         self.name = name
         self.act_order = act_order
+        if self.layer.weight_quant.is_groupwise:
+            weight = self.layer.weight_quant.apply_input_view(self.layer.weight)
+            weight = weight.view(self.layer.weight_quant.quant_injector.reshaped_scaling_shape)
+            self.layer.weight.data = weight.data
+            self.layer.in_channels = weight.shape[1] if is_conv_transposed(
+                self.layer) else weight.shape[0]
 
-        weight = layer.weight.data
+        weight_shape = list(layer.weight.shape)
 
         if create_weight_orig and not hasattr(self.layer, 'weight_orig'):
             self.layer.register_buffer('weight_orig', layer.weight.detach().clone())
@@ -203,17 +212,14 @@ class GPxQ(ABC):
         # By default, use groups = 1
         self.groups = 1
         if isinstance(self.layer, SUPPORTED_CONV_OP):
-            if isinstance(
-                    self.layer,
-                (qnn.QuantConvTranspose1d, qnn.QuantConvTranspose2d, qnn.QuantConvTranspose3d)):
-                weight = weight.transpose(1, 0)  # This performs a view
-            weight = weight.flatten(1)
+            if is_conv_transposed(self.layer):
+                weight_shape[1], weight_shape[0] = weight_shape[0], weight_shape[1]
             self.groups = self.layer.groups
 
         # Number of rows is equal to the output channels (OC)
-        self.rows = weight.shape[0]
+        self.rows = weight_shape[0]
         # Number of columns is equal to the input channels (IC)
-        self.columns = weight.shape[1]
+        self.columns = torch.prod(weight_shape[1:])
         self.len_parallel_layers = len_parallel_layers
 
         self.disable_pre_forward_hook = False
@@ -232,7 +238,8 @@ class GPxQ(ABC):
         if isinstance(inp, IntQuantTensor):
             if is_quant_enabled and self.quant_metadata is None:
                 self.quant_metadata = _CachedIO(inp, metadata_only=True)
-            inp = inp.value
+            if isinstance(inp, QuantTensor):
+                inp = inp.value
 
         # If input is unbatched, add batch_size = 1
         if len(inp.shape) == 1:
@@ -262,17 +269,25 @@ class GPxQ(ABC):
         # For QuantLinear and for some QuantConvolutional layers, we exploit the possibility
         # of quantizing only a subset of the entire matrix speeding up the computation of GPxQ
         if isinstance(self.layer, qnn.QuantLinear):
-            index = permutation_list[0][i]
-            subtensor_slice_list = [None, (index, index + 1)]
-            q = self.layer.quant_weight(
-                subtensor_slice_list=subtensor_slice_list,
-                quant_input=self.quant_metadata).value.unsqueeze(0)  # [1, OC, 1]
+            if self.layer.weight_quant.is_groupwise:
+                # No slicing, not optimized
+                index = permutation_list[0][i]
+                q = self.layer.quant_weight(quant_input=self.quant_metadata).value.unsqueeze(
+                    0)  # [1, OC, 1]
+                q = q[:, :, i:i + 1]  # [groups, OC/groups, 1]
+            else:
+                index = permutation_list[0][i]
+                subtensor_slice_list = [None, (index, index + 1)]
+                q = self.layer.quant_weight(
+                    subtensor_slice_list=subtensor_slice_list,
+                    quant_input=self.quant_metadata).value.unsqueeze(0)  # [1, OC, 1]
         elif isinstance(self.layer, SUPPORTED_CONV_OP):
             # For depthwise and ConvTranspose we fall back to quantizing the entire martix.
             # For all other cases, we create a mask that represent the slicing we will perform on the weight matrix
             # and we quantize only the selected dimensions.
-            if self.groups > 1 or (self.groups == 1 and isinstance(
-                    self.layer, (qnn.QuantConvTranspose1d, qnn.QuantConvTranspose2d))):
+            if self.layer.weight_quant.is_groupwise or self.groups > 1 or (
+                    self.groups == 1 and
+                    isinstance(self.layer, (qnn.QuantConvTranspose1d, qnn.QuantConvTranspose2d))):
 
                 quant_weight = self.layer.quant_weight(quant_input=self.quant_metadata)
                 quant_weight = quant_weight.value

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -199,7 +199,7 @@ class GPxQ(ABC):
         self.act_order = act_order
         if self.layer.weight_quant.is_groupwise:
             weight = self.layer.weight_quant.apply_input_view(self.layer.weight)
-            weight = weight.view(self.layer.weight_quant.quant_injector.reshaped_scaling_shape)
+            weight = weight.view(self.layer.weight_quant.quant_injector.reshaped_groupwise_shape)
             self.layer.weight.data = weight.data
             self.layer.in_channels = weight.shape[1] if is_conv_transposed(
                 self.layer) else weight.shape[0]

--- a/src/brevitas/graph/utils.py
+++ b/src/brevitas/graph/utils.py
@@ -26,13 +26,13 @@ __all__ = [
     'get_output_channels',
     'get_output_channel_dim']
 
-CONV_TRANSPOSED = [
+CONV_TRANSPOSED = (
     nn.ConvTranspose1d,
     nn.ConvTranspose2d,
     nn.ConvTranspose3d,
     qnn.QuantConvTranspose1d,
     qnn.QuantConvTranspose2d,
-    qnn.QuantConvTranspose3d]
+    qnn.QuantConvTranspose3d)
 
 
 def module_class_name(m: torch.nn.Module):
@@ -146,7 +146,7 @@ def matches_module_pattern(pattern: Iterable, node: Node, modules: Dict[str, Any
 
 
 def is_conv_transposed(module):
-    return isinstance(module, tuple(CONV_TRANSPOSED))
+    return isinstance(module, CONV_TRANSPOSED)
 
 
 def get_output_channel_dim(module):

--- a/src/brevitas/jit.py
+++ b/src/brevitas/jit.py
@@ -14,6 +14,7 @@ if JIT_ENABLED:
 
     script_method = torch.jit.script_method
     script = torch.jit.script
+    ignore = torch.jit.ignore
     ScriptModule = torch.jit.ScriptModule
     Attribute = torch.jit.Attribute
 
@@ -21,5 +22,6 @@ else:
 
     script_method = _disabled
     script = _disabled
+    ignore = _disabled
     ScriptModule = torch.nn.Module
     Attribute = lambda val, type: val

--- a/src/brevitas/proxy/groupwise_float_parameter_quant.py
+++ b/src/brevitas/proxy/groupwise_float_parameter_quant.py
@@ -22,6 +22,11 @@ class GroupwiseWeightFloatQuantProxyFromInjector(WeightFloatQuantProxyFromInject
     def group_size(self):
         return self.quant_injector.group_size
 
+    def apply_input_view(self, x):
+        x = super().apply_input_view(x)
+        start_dim = self.group_dim if self.group_dim != -1 else -2
+        return x.flatten(start_dim, start_dim + 1)
+
     def create_quant_tensor(self, qt_args: Tuple[Any]) -> GroupwiseFloatQuantTensor:
         out, scale, zero_point, exponent_bit_width, mantissa_bit_width, exponent_bias, saturating, inf_values, nan_values = qt_args
         return GroupwiseFloatQuantTensor(

--- a/src/brevitas/proxy/groupwise_float_runtime_quant.py
+++ b/src/brevitas/proxy/groupwise_float_runtime_quant.py
@@ -21,6 +21,11 @@ class GroupwiseActFloatQuantProxyFromInjector(ActFloatQuantProxyFromInjectorBase
     def group_size(self):
         return self.quant_injector.group_size
 
+    def apply_input_view(self, x):
+        x = super().apply_input_view(x)
+        start_dim = self.group_dim if self.group_dim != -1 else -2
+        return x.flatten(start_dim, start_dim + 1)
+
     def create_quant_tensor(
             self,
             qt_args: Union[torch.Tensor, Tuple[Any]],

--- a/src/brevitas/proxy/groupwise_int_parameter_quant.py
+++ b/src/brevitas/proxy/groupwise_int_parameter_quant.py
@@ -22,6 +22,11 @@ class GroupwiseWeightQuantProxyFromInjector(WeightQuantProxyFromInjector):
     def group_size(self):
         return self.quant_injector.group_size
 
+    def apply_input_view(self, x):
+        x = super().apply_input_view(x)
+        start_dim = self.group_dim if self.group_dim != -1 else -2
+        return x.flatten(start_dim, start_dim + 1)
+
     def create_quant_tensor(self, qt_args: Tuple[Any]) -> GroupwiseIntQuantTensor:
         out, scale, zero_point, bit_width = qt_args
         return GroupwiseIntQuantTensor(

--- a/src/brevitas/proxy/groupwise_int_runtime_quant.py
+++ b/src/brevitas/proxy/groupwise_int_runtime_quant.py
@@ -21,6 +21,11 @@ class GroupwiseActQuantProxyFromInjector(ActQuantProxyFromInjector):
     def group_size(self):
         return self.quant_injector.group_size
 
+    def apply_input_view(self, x):
+        x = super().apply_input_view(x)
+        start_dim = self.group_dim if self.group_dim != -1 else -2
+        return x.flatten(start_dim, start_dim + 1)
+
     def create_quant_tensor(
             self,
             qt_args: Union[torch.Tensor, Tuple[Any]],

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -132,7 +132,7 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
                     self._cached_weight = self.cache_class(
                         out.detach(), metadata_only=self.cache_inference_quant_weight_metadata_only)
         else:  # quantization disabled
-            out = x
+            out = self.apply_input_view(x)
         return out
 
 

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -14,6 +14,7 @@ from brevitas.common import ExportMixin
 from brevitas.core.utils import StatelessBuffer
 from brevitas.inject import BaseInjector as Injector
 from brevitas.utils.quant_utils import float_to_int_impl_to_enum
+from brevitas.core.scaling import ScalingPerOutputType
 
 __all__ = [
     'QuantProxyProtocol',
@@ -21,10 +22,7 @@ __all__ = [
 
 
 def _is_groupwise(quant_injector):
-    if 'group_size' in quant_injector:
-        return True
-    else:
-        return False
+    return 'scaling_per_output' in quant_injector and quant_injector.scaling_per_output == ScalingPerOutputType.GROUP
 
 
 def _is_narrow_range(quant_injector):

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -11,10 +11,10 @@ from typing_extensions import runtime_checkable
 
 from brevitas import config
 from brevitas.common import ExportMixin
+from brevitas.core.scaling import ScalingPerOutputType
 from brevitas.core.utils import StatelessBuffer
 from brevitas.inject import BaseInjector as Injector
 from brevitas.utils.quant_utils import float_to_int_impl_to_enum
-from brevitas.core.scaling import ScalingPerOutputType
 
 __all__ = [
     'QuantProxyProtocol',
@@ -120,6 +120,9 @@ class QuantProxyFromInjector(ExportMixin, nn.Module, QuantProxyProtocol):
             self.init_tensor_quant()
         else:
             raise RuntimeError("Trying to add None as a parent module.")
+
+    def apply_input_view(self, x):
+        return self.quant_injector.input_view_impl(x)
 
     def _load_from_state_dict(
             self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -168,7 +168,9 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         elif not self.is_quant_enabled:
             # A tuple helps later with control flows
             # The second None value is used later
-            y = (self.fused_activation_quant_proxy.activation_impl(y), None)
+            # If quant is not enabled, we still apply input_view in the case of groupwise + padding
+            y = self.apply_input_view(self.fused_activation_quant_proxy.activation_impl(y))
+            y = (y, None)
         else:
             y = self.fused_activation_quant_proxy(y)
         # If y is an empty QuantTensor, we need to check if this is a passthrough proxy,

--- a/src/brevitas/quant/solver/parameter.py
+++ b/src/brevitas/quant/solver/parameter.py
@@ -109,6 +109,7 @@ class SolveParameterScalingImplFromEnum(SolveAffineRescalingFromEnum):
 
 
 class SolveParameterScalingShape(ExtendedInjector):
+
     @value
     def scaling_shape(weight_shape, group_dim, group_size=None, scaling_per_output=None):
         if scaling_per_output == ScalingPerOutputType.TENSOR:

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -104,6 +104,7 @@ def float_internal_scale(
     return internal_scale
 
 
+@brevitas.jit.ignore
 def padding(x, group_size, group_dim):
     # Given a tensor X, compute the padding aloing group_dim so that groupwise shaping is possible
     padding = [0, 0] * len(x.shape)

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 from torch.nn import Sequential
@@ -105,7 +105,7 @@ def float_internal_scale(
 
 
 @brevitas.jit.ignore
-def padding(x, group_size, group_dim):
+def padding(x: torch.Tensor, group_size: int, group_dim: int) -> List[int]:
     # Given a tensor X, compute the padding aloing group_dim so that groupwise shaping is possible
     padding = [0, 0] * len(x.shape)
     size = x.shape

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -102,3 +102,13 @@ def float_internal_scale(
     internal_scale = torch.clamp_min(internal_scale, fp_internal_scale_min)
     internal_scale = torch.exp2(internal_scale)
     return internal_scale
+
+
+def padding(x, group_size, group_dim):
+    # Given a tensor X, compute the padding aloing group_dim so that groupwise shaping is possible
+    padding = [0, 0] * len(x.shape)
+    size = x.shape
+    if size[group_dim] % group_size != 0:
+        padding[2 * group_dim] = group_size - size[group_dim] % group_size
+    padding = list(reversed(padding))
+    return padding

--- a/tests/brevitas/graph/equalization_fixtures.py
+++ b/tests/brevitas/graph/equalization_fixtures.py
@@ -384,7 +384,7 @@ RESNET_18_REGIONS = [
     [('layer4.0.bn2', 'layer4.0.downsample.1', 'layer4.1.bn2'), ('fc', 'layer4.1.conv1')],]
 
 
-input_quant, weight_quant = pytest_cases.param_fixtures("input_quant, weight_quant", [(Int8ActPerTensorFloat, Int8WeightPerTensorFloat), (MXInt8Act, MXInt8Weight), (MXFloat8e4m3Act, MXFloat8e4m3Weight)])
+input_quant, weight_quant = pytest_cases.param_fixtures("input_quant, weight_quant", [(None, Int8WeightPerTensorFloat), (Int8ActPerTensorFloat, Int8WeightPerTensorFloat), (MXInt8Act, MXInt8Weight), (MXFloat8e4m3Act, MXFloat8e4m3Weight)])
 
 
 @pytest_cases.fixture
@@ -439,7 +439,7 @@ def quant_residual_model(input_quant, weight_quant):
                 3, 16, kernel_size=1, input_quant=input_quant, weight_quant=weight_quant)
             self.conv_0 = qnn.QuantConv2d(
                 16, 3, kernel_size=1, input_quant=input_quant, weight_quant=weight_quant)
-            self.relu = qnn.QuantReLU(return_quant_tensor=True)
+            self.relu = qnn.QuantReLU(return_quant_tensor=input_quant != None)
 
         def forward(self, x):
             start = x
@@ -447,6 +447,7 @@ def quant_residual_model(input_quant, weight_quant):
             x = self.relu(x)
             x = self.conv_0(x)
             x = start + x
+
             return x
 
     return QuantResidualModel
@@ -459,7 +460,7 @@ def quant_convtranspose_model(input_quant, weight_quant):
 
         def __init__(self) -> None:
             super().__init__()
-            self.relu = qnn.QuantReLU(return_quant_tensor=True)
+            self.relu = qnn.QuantReLU(return_quant_tensor=input_quant != None)
             self.conv_0 = qnn.QuantConvTranspose2d(
                 in_channels=3,
                 out_channels=8,

--- a/tests/brevitas/graph/equalization_fixtures.py
+++ b/tests/brevitas/graph/equalization_fixtures.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 from packaging import version
 import pytest
 import pytest_cases
@@ -9,12 +8,16 @@ from pytest_cases import fixture_union
 import torch
 import torch.nn as nn
 from torchvision import models
-from brevitas.quant.experimental.mx_quant_ocp import MXInt8Act, MXInt8Weight, MXFloat8e4m3Act, MXFloat8e4m3Weight
 
 from brevitas import torch_version
 from brevitas.graph.equalize import _cross_layer_equalization
 import brevitas.nn as qnn
 from brevitas.quant import Int8ActPerTensorFloat
+from brevitas.quant.experimental.mx_quant_ocp import MXFloat8e4m3Act
+from brevitas.quant.experimental.mx_quant_ocp import MXFloat8e4m3Weight
+from brevitas.quant.experimental.mx_quant_ocp import MXInt8Act
+from brevitas.quant.experimental.mx_quant_ocp import MXInt8Weight
+from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 
 SEED = 123456
 ATOL = 1e-3
@@ -383,6 +386,7 @@ RESNET_18_REGIONS = [
 
 input_quant, weight_quant = pytest_cases.param_fixtures("input_quant, weight_quant", [(Int8ActPerTensorFloat, Int8WeightPerTensorFloat), (MXInt8Act, MXInt8Weight), (MXFloat8e4m3Act, MXFloat8e4m3Weight)])
 
+
 @pytest_cases.fixture
 def quant_conv_with_input_quant_model(input_quant, weight_quant):
 
@@ -392,7 +396,8 @@ def quant_conv_with_input_quant_model(input_quant, weight_quant):
             super().__init__()
             self.conv_0 = qnn.QuantConv2d(
                 3, 16, kernel_size=3)  # gpxq tests assume no quant on first layer
-            self.conv_1 = qnn.QuantConv2d(16, 32, kernel_size=3, input_quant=input_quant, weight_quant=weight_quant)
+            self.conv_1 = qnn.QuantConv2d(
+                16, 32, kernel_size=3, input_quant=input_quant, weight_quant=weight_quant)
 
         def forward(self, x):
             x = self.conv_0(x)
@@ -430,8 +435,10 @@ def quant_residual_model(input_quant, weight_quant):
 
         def __init__(self) -> None:
             super().__init__()
-            self.conv = qnn.QuantConv2d(3, 16, kernel_size=1, input_quant=input_quant, weight_quant=weight_quant)
-            self.conv_0 = qnn.QuantConv2d(16, 3, kernel_size=1, input_quant=input_quant, weight_quant=weight_quant)
+            self.conv = qnn.QuantConv2d(
+                3, 16, kernel_size=1, input_quant=input_quant, weight_quant=weight_quant)
+            self.conv_0 = qnn.QuantConv2d(
+                16, 3, kernel_size=1, input_quant=input_quant, weight_quant=weight_quant)
             self.relu = qnn.QuantReLU(return_quant_tensor=True)
 
         def forward(self, x):
@@ -453,8 +460,18 @@ def quant_convtranspose_model(input_quant, weight_quant):
         def __init__(self) -> None:
             super().__init__()
             self.relu = qnn.QuantReLU(return_quant_tensor=True)
-            self.conv_0 = qnn.QuantConvTranspose2d(in_channels=3, out_channels=8, kernel_size=3, input_quant=input_quant, weight_quant=weight_quant)
-            self.conv_1 = qnn.QuantConvTranspose2d(in_channels=8, out_channels=32, kernel_size=3, input_quant=input_quant, weight_quant=weight_quant)
+            self.conv_0 = qnn.QuantConvTranspose2d(
+                in_channels=3,
+                out_channels=8,
+                kernel_size=3,
+                input_quant=input_quant,
+                weight_quant=weight_quant)
+            self.conv_1 = qnn.QuantConvTranspose2d(
+                in_channels=8,
+                out_channels=32,
+                kernel_size=3,
+                input_quant=input_quant,
+                weight_quant=weight_quant)
 
         def forward(self, x):
             x = self.conv_0(x)

--- a/tests/brevitas/graph/test_gpxq.py
+++ b/tests/brevitas/graph/test_gpxq.py
@@ -122,7 +122,8 @@ def test_toymodels(
                 act_order=act_order,
                 use_quant_activations=use_quant_activations)
 
-    elif (name == 'gpfq') and (acc_bit_width < 32) and (not use_quant_activations or input_quant == 'None'):
+    elif (name == 'gpfq') and (acc_bit_width < 32) and (not use_quant_activations or
+                                                        input_quant == 'None'):
         # GPFA2Q requires that the quant activations are used. GPFA2Q.single_layer_update will
         # raise a ValueError if GPFA2Q.quant_input is None (also see GPxQ.process_input). This will
         # happen when `use_quant_activations=False` or when the input to a model is not quantized

--- a/tests/brevitas/nn/test_nn_quantizers.py
+++ b/tests/brevitas/nn/test_nn_quantizers.py
@@ -173,11 +173,6 @@ def test_quant_mha(model_input, current_cases):
     args = case_id.split('-')[1:]  # Exclude first argument
     kwargs = parse_args(args)
 
-    # TODO: restore compatibility
-    skipped_quant = ['quant_mx', 'quant_float']
-    if kwargs['io_quant'] in skipped_quant or kwargs['weight_quant'] in skipped_quant:
-        pytest.skip("MX and Float quant not supported for MHA")
-
     is_input_quanttensor = kwargs['io_quant'] is not None or kwargs['input_quantized']
     if (not is_input_quanttensor or
             kwargs['weight_quant'] is None) and kwargs['bias_quant'] == 'quant_external':

--- a/tests/brevitas/nn/test_nn_quantizers.py
+++ b/tests/brevitas/nn/test_nn_quantizers.py
@@ -172,6 +172,12 @@ def test_quant_mha(model_input, current_cases):
     case_id = get_case_id(cases_generator_func)
     args = case_id.split('-')[1:]  # Exclude first argument
     kwargs = parse_args(args)
+
+    # TODO: restore compatibility
+    skipped_quant = ['quant_mx', 'quant_float']
+    if kwargs['io_quant'] in skipped_quant or kwargs['weight_quant'] in skipped_quant:
+        pytest.skip("MX and Float quant not supported for MHA")
+
     is_input_quanttensor = kwargs['io_quant'] is not None or kwargs['input_quantized']
     if (not is_input_quanttensor or
             kwargs['weight_quant'] is None) and kwargs['bias_quant'] == 'quant_external':


### PR DESCRIPTION
Depends on #1011 and #1012

Added tests for MX and FloatQuant, with some restrictions;
- Neither support external bias quantization at the moment
- Compatibility with MHA is limited due to how the various quant options interact with each-other
- MX quantizers need to be paired to account for the possibility of padding (to be revisited post-release)
- MX quantizers are not JIT compatible