### PR TITLE
Decoupled PerChannel/PerTensor quantization

### DIFF
--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -366,9 +366,9 @@ class AccumulatorAwareZeroCenterPerChannelPreNorm(AccumulatorAwarePerChannelPreN
 
     pre_scaling_impl = AccumulatorAwareZeroCenterParameterPreScaling
     pre_zero_point_impl = PreZeroCenterZeroPoint
-    pre_zero_point_shape = this.scaling_shape  # TODO: decouple zero_point from scaling
+    pre_zero_point_shape = this.pre_scaling_shape  # TODO: decouple zero_point from scaling
     pre_zero_point_stats_input_view_shape_impl = this.scaling_stats_input_view_shape_impl
-    stats_reduce_dim = (this << 1).stats_reduce_dim
+    stats_reduce_dim = SCALING_STATS_REDUCE_DIM
     scaling_shape = (this << 1).scaling_shape
 
 

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -53,7 +53,7 @@ from brevitas.inject.enum import ScalingPerOutputType
 from brevitas.inject.enum import StatsOp
 from brevitas.proxy import DecoupledWeightQuantProxyFromInjector
 from brevitas.proxy import DecoupledWeightQuantWithInputProxyFromInjector
-from brevitas.quant.solver.common import SolveStatsReduceDimFromEnum
+from brevitas.quant.solver.common import SolveScalingStatsInputViewShapeImplFromEnum, SolveStatsReduceDimFromEnum
 from brevitas.quant.solver.parameter import SolveInputViewImpl
 from brevitas.quant.solver.parameter import SolveParameterScalingShape
 from brevitas.quant.solver.weight import SolveWeightScalingPerOutputChannelShapeFromModule
@@ -334,8 +334,21 @@ class WeightPerChannelFloatDecoupled(SolveStatsReduceDimFromEnum,
     stats_reduce_dim = SCALING_STATS_REDUCE_DIM
     scaling_per_output_type = ScalingPerOutputType.CHANNEL
 
+class PerChannelL2Norm(ExtendedInjector):
+    stats_reduce_dim = SCALING_STATS_REDUCE_DIM
+    normalize_stats_impl = L2Norm
+
+class PerChannelPreNorm(ExtendedInjector):
+
+    pre_scaling_impl = ParameterPreScalingWeightNorm
+    scaling_stats_input_view_shape_impl = OverOutputChannelView
+    scaling_impl = (this<<1).scaling_impl
+    normalize_stats_impl = (this<<1).normalize_stats_impl
+    tracked_parameter_list = (this<<1).tracked_parameter_list
+    pre_scaling_shape = (this<<1).pre_scaling_shape
 
 class WeightNormPerChannelFloatDecoupled(SolveStatsReduceDimFromEnum,
+                                         SolveScalingStatsInputViewShapeImplFromEnum,
                                          SolveWeightScalingStatsInputDimsFromModule,
                                          SolveWeightScalingPerOutputChannelShapeFromModule,
                                          SolveParameterScalingShape,
@@ -359,6 +372,8 @@ class WeightNormPerChannelFloatDecoupled(SolveStatsReduceDimFromEnum,
         scales = scaling_init_impl.parameter_list_stats() / (pow(2., bit_width - 1.) - 1.)
         return scales
 
+    per_channel_pre_norm = PerChannelPreNorm
+
     proxy_class = DecoupledWeightQuantProxyFromInjector
     tensor_quant = DecoupledRescalingIntQuant
     decoupled_int_quant = DecoupledIntQuant
@@ -367,21 +382,24 @@ class WeightNormPerChannelFloatDecoupled(SolveStatsReduceDimFromEnum,
     scaling_init_impl = StatsFromParameterScaling
     restrict_scaling_impl = LogFloatRestrictValue
     scaling_stats_impl = AbsMax
-    pre_scaling_impl = ParameterPreScalingWeightNorm
     restrict_pre_scaling_impl = LogFloatRestrictValue
-    normalize_stats_impl = L2Norm
-    scaling_per_output_type = ScalingPerOutputType.CHANNEL
-    pre_scaling_shape = this.scaling_shape  # TODO: decouple pre_scaling_shape from scaling_shape
+    normalize_stats_impl = PerChannelL2Norm.normalize_stats_impl
+    scaling_per_output_type = ScalingPerOutputType.TENSOR
+    pre_scaling_shape = this.scaling_per_output_channel_shape
     int_scaling_impl = SingleArgStatelessBuffer(1.)
     zero_point_impl = ZeroZeroPoint
     pre_zero_point_impl = ZeroZeroPoint
     bit_width_impl = BitWidthConst
     narrow_range = True
     signed = True
-    scaling_stats_input_view_shape_impl = OverOutputChannelView
-    stats_reduce_dim = SCALING_STATS_REDUCE_DIM
+    scaling_stats_input_view_shape_impl = StatsInputViewShapeImpl.OVER_TENSOR
+    stats_reduce_dim = None
     scaling_min_val = 1e-10
     pre_scaling_min_val = 1e-10
+
+    @value 
+    def pre_scaling_impl():
+        return this.per_channel_pre_norm.pre_scaling_impl
 
 
 class AccumulatorAwareWeightQuant(WeightNormPerChannelFloatDecoupled):

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -348,6 +348,7 @@ class PerChannelPreNorm(ExtendedInjector):
     normalize_stats_impl = (this << 1).normalize_stats_impl
     tracked_parameter_list = (this << 1).tracked_parameter_list
     pre_scaling_shape = (this << 1).pre_scaling_shape
+    permute_dims = (this << 1).permute_dims
 
 
 class SolvePostScaleGranularity(ExtendedInjector):

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -481,6 +481,10 @@ class AccumulatorAwareZeroCenterWeightQuant(AccumulatorAwareWeightQuant):
     """
     per_channel_pre_norm = AccumulatorAwareZeroCenterPerChannelPreNorm
 
+    @value
+    def pre_zero_point_impl():
+        return this.per_channel_pre_norm.pre_zero_point_impl
+
 
 class MSESubInjectorBase(ExtendedInjector):
 

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -53,7 +53,6 @@ from brevitas.inject.enum import ScalingPerOutputType
 from brevitas.inject.enum import StatsOp
 from brevitas.proxy import DecoupledWeightQuantProxyFromInjector
 from brevitas.proxy import DecoupledWeightQuantWithInputProxyFromInjector
-from brevitas.quant.solver.common import SolveScalingStatsInputViewShapeImplFromEnum
 from brevitas.quant.solver.common import SolveStatsReduceDimFromEnum
 from brevitas.quant.solver.parameter import SolveInputViewImpl
 from brevitas.quant.solver.parameter import SolveParameterScalingShape
@@ -370,7 +369,6 @@ class SolvePostScaleGranularity(ExtendedInjector):
 
 class WeightNormPerChannelFloatDecoupled(SolvePostScaleGranularity,
                                          SolveStatsReduceDimFromEnum,
-                                         SolveScalingStatsInputViewShapeImplFromEnum,
                                          SolveWeightScalingStatsInputDimsFromModule,
                                          SolveWeightScalingPerOutputChannelShapeFromModule,
                                          SolveParameterScalingShape,

--- a/tests/brevitas/export/quant_module_fixture.py
+++ b/tests/brevitas/export/quant_module_fixture.py
@@ -7,6 +7,7 @@ from pytest_cases import set_case_id
 import torch
 from torch import nn
 
+from brevitas.inject.enum import ScalingPerOutputType
 from brevitas.nn import QuantConv1d
 from brevitas.nn import QuantConv2d
 from brevitas.nn import QuantConv3d
@@ -16,12 +17,11 @@ from brevitas.nn import QuantConvTranspose3d
 from brevitas.nn import QuantIdentity
 from brevitas.nn import QuantLinear
 from brevitas.nn import TruncAvgPool2d
-from brevitas.inject.enum import ScalingPerOutputType
-from brevitas.quant.scaled_int import Int8AccumulatorAwareZeroCenterWeightQuant
 from brevitas.quant.fixed_point import Int8ActPerTensorFixedPoint
 from brevitas.quant.fixed_point import Int8WeightPerChannelFixedPoint
 from brevitas.quant.fixed_point import Int8WeightPerTensorFixedPoint
 from brevitas.quant.scaled_int import Int8AccumulatorAwareWeightQuant
+from brevitas.quant.scaled_int import Int8AccumulatorAwareZeroCenterWeightQuant
 from brevitas.quant.scaled_int import Int8ActPerTensorFloat
 from brevitas.quant.scaled_int import Int8BiasPerTensorFloatInternalScaling
 from brevitas.quant.scaled_int import Int8WeightPerChannelFloat
@@ -41,13 +41,16 @@ FEATURES = 5
 KERNEL_SIZE = 3
 TOLERANCE = 1
 
+
 class Int8AccumulatorawareZeroCenterWeightQuantPerTensorFloat(
         Int8AccumulatorAwareZeroCenterWeightQuant):
     scaling_per_output_type = ScalingPerOutputType.TENSOR
 
+
 A2Q_QUANTIZERS = {
     'a2q_per_channel_float': (Int8AccumulatorAwareWeightQuant, Int8ActPerTensorFloat),
-    'a2q_plus_per_tensor_float': (Int8AccumulatorawareZeroCenterWeightQuantPerTensorFloat, Int8ActPerTensorFloat)}
+    'a2q_plus_per_tensor_float':
+        (Int8AccumulatorawareZeroCenterWeightQuantPerTensorFloat, Int8ActPerTensorFloat)}
 
 QUANTIZERS = {
     'asymmetric_per_tensor_float':

--- a/tests/brevitas/export/quant_module_fixture.py
+++ b/tests/brevitas/export/quant_module_fixture.py
@@ -16,6 +16,8 @@ from brevitas.nn import QuantConvTranspose3d
 from brevitas.nn import QuantIdentity
 from brevitas.nn import QuantLinear
 from brevitas.nn import TruncAvgPool2d
+from brevitas.inject.enum import ScalingPerOutputType
+from brevitas.quant.scaled_int import Int8AccumulatorAwareZeroCenterWeightQuant
 from brevitas.quant.fixed_point import Int8ActPerTensorFixedPoint
 from brevitas.quant.fixed_point import Int8WeightPerChannelFixedPoint
 from brevitas.quant.fixed_point import Int8WeightPerTensorFixedPoint
@@ -39,6 +41,14 @@ FEATURES = 5
 KERNEL_SIZE = 3
 TOLERANCE = 1
 
+class Int8AccumulatorawareZeroCenterWeightQuantPerTensorFloat(
+        Int8AccumulatorAwareZeroCenterWeightQuant):
+    scaling_per_output_type = ScalingPerOutputType.TENSOR
+
+A2Q_QUANTIZERS = {
+    'a2q_per_channel_float': (Int8AccumulatorAwareWeightQuant, Int8ActPerTensorFloat),
+    'a2q_plus_per_tensor_float': (Int8AccumulatorawareZeroCenterWeightQuantPerTensorFloat, Int8ActPerTensorFloat)}
+
 QUANTIZERS = {
     'asymmetric_per_tensor_float':
         (ShiftedUint8WeightPerTensorFloat, ShiftedUint8ActPerTensorFloat),
@@ -46,14 +56,15 @@ QUANTIZERS = {
     'asymmetric_per_channel_float':
         (ShiftedUint8WeightPerChannelFloat, ShiftedUint8ActPerTensorFloat),
     'symmetric_per_channel_float': (Int8WeightPerChannelFloat, Int8ActPerTensorFloat),
-    'a2q': (Int8AccumulatorAwareWeightQuant, Int8ActPerTensorFloat),
     'symmetric_per_tensor_fixed_point': (Int8WeightPerTensorFixedPoint, Int8ActPerTensorFixedPoint),
     'symmetric_per_channel_fixed_point':
-        (Int8WeightPerChannelFixedPoint, Int8ActPerTensorFixedPoint)}
+        (Int8WeightPerChannelFixedPoint, Int8ActPerTensorFixedPoint),
+    **A2Q_QUANTIZERS}
 
 BIAS_QUANTIZERS = {
     'bias_external_scale': (Int32Bias,),
     'bias_internal_scale': (Int8BiasPerTensorFloatInternalScaling,)}
+
 QUANT_WBIOL_IMPL = [
     QuantLinear,
     QuantConv1d,
@@ -62,6 +73,7 @@ QUANT_WBIOL_IMPL = [
     QuantConvTranspose1d,
     QuantConvTranspose2d,
     QuantConvTranspose3d,]
+
 BIT_WIDTHS = [4, 8, 10]  # below 8, equal 8, above 8
 BIAS_BIT_WIDTHS = [8, 16, 32]
 
@@ -99,6 +111,12 @@ def bias_bit_width(bit_width):
 @fixture
 @parametrize('quantizers', QUANTIZERS.items(), ids=list(QUANTIZERS.keys()))
 def weight_act_quantizers(quantizers):
+    return quantizers
+
+
+@fixture
+@parametrize('quantizers', A2Q_QUANTIZERS.items(), ids=list(A2Q_QUANTIZERS.keys()))
+def a2q_weight_act_quantizers(quantizers):
     return quantizers
 
 

--- a/tests/brevitas/export/test_qonnx_export.py
+++ b/tests/brevitas/export/test_qonnx_export.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+
 import torch
 
 from brevitas.export import enable_debug
@@ -80,6 +81,7 @@ def test_generic_decoupled_quant_linear_export():
     model(inp)  # collect scale factors
     model.eval()
     export_qonnx(model, inp, export_path='generic_decoupled_quant_linear.onnx')
+
 
 @jit_disabled_for_export()
 def test_a2q_quant_linear_export(a2q_weight_act_quantizers):

--- a/tests/brevitas/export/test_qonnx_export.py
+++ b/tests/brevitas/export/test_qonnx_export.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
 import torch
 
 from brevitas.export import enable_debug
@@ -9,13 +10,14 @@ from brevitas.export import export_qonnx
 from brevitas.nn import QuantConv2d
 from brevitas.nn import QuantIdentity
 from brevitas.nn import QuantLinear
-from brevitas.nn import QuantReLU
 from brevitas.nn import TruncAvgPool2d
 from brevitas.quant.scaled_int import Int4WeightPerTensorFloatDecoupled
 from brevitas.quant.scaled_int import Int8ActPerTensorFloat
 from brevitas.quant.scaled_int import Int16Bias
 from brevitas_examples import imagenet_classification
 from tests.marker import jit_disabled_for_export
+
+from .quant_module_fixture import *
 
 OUT_CH = 50
 IN_CH = 40
@@ -48,6 +50,7 @@ def test_generic_quant_linear_export():
     model(inp)  # collect scale factors
     model.eval()
     export_qonnx(model, inp, export_path='generic_quant_linear.onnx')
+    os.remove('generic_quant_linear.onnx')
 
 
 @jit_disabled_for_export()
@@ -77,6 +80,36 @@ def test_generic_decoupled_quant_linear_export():
     model(inp)  # collect scale factors
     model.eval()
     export_qonnx(model, inp, export_path='generic_decoupled_quant_linear.onnx')
+
+@jit_disabled_for_export()
+def test_a2q_quant_linear_export(a2q_weight_act_quantizers):
+    IN_SIZE = (2, IN_CH)
+
+    _, (weight_quant, io_quant) = a2q_weight_act_quantizers
+
+    class Model(torch.nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.linear = QuantLinear(
+                out_features=OUT_CH,
+                in_features=IN_CH,
+                bias=True,
+                input_quant=io_quant,
+                output_quant=io_quant,
+                weight_quant=weight_quant,
+                bias_quant=Int16Bias,
+                return_quant_tensor=False)
+            self.linear.weight.data.uniform_(-0.1, 0.1)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    inp = torch.randn(IN_SIZE)
+    model = Model()
+    model(inp)  # collect scale factors
+    model.eval()
+    export_qonnx(model, inp, export_path='a2q_quant_linear.onnx')
 
 
 @jit_disabled_for_export()

--- a/tests/brevitas/nn/nn_quantizers_fixture.py
+++ b/tests/brevitas/nn/nn_quantizers_fixture.py
@@ -54,8 +54,7 @@ class Int8WeightNormL2PerChannelPerTensorFixedPoint(Int8WeightNormL2PerChannelFi
     scaling_per_output_type = ScalingPerOutputType.TENSOR
 
 
-class Int8AccumulatorAwareWeightQuantPerTensorFloat(
-        Int8AccumulatorAwareWeightQuant):
+class Int8AccumulatorAwareWeightQuantPerTensorFloat(Int8AccumulatorAwareWeightQuant):
     scaling_per_output_type = ScalingPerOutputType.TENSOR
 
 

--- a/tests/brevitas/nn/nn_quantizers_fixture.py
+++ b/tests/brevitas/nn/nn_quantizers_fixture.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 
 from brevitas import torch_version
 import brevitas.config as config
+from brevitas.inject.enum import ScalingPerOutputType
 from brevitas.nn import QuantConv1d
 from brevitas.nn import QuantConv2d
 from brevitas.nn import QuantConv3d
@@ -48,6 +49,11 @@ KERNEL_SIZE = 3
 EMBED_DIM = 9
 NUM_HEADS = 3
 
+
+class Int8WeightNormL2PerChannelPerTensorFixedPoint(Int8WeightNormL2PerChannelFixedPoint):
+    scaling_per_output_type = ScalingPerOutputType.TENSOR
+
+
 LSTM_WEIGHT_QUANTIZER = {
     'None': None,
     'quant_sym': Int8WeightPerTensorFloat,
@@ -62,6 +68,7 @@ WBIOL_WEIGHT_QUANTIZER = {
     'quant_sym': Int8WeightPerTensorFloat,
     'quant_asym': ShiftedUint8WeightPerTensorFloat,
     'quant_decoupled': Int8WeightNormL2PerChannelFixedPoint,
+    'quant_decoupled_per_tensor': Int8WeightNormL2PerChannelPerTensorFixedPoint,
     'quant_mx': MXInt8Weight,
     'quant_float': Fp8e4m3WeightPerTensorFloat,
     **A2Q_WBIOL_WEIGHT_QUANTIZER}

--- a/tests/brevitas/nn/nn_quantizers_fixture.py
+++ b/tests/brevitas/nn/nn_quantizers_fixture.py
@@ -54,6 +54,16 @@ class Int8WeightNormL2PerChannelPerTensorFixedPoint(Int8WeightNormL2PerChannelFi
     scaling_per_output_type = ScalingPerOutputType.TENSOR
 
 
+class Int8AccumulatorAwareWeightQuantPerTensorFloat(
+        Int8AccumulatorAwareWeightQuant):
+    scaling_per_output_type = ScalingPerOutputType.TENSOR
+
+
+class Int8AccumulatorawareZeroCenterWeightQuantPerTensorFloat(
+        Int8AccumulatorAwareZeroCenterWeightQuant):
+    scaling_per_output_type = ScalingPerOutputType.TENSOR
+
+
 LSTM_WEIGHT_QUANTIZER = {
     'None': None,
     'quant_sym': Int8WeightPerTensorFloat,
@@ -61,7 +71,9 @@ LSTM_WEIGHT_QUANTIZER = {
 
 A2Q_WBIOL_WEIGHT_QUANTIZER = {
     'quant_a2q': Int8AccumulatorAwareWeightQuant,
-    'quant_a2q_plus': Int8AccumulatorAwareZeroCenterWeightQuant}
+    'quant_a2q_per_tensor': Int8AccumulatorAwareWeightQuantPerTensorFloat,
+    'quant_a2q_plus': Int8AccumulatorAwareZeroCenterWeightQuant,
+    'quant_a2q_plus_per_tensor': Int8AccumulatorawareZeroCenterWeightQuantPerTensorFloat}
 
 WBIOL_WEIGHT_QUANTIZER = {
     'None': None,


### PR DESCRIPTION
To have a decouple per channel pre-scale, and per tensor post scale:
```python
class Int8WeightNormL2PerChannelPerTensorFixedPoint(Int8WeightNormL2PerChannelFixedPoint):
    scaling_per_output_type = ScalingPerOutputType.TENSOR

```

It currently works for all quantizers that inherit from `WeightNormPerChannelFloatDecoupled`

It can be extended to other decoupled quantization quantizers if needed