### PR TITLE
Fix (proxy): fix for float quant properties is_ocp and is_fnuz

### DIFF
--- a/src/brevitas/proxy/float_parameter_quant.py
+++ b/src/brevitas/proxy/float_parameter_quant.py
@@ -66,7 +66,7 @@ class WeightFloatQuantProxyFromInjectorBase(WeightQuantProxyFromInjectorBase, AB
         is_e4m3 = self.mantissa_bit_width() == 3 and self.exponent_bit_width() == 4
         is_ocp_e4m3 = is_e4m3 and self.inf_values() is None and self.nan_values() == (('111',))
 
-        is_e5m2 = self.mantissa_bit_width() == 5 and self.exponent_bit_width() == 2
+        is_e5m2 = self.mantissa_bit_width() == 2 and self.exponent_bit_width() == 5
         is_ocp_e5m2 = is_e5m2 and self.inf_values() == (
             ('00',)) and self.nan_values() == ('01', '11', '10')
 
@@ -78,7 +78,7 @@ class WeightFloatQuantProxyFromInjectorBase(WeightQuantProxyFromInjectorBase, AB
         is_fnuz_e4m3 = is_e4m3 and self.inf_values() is None and self.nan_values(
         ) is None and self.exponent_bias() == 8
 
-        is_e5m2 = self.mantissa_bit_width() == 5 and self.exponent_bit_width() == 2
+        is_e5m2 = self.mantissa_bit_width() == 2 and self.exponent_bit_width() == 5
         is_fnuz_e5m2 = is_e5m2 and self.inf_values() is None and self.nan_values(
         ) is None and self.exponent_bias() == 16
         return is_fnuz_e4m3 or is_fnuz_e5m2

--- a/src/brevitas/proxy/float_runtime_quant.py
+++ b/src/brevitas/proxy/float_runtime_quant.py
@@ -41,7 +41,7 @@ class ActFloatQuantProxyFromInjectorBase(ActQuantProxyFromInjectorBase, ABC):
         is_e4m3 = self.mantissa_bit_width() == 3 and self.exponent_bit_width() == 4
         is_ocp_e4m3 = is_e4m3 and self.inf_values() is None and self.nan_values() == (('111',))
 
-        is_e5m2 = self.mantissa_bit_width() == 5 and self.exponent_bit_width() == 2
+        is_e5m2 = self.mantissa_bit_width() == 2 and self.exponent_bit_width() == 5
         is_ocp_e5m2 = is_e5m2 and self.inf_values() == (
             ('00',)) and self.nan_values() == ('01', '11', '10')
 
@@ -53,7 +53,7 @@ class ActFloatQuantProxyFromInjectorBase(ActQuantProxyFromInjectorBase, ABC):
         is_fnuz_e4m3 = is_e4m3 and self.inf_values() is None and self.nan_values(
         ) is None and self.exponent_bias() == 8
 
-        is_e5m2 = self.mantissa_bit_width() == 5 and self.exponent_bit_width() == 2
+        is_e5m2 = self.mantissa_bit_width() == 2 and self.exponent_bit_width() == 5
         is_fnuz_e5m2 = is_e5m2 and self.inf_values() is None and self.nan_values(
         ) is None and self.exponent_bias() == 16
         return is_fnuz_e4m3 or is_fnuz_e5m2


### PR DESCRIPTION
Fixes issue #1027 and float quant proxies now check that `mantissa_bit_width = 2` and `exponent_bit_width = 5` when determining if an FP8E5M2 minifloat is OCP or FNUZ.