### PR TITLE
Fix (minifloat): correct minifloat computation and tests

### DIFF
--- a/src/brevitas/quant_tensor/float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/float_quant_tensor.py
@@ -103,8 +103,9 @@ class FloatQuantTensor(FloatQuantTensorBase, QuantTensor):
             scale = self.scale.type(torch.float32)
         minifloat_value = value / scale
         fp_internal_scale = 1. - self.exponent_bias - self.mantissa_bit_width
+        eps = torch.finfo(self.scale.dtype).tiny
         int_scale = float_internal_scale(
-            self.value, self.mantissa_bit_width, fp_internal_scale, self.eps)
+            self.value / self.scale, self.mantissa_bit_width, fp_internal_scale, eps)
         minifloat_value = minifloat_value / int_scale
         return minifloat_value
 
@@ -140,8 +141,9 @@ class FloatQuantTensor(FloatQuantTensorBase, QuantTensor):
 
         if self.is_valid:
             fp_internal_scale = 1. - self.exponent_bias - self.mantissa_bit_width
+            eps = torch.finfo(self.scale.dtype).tiny
             int_scale = float_internal_scale(
-                self.value, self.mantissa_bit_width, fp_internal_scale, self.eps)
+                self.value / self.scale, self.mantissa_bit_width, fp_internal_scale, eps)
             float_value = torch.round(self._pre_round_float_value) * int_scale
             return float_value.type(self.scale.dtype)
         else:

--- a/src/brevitas/quant_tensor/float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/float_quant_tensor.py
@@ -103,9 +103,9 @@ class FloatQuantTensor(FloatQuantTensorBase, QuantTensor):
             scale = self.scale.type(torch.float32)
         minifloat_value = value / scale
         fp_internal_scale = 1. - self.exponent_bias - self.mantissa_bit_width
-        eps = torch.finfo(self.scale.dtype).tiny
+        eps = torch.finfo(scale.dtype).tiny
         int_scale = float_internal_scale(
-            self.value / self.scale, self.mantissa_bit_width, fp_internal_scale, eps)
+            minifloat_value, self.mantissa_bit_width, fp_internal_scale, eps)
         minifloat_value = minifloat_value / int_scale
         return minifloat_value
 
@@ -138,12 +138,17 @@ class FloatQuantTensor(FloatQuantTensorBase, QuantTensor):
     def minifloat(self, float_datatype=True):
         # TODO: Check if OCP and cast to proper data-type if matching
         assert float_datatype, "Minifloat quant returns only higher precision dtype"
-
         if self.is_valid:
+            value = self.value
+            scale = self.scale
+            if self.scale.dtype == torch.bfloat16:
+                value = self.value.type(torch.float32)
+                scale = self.scale.type(torch.float32)
+            minifloat_value = value / scale
             fp_internal_scale = 1. - self.exponent_bias - self.mantissa_bit_width
-            eps = torch.finfo(self.scale.dtype).tiny
+            eps = torch.finfo(scale.dtype).tiny
             int_scale = float_internal_scale(
-                self.value / self.scale, self.mantissa_bit_width, fp_internal_scale, eps)
+                minifloat_value, self.mantissa_bit_width, fp_internal_scale, eps)
             float_value = torch.round(self._pre_round_float_value) * int_scale
             return float_value.type(self.scale.dtype)
         else:

--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -144,7 +144,9 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, QuantTensor):
             scale = scale.type(torch.float32)
         minifloat_value = value / scale
         fp_internal_scale = 1. - self.exponent_bias - self.mantissa_bit_width
-        int_scale = float_internal_scale(self.value, self.mantissa_bit_width, fp_internal_scale)
+        eps = torch.finfo(self.scale_.dtype).tiny
+        int_scale = float_internal_scale(
+            self.value / self.scale, self.mantissa_bit_width, fp_internal_scale, eps)
         minifloat_value = minifloat_value / int_scale
         return minifloat_value
 
@@ -180,7 +182,9 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, QuantTensor):
 
         if self.is_valid:
             fp_internal_scale = 1. - self.exponent_bias - self.mantissa_bit_width
-            int_scale = float_internal_scale(self.value, self.mantissa_bit_width, fp_internal_scale)
+            eps = torch.finfo(self.scale_.dtype).tiny
+            int_scale = float_internal_scale(
+                self.value / self.scale, self.mantissa_bit_width, fp_internal_scale, eps)
             float_value = torch.round(self._pre_round_float_value) * int_scale
             return float_value.type(self.scale.dtype)
         else:


### PR DESCRIPTION
## Reason for this PR

Current minifloat computation is broken for minifloat and groupwise minifloat

## Changes Made in this PR

Correct computation and tests

## Testing Summary

The new test check that `minifloat` method can be called without error


## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
