### PR TITLE
Feat (export): qonnx minifloat export

### DIFF
--- a/src/brevitas/export/onnx/qonnx/function.py
+++ b/src/brevitas/export/onnx/qonnx/function.py
@@ -71,6 +71,7 @@ class BrevitasFloatQuantFn(Function):
             exponent_bias,
             has_inf,
             has_nan,
+            saturating,
             has_subnormal,
             rounding_mode,
             max_val):
@@ -81,11 +82,12 @@ class BrevitasFloatQuantFn(Function):
             exponent_bit_width,
             mantissa_bit_width,
             exponent_bias,
+            max_val,
             has_inf_i=int(has_inf),
             has_nan_i=int(has_nan),
             has_subnormal_i=int(has_subnormal),
             rounding_mode_s=rounding_mode,
-            max_val_f=max_val)
+            saturation_i=saturating)
         ret.setType(x.type())
         return ret
 
@@ -99,6 +101,7 @@ class BrevitasFloatQuantFn(Function):
             exponent_bias,
             has_inf,
             has_nan,
+            saturating,
             has_subnormal,
             rounding_mode,
             max_val):

--- a/src/brevitas/export/onnx/qonnx/function.py
+++ b/src/brevitas/export/onnx/qonnx/function.py
@@ -59,6 +59,52 @@ class BrevitasQuantFn(Function):
         return y
 
 
+class BrevitasFloatQuantFn(Function):
+
+    @staticmethod
+    def symbolic(
+            g,
+            x,
+            scale,
+            exponent_bit_width,
+            mantissa_bit_width,
+            exponent_bias,
+            has_inf,
+            has_nan,
+            has_subnormal,
+            rounding_mode,
+            max_val):
+        ret = g.op(
+            f'{DOMAIN_STRING}::FloatQuant',
+            x,
+            scale,
+            exponent_bit_width,
+            mantissa_bit_width,
+            exponent_bias,
+            has_inf_i=int(has_inf),
+            has_nan_i=int(has_nan),
+            has_subnormal_i=int(has_subnormal),
+            rounding_mode_s=rounding_mode,
+            max_val_f=max_val)
+        ret.setType(x.type())
+        return ret
+
+    @staticmethod
+    def forward(
+            g,
+            x,
+            scale,
+            exponent_bit_width,
+            mantissa_bit_width,
+            exponent_bias,
+            has_inf,
+            has_nan,
+            has_subnormal,
+            rounding_mode,
+            max_val):
+        return x
+
+
 class BrevitasTruncFn(Function):
 
     @staticmethod

--- a/src/brevitas/export/onnx/qonnx/handler.py
+++ b/src/brevitas/export/onnx/qonnx/handler.py
@@ -43,7 +43,7 @@ class BrevitasFloatQuantProxyHandler(ONNXBaseHandler, ABC):
                 'saturating': module.is_saturating(),
                 'has_subnormal': True,  # Currently we only support subnormal
                 'rounding_mode': module.rounding_mode,
-                'max_float': module.quant_injector.max_available_float}
+                'max_float': torch.tensor(module.quant_injector.max_available_float).type_as(module.scale())}
             self.return_args = {
                 'scale': module.scale(),
                 'zero_point': torch.zeros_like(module.scale()),
@@ -84,7 +84,7 @@ class BrevitasWeightFloatQuantProxyHandler(BrevitasFloatQuantProxyHandler):
                 'saturating': first_qweight.saturating,
                 'has_subnormal': True,  # Currently we only support subnormal
                 'rounding_mode': module.rounding_mode,
-                'max_float': module.quant_injector.max_available_float,}
+                'max_float': torch.tensor(module.quant_injector.max_available_float).type_as(first_qweight.scale)}
             self.return_args = {
                 'scale': first_qweight.scale,
                 'zero_point': torch.zeros_like(first_qweight.scale),

--- a/src/brevitas/export/onnx/qonnx/handler.py
+++ b/src/brevitas/export/onnx/qonnx/handler.py
@@ -56,7 +56,8 @@ class BrevitasFloatQuantProxyHandler(ONNXBaseHandler, ABC):
 
     def symbolic_execution(self, x: Tensor):
         x = BrevitasFloatQuantFn.apply(x, *self.symbolic_kwargs.values())
-        return x, *self.return_args.values()
+        return_args = (x, *self.return_args.values())
+        return return_args
 
 
 class BrevitasWeightFloatQuantProxyHandler(BrevitasFloatQuantProxyHandler):

--- a/src/brevitas/export/onnx/qonnx/handler.py
+++ b/src/brevitas/export/onnx/qonnx/handler.py
@@ -34,16 +34,26 @@ class BrevitasFloatQuantProxyHandler(ONNXBaseHandler, ABC):
         if module.is_quant_enabled:
             self.validate(module)
             self.symbolic_kwargs = {
-                'scale': module.scale(),
-                'exponent_bit_width': module.exponent_bit_width(),
-                'mantissa_bit_width': module.mantissa_bit_width(),
-                'exponent_bias': module.exponent_bias(),
-                'has_inf': module.inf_values() is not None,
-                'has_nan': module.nan_values() is not None,
-                'saturating': module.is_saturating(),
-                'has_subnormal': True,  # Currently we only support subnormal
-                'rounding_mode': module.rounding_mode,
-                'max_float': torch.tensor(module.quant_injector.max_available_float).type_as(module.scale())}
+                'scale':
+                    module.scale(),
+                'exponent_bit_width':
+                    module.exponent_bit_width(),
+                'mantissa_bit_width':
+                    module.mantissa_bit_width(),
+                'exponent_bias':
+                    module.exponent_bias(),
+                'has_inf':
+                    module.inf_values() is not None,
+                'has_nan':
+                    module.nan_values() is not None,
+                'saturating':
+                    module.is_saturating(),
+                'has_subnormal':
+                    True,  # Currently we only support subnormal
+                'rounding_mode':
+                    module.rounding_mode,
+                'max_float':
+                    torch.tensor(module.quant_injector.max_available_float).type_as(module.scale())}
             self.return_args = {
                 'scale': module.scale(),
                 'zero_point': torch.zeros_like(module.scale()),
@@ -75,16 +85,27 @@ class BrevitasWeightFloatQuantProxyHandler(BrevitasFloatQuantProxyHandler):
             first_qweight = module.tracked_module_list[0].quant_weight()
             self.validate(first_qweight.zero_point)
             self.symbolic_kwargs = {
-                'scale': first_qweight.scale,
-                'exponent_bit_width': first_qweight.exponent_bit_width,
-                'mantissa_bit_width': first_qweight.mantissa_bit_width,
-                'exponent_bias': first_qweight.exponent_bias,
-                'has_inf': first_qweight.inf_values is not None,
-                'has_nan': first_qweight.nan_values is not None,
-                'saturating': first_qweight.saturating,
-                'has_subnormal': True,  # Currently we only support subnormal
-                'rounding_mode': module.rounding_mode,
-                'max_float': torch.tensor(module.quant_injector.max_available_float).type_as(first_qweight.scale)}
+                'scale':
+                    first_qweight.scale,
+                'exponent_bit_width':
+                    first_qweight.exponent_bit_width,
+                'mantissa_bit_width':
+                    first_qweight.mantissa_bit_width,
+                'exponent_bias':
+                    first_qweight.exponent_bias,
+                'has_inf':
+                    first_qweight.inf_values is not None,
+                'has_nan':
+                    first_qweight.nan_values is not None,
+                'saturating':
+                    first_qweight.saturating,
+                'has_subnormal':
+                    True,  # Currently we only support subnormal
+                'rounding_mode':
+                    module.rounding_mode,
+                'max_float':
+                    torch.tensor(module.quant_injector.max_available_float
+                                ).type_as(first_qweight.scale)}
             self.return_args = {
                 'scale': first_qweight.scale,
                 'zero_point': torch.zeros_like(first_qweight.scale),

--- a/src/brevitas/export/onnx/qonnx/manager.py
+++ b/src/brevitas/export/onnx/qonnx/manager.py
@@ -17,12 +17,14 @@ from .function import BrevitasBinaryQuantFn
 from .function import BrevitasQuantFn
 from .function import BrevitasQuantLSTMCellFn
 from .function import BrevitasTruncFn
+from .handler import BrevitasActFloatQuantProxyHandler
 from .handler import BrevitasActQuantProxyHandler
 from .handler import BrevitasBiasQuantProxyHandler
 from .handler import BrevitasDecoupledWeightQuantProxyHandler
 from .handler import BrevitasDecoupledWeightQuantWithInputProxyHandler
 from .handler import BrevitasQuantLSTMLayerHandler
 from .handler import BrevitasTruncQuantProxyHandler
+from .handler import BrevitasWeightFloatQuantProxyHandler
 from .handler import BrevitasWeightQuantProxyHandler
 
 
@@ -42,7 +44,9 @@ class QONNXManager(ONNXBaseManager):
         BrevitasDecoupledWeightQuantProxyHandler,
         BrevitasDecoupledWeightQuantWithInputProxyHandler,
         BrevitasTruncQuantProxyHandler,
-        BrevitasQuantLSTMLayerHandler]
+        BrevitasQuantLSTMLayerHandler,
+        BrevitasWeightFloatQuantProxyHandler,
+        BrevitasActFloatQuantProxyHandler]
 
     custom_fns = [
         DebugMarkerFunction,

--- a/tests/brevitas/export/test_onnx_fp8.py
+++ b/tests/brevitas/export/test_onnx_fp8.py
@@ -7,6 +7,7 @@ import torch
 
 from brevitas import torch_version
 from brevitas.export import export_onnx_qcdq
+from brevitas.export import export_qonnx
 import brevitas.nn as qnn
 from brevitas.quant.experimental.float_quant_ocp import Fp8e4m3OCPActPerTensorFloat
 from brevitas.quant.experimental.float_quant_ocp import Fp8e4m3OCPWeightPerTensorFloat
@@ -20,6 +21,17 @@ def test_simple_fp8_export():
 
     model = qnn.QuantLinear(3, 16, weight_quant=Fp8e4m3OCPWeightPerTensorFloat)
     export_onnx_qcdq(model, torch.randn(1, 3), 'weight_fp8.onnx', export_weight_q_node=True)
+    assert True
+
+
+@jit_disabled_for_export()
+def test_qonnx_simple_fp8_export():
+    if torch_version < version.parse('2.1.0'):
+        pytest.skip(f"OCP FP8 types not supported by {torch_version}")
+
+    model = qnn.QuantLinear(
+        3, 16, weight_quant=Fp8e4m3OCPWeightPerTensorFloat, input_quant=Fp8e4m3OCPActPerTensorFloat)
+    export_qonnx(model, torch.randn(1, 3), 'qonnx_act_weight_fp8.onnx')
     assert True
 
 


### PR DESCRIPTION
## Reason for this PR
Minifloat export to QONNX

## Changes Made in this PR

Extended QONNX export to support Weight/Activations export of generic minifloat

## Testing Summary

Simple test to generate the ONNX file. Since we don't have the corresponding mathematical implementation, we can't verify the math.

## Risk Highlight
 
We can only rely on visual inspection of the ONNX.


## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [x] Post-review full CI/CD passing.


@maltanar 