### PR TITLE
Fix: correct output scale compute

### DIFF
--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -22,7 +22,8 @@ from brevitas.quant_tensor import _unpack_quant_tensor
 from brevitas.quant_tensor import IntQuantTensor
 from brevitas.quant_tensor import QuantTensor
 from brevitas.utils.quant_utils import _CachedIO
-from brevitas.utils.torch_utils import compute_channel_view_shape, is_broadcastable
+from brevitas.utils.torch_utils import compute_channel_view_shape
+from brevitas.utils.torch_utils import is_broadcastable
 
 from .quant_proxy import QuantProxyFromInjector
 from .quant_proxy import QuantProxyProtocol

--- a/src/brevitas/quant_tensor/int_torch_handler.py
+++ b/src/brevitas/quant_tensor/int_torch_handler.py
@@ -234,8 +234,6 @@ def quant_output_scale_impl(
     output_scale_shape = compute_channel_view_shape(inp, channel_dim=channel_dim)
 
     quant_weight_scale = quant_weight_scale.view(output_scale_shape)
-    if len(quant_input_scale.shape) == 0:
-        quant_input_scale = quant_input_scale.view(output_scale_shape)
     quant_input_scale = quant_input_scale.view(output_scale_shape)
     if not is_broadcastable(quant_weight_scale.shape, quant_input_scale.shape):
         return None

--- a/src/brevitas/quant_tensor/int_torch_handler.py
+++ b/src/brevitas/quant_tensor/int_torch_handler.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 
 from brevitas.function.ops import max_int
 from brevitas.function.ops_ste import ceil_ste
-from brevitas.utils.torch_utils import compute_channel_view_shape
+from brevitas.utils.torch_utils import compute_channel_view_shape, is_broadcastable
 
 INT_QUANT_TENSOR_FN_HANDLER = {}
 
@@ -198,6 +198,9 @@ def quant_layer(fn, quant_input, quant_weight, bias, *args, **kwargs):
                                                        (quant_weight.zero_point != 0.0).any()):
             warnings.warn("Computing zero point of output accumulator not supported yet.")
             compute_output_quant_tensor = False
+        if output_scale is None:
+            warnings.warn("Could not compute output scale factor, returning Tensor")
+            compute_output_quant_tensor = False
 
     if compute_output_quant_tensor:
         if output_zero_point is None:
@@ -232,6 +235,9 @@ def quant_output_scale_impl(
     quant_weight_scale = quant_weight_scale.view(output_scale_shape)
     if len(quant_input_scale.shape) == 0:
         quant_input_scale = quant_input_scale.view(output_scale_shape)
+    quant_input_scale = quant_input_scale.view(output_scale_shape)
+    if not is_broadcastable(output_scale_shape, quant_input_scale.shape):
+        return None
 
     output_scale = quant_weight_scale * quant_input_scale
     return output_scale

--- a/src/brevitas/quant_tensor/int_torch_handler.py
+++ b/src/brevitas/quant_tensor/int_torch_handler.py
@@ -9,7 +9,8 @@ import torch.nn.functional as F
 
 from brevitas.function.ops import max_int
 from brevitas.function.ops_ste import ceil_ste
-from brevitas.utils.torch_utils import compute_channel_view_shape, is_broadcastable
+from brevitas.utils.torch_utils import compute_channel_view_shape
+from brevitas.utils.torch_utils import is_broadcastable
 
 INT_QUANT_TENSOR_FN_HANDLER = {}
 

--- a/src/brevitas/quant_tensor/int_torch_handler.py
+++ b/src/brevitas/quant_tensor/int_torch_handler.py
@@ -237,7 +237,7 @@ def quant_output_scale_impl(
     if len(quant_input_scale.shape) == 0:
         quant_input_scale = quant_input_scale.view(output_scale_shape)
     quant_input_scale = quant_input_scale.view(output_scale_shape)
-    if not is_broadcastable(output_scale_shape, quant_input_scale.shape):
+    if not is_broadcastable(quant_weight_scale.shape, quant_input_scale.shape):
         return None
 
     output_scale = quant_weight_scale * quant_input_scale

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -113,3 +113,11 @@ def padding(x: torch.Tensor, group_size: int, group_dim: int) -> List[int]:
         padding[2 * group_dim] = group_size - size[group_dim] % group_size
     padding = list(reversed(padding))
     return padding
+
+def is_broadcastable(tensor, other):
+    for a, b in zip(tensor[::-1], other[::-1]):
+        if a == 1 or b == 1 or a == b:
+            pass
+        else:
+            return False
+    return True

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -114,6 +114,7 @@ def padding(x: torch.Tensor, group_size: int, group_dim: int) -> List[int]:
     padding = list(reversed(padding))
     return padding
 
+
 def is_broadcastable(tensor, other):
     for a, b in zip(tensor[::-1], other[::-1]):
         if a == 1 or b == 1 or a == b:


### PR DESCRIPTION
## Reason for this PR

There is a bug when computing output scale factor, when the input scale is quantized per-row and the weights are quantized per channel

## Changes Made in this PR

Resolves the issue by skipping scale factor computation in this case. This means that we cannot have a properly formed quant tensor with this quantization strategy.
In theory, if I am not hallucinating, the math would results in a per-element scale factor, but we need to decide whether it's worth keeping track of this since any operation with such QuantTensor would results in dequantize.

## Testing Summary
None

## Risk Highlight

NA

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
