### PR TITLE
Fix (data): updating wikitext2 data utility

### DIFF
--- a/src/brevitas_examples/llm/llm_quant/data_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/data_utils.py
@@ -30,10 +30,11 @@ from typing import Any, Optional, Union
 import numpy as np
 from optimum.amd.brevitas.data_utils import DatasetToDevice
 from optimum.amd.brevitas.data_utils import get_c4
-from optimum.amd.brevitas.data_utils import get_wikitext2
 from optimum.utils.normalized_config import NormalizedConfigManager
 import torch
 from transformers import AutoConfig
+
+from .data import get_wikitext2
 
 
 def get_dataset_for_model(


### PR DESCRIPTION
## Reason for this PR

Update the wikitext2 data utility to work within the latest LLM quantization entry point. This version of the wikitext2 data loader uses the whole test dataset without random subsampling, which affords us more consistent benchmarking.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

Integrated the data pre-processing into the `get_wikitext2` function.

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

N/A 

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

N/A

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
