### PR TITLE
Fix (per_group): fixing the per_group sym quantizer

### DIFF
--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -181,7 +181,8 @@ INPUT_QUANT_MAP = {
         'dynamic': {
             'float_scale': {
                 'stats': {
-                    'per_group': Fp8e4m3DynamicActPerGroupFloat}}},
+                    'per_group': {
+                        'sym': Fp8e4m3DynamicActPerGroupFloat}}}},
         'no_scale': {
             'sym': Fp8e4m3Act,}},
     'float_ocp': {


### PR DESCRIPTION
## Reason for this PR

Fixing the nested hierarchy for pre-packaged quantizers in brevitas_examples.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

Added "sym" for dynamic floating-point activation quantizer.

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

N/A

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

N/A

## Checklist

- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [x] 1+ reviews given, and any review issues addressed and approved.
- [x] Post-review full CI/CD passing.
