### PR TITLE
Fix (scaling)!: clamp to avoid inf/nan in forward/backward

### DIFF
--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -251,9 +251,7 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
         if self.init_done:
             threshold = self.stats_scaling_impl.restrict_clamp_threshold(
                 self.restrict_threshold_pre(threshold))
-            # Clamping avoids eventual log(0) with restrict_val
-            value = self.clamp_scaling(self.value)
-            value = abs_binary_sign_grad(self.stats_scaling_impl.restrict_clamp_scaling(value))
+            value = abs_binary_sign_grad(self.stats_scaling_impl.restrict_clamp_scaling(self.value))
             value = value / threshold
             return value
         else:
@@ -425,10 +423,8 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
                 out = self.restrict_scaling_pre(out)
             else:
                 out = self.value
-                # Clamping avoids eventual log(0) with restrict_val
-                out = self.clamp_scaling(out)
             threshold = self.restrict_threshold(self.restrict_threshold_pre(threshold))
-            out = self.clamp_scaling(self.restrict_scaling(out))
+            out = self.restrict_scaling(out)
             out = out / threshold
             out = abs_binary_sign_grad(self.clamp_scaling(out))
         return out

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -1,0 +1,54 @@
+import torch
+
+from brevitas.core.function_wrapper.misc import Identity
+from brevitas.core.restrict_val import PowerOfTwoRestrictValue
+from brevitas.core.scaling.runtime import RuntimeDynamicGroupStatsScaling
+from brevitas.core.scaling.runtime import RuntimeStatsScaling
+from brevitas.core.scaling.runtime import StatsFromParameterScaling
+from brevitas.core.stats.stats_op import AbsMax
+from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
+
+
+def test_scaling_min_val_parameter():
+    inp = torch.zeros(1, 5, requires_grad=True)
+    scaling_min_val = torch.tensor(1e-6)
+    scaling_op = StatsFromParameterScaling(
+        scaling_stats_impl=AbsMax(),
+        scaling_stats_input_view_shape_impl=Identity(),
+        scaling_stats_input_concat_dim=None,
+        tracked_parameter_list=[inp],
+        scaling_shape=SCALAR_SHAPE,
+        restrict_scaling_impl=PowerOfTwoRestrictValue(),
+        scaling_min_val=scaling_min_val)
+    pre_scale = scaling_op(inp)
+    pre_scale.sum().backward()
+    assert not torch.isnan(inp.grad).any()
+
+
+def test_scaling_min_val_runtime():
+    inp = torch.zeros(1, 5, requires_grad=True)
+    scaling_min_val = torch.tensor(1e-6)
+    scaling_op = RuntimeStatsScaling(
+        scaling_stats_impl=AbsMax(),
+        scaling_stats_input_view_shape_impl=Identity(),
+        scaling_shape=SCALAR_SHAPE,
+        restrict_scaling_impl=PowerOfTwoRestrictValue(),
+        scaling_min_val=scaling_min_val)
+    pre_scale = scaling_op(inp)
+    pre_scale.sum().backward()
+    assert not torch.isnan(inp.grad).any()
+
+
+def test_scaling_min_val_dynamic_group():
+    inp = torch.zeros(1, 6, requires_grad=True)
+    scaling_min_val = torch.tensor(1e-6)
+    scaling_op = RuntimeDynamicGroupStatsScaling(
+        group_size=3,
+        group_dim=1,
+        input_view_impl=Identity(),
+        scaling_min_val=scaling_min_val,
+        restrict_scaling_impl=PowerOfTwoRestrictValue(),
+        scaling_stats_impl=AbsMax())
+    pre_scale = scaling_op(inp)
+    pre_scale.sum().backward()
+    assert not torch.isnan(inp.grad).any()

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -8,10 +8,11 @@ from brevitas.core.scaling.runtime import StatsFromParameterScaling
 from brevitas.core.stats.stats_op import AbsMax
 from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
 
+SCALING_MIN_VAL = 1e-6
+
 
 def test_scaling_min_val_parameter():
     inp = torch.zeros(1, 5, requires_grad=True)
-    scaling_min_val = torch.tensor(1e-6)
     scaling_op = StatsFromParameterScaling(
         scaling_stats_impl=AbsMax(),
         scaling_stats_input_view_shape_impl=Identity(),
@@ -19,7 +20,7 @@ def test_scaling_min_val_parameter():
         tracked_parameter_list=[inp],
         scaling_shape=SCALAR_SHAPE,
         restrict_scaling_impl=PowerOfTwoRestrictValue(),
-        scaling_min_val=scaling_min_val)
+        scaling_min_val=SCALING_MIN_VAL)
     pre_scale = scaling_op(inp)
     pre_scale.sum().backward()
     assert not torch.isnan(inp.grad).any()
@@ -27,13 +28,12 @@ def test_scaling_min_val_parameter():
 
 def test_scaling_min_val_runtime():
     inp = torch.zeros(1, 5, requires_grad=True)
-    scaling_min_val = torch.tensor(1e-6)
     scaling_op = RuntimeStatsScaling(
         scaling_stats_impl=AbsMax(),
         scaling_stats_input_view_shape_impl=Identity(),
         scaling_shape=SCALAR_SHAPE,
         restrict_scaling_impl=PowerOfTwoRestrictValue(),
-        scaling_min_val=scaling_min_val)
+        scaling_min_val=SCALING_MIN_VAL)
     pre_scale = scaling_op(inp)
     pre_scale.sum().backward()
     assert not torch.isnan(inp.grad).any()
@@ -41,12 +41,11 @@ def test_scaling_min_val_runtime():
 
 def test_scaling_min_val_dynamic_group():
     inp = torch.zeros(1, 6, requires_grad=True)
-    scaling_min_val = torch.tensor(1e-6)
     scaling_op = RuntimeDynamicGroupStatsScaling(
         group_size=3,
         group_dim=1,
         input_view_impl=Identity(),
-        scaling_min_val=scaling_min_val,
+        scaling_min_val=SCALING_MIN_VAL,
         restrict_scaling_impl=PowerOfTwoRestrictValue(),
         scaling_stats_impl=AbsMax())
     pre_scale = scaling_op(inp)

--- a/tests/brevitas/core/test_standalone_scaling.py
+++ b/tests/brevitas/core/test_standalone_scaling.py
@@ -22,7 +22,7 @@ def test_scaling_state_dict():
 
 @torch.no_grad()
 def test_scaling_min_val_runtime():
-    scaling_min_val = torch.tensor(1e-6)
+    scaling_min_val = 1e-6
     scaling_op = ParameterFromRuntimeStatsScaling(
         collect_stats_steps=1,
         scaling_stats_impl=AbsMax(),
@@ -38,7 +38,7 @@ def test_scaling_min_val_runtime():
 @torch.no_grad()
 def test_scaling_min_val_param():
     inp = torch.zeros(1, 5)
-    scaling_min_val = torch.tensor(1e-6)
+    scaling_min_val = 1e-6
     scaling_op = ParameterFromStatsFromParameterScaling(
         scaling_stats_impl=AbsMax(),
         scaling_min_val=scaling_min_val,

--- a/tests/brevitas/core/test_standalone_scaling.py
+++ b/tests/brevitas/core/test_standalone_scaling.py
@@ -1,7 +1,13 @@
 import warnings
 
+import torch
+
+from brevitas.core.function_wrapper.misc import Identity
+from brevitas.core.restrict_val import PowerOfTwoRestrictValue
 from brevitas.core.scaling import ParameterFromRuntimeStatsScaling
+from brevitas.core.scaling.standalone import ParameterFromStatsFromParameterScaling
 from brevitas.core.stats.stats_op import AbsMax
+from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
 
 
 def test_scaling_state_dict():
@@ -12,3 +18,35 @@ def test_scaling_state_dict():
         scaling_op.state_dict()
         for w in wlist:
             assert "Positional args are being deprecated" not in str(w.message)
+
+
+@torch.no_grad()
+def test_scaling_min_val_runtime():
+    scaling_min_val = torch.tensor(1e-6)
+    scaling_op = ParameterFromRuntimeStatsScaling(
+        collect_stats_steps=1,
+        scaling_stats_impl=AbsMax(),
+        scaling_min_val=scaling_min_val,
+        restrict_scaling_impl=PowerOfTwoRestrictValue())
+    inp = torch.zeros(1, 5)
+    pre_scale = scaling_op(inp)
+    value_scale_converted = scaling_op(inp)
+    scaling_op.eval()
+    assert not torch.isinf(scaling_op.value).any()
+
+
+@torch.no_grad()
+def test_scaling_min_val_param():
+    inp = torch.zeros(1, 5)
+    scaling_min_val = torch.tensor(1e-6)
+    scaling_op = ParameterFromStatsFromParameterScaling(
+        scaling_stats_impl=AbsMax(),
+        scaling_min_val=scaling_min_val,
+        restrict_scaling_impl=PowerOfTwoRestrictValue(),
+        scaling_stats_input_view_shape_impl=Identity(),
+        scaling_stats_input_concat_dim=None,
+        tracked_parameter_list=[inp],
+        scaling_shape=SCALAR_SHAPE)
+    pre_scale = scaling_op(inp)
+    value_scale_converted = scaling_op(inp)
+    assert not torch.isinf(scaling_op.value).any()

--- a/tests/brevitas/core/test_standalone_scaling.py
+++ b/tests/brevitas/core/test_standalone_scaling.py
@@ -9,6 +9,8 @@ from brevitas.core.scaling.standalone import ParameterFromStatsFromParameterScal
 from brevitas.core.stats.stats_op import AbsMax
 from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
 
+SCALING_MIN_VAL = 1e-6
+
 
 def test_scaling_state_dict():
     scaling_op = ParameterFromRuntimeStatsScaling(
@@ -22,11 +24,10 @@ def test_scaling_state_dict():
 
 @torch.no_grad()
 def test_scaling_min_val_runtime():
-    scaling_min_val = 1e-6
     scaling_op = ParameterFromRuntimeStatsScaling(
         collect_stats_steps=1,
         scaling_stats_impl=AbsMax(),
-        scaling_min_val=scaling_min_val,
+        scaling_min_val=SCALING_MIN_VAL,
         restrict_scaling_impl=PowerOfTwoRestrictValue())
     inp = torch.zeros(1, 5)
     pre_scale = scaling_op(inp)
@@ -38,10 +39,9 @@ def test_scaling_min_val_runtime():
 @torch.no_grad()
 def test_scaling_min_val_param():
     inp = torch.zeros(1, 5)
-    scaling_min_val = 1e-6
     scaling_op = ParameterFromStatsFromParameterScaling(
         scaling_stats_impl=AbsMax(),
-        scaling_min_val=scaling_min_val,
+        scaling_min_val=SCALING_MIN_VAL,
         restrict_scaling_impl=PowerOfTwoRestrictValue(),
         scaling_stats_input_view_shape_impl=Identity(),
         scaling_stats_input_concat_dim=None,


### PR DESCRIPTION
## Reason for this PR

Restrict scaling with log op could cause inf/nan in the forward pass and/or in the gradients.




## Changes Made in this PR

Applying a restriction before (new behaviour) and after (existing behaviour) helps avoiding that.

## Testing Summary

Add tests for standalone and runtime scaling to check inf/nan in forward/backwards.

## Risk Highlight


This is a breaking change. Old checkpoints will work, new QAT/PTQ runs could produce different results from before.


- [ ] This PR includes code from another work (please detail).
- [x] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
