### PR TITLE
Fix (scaling/standalone): better switch from runtime stats to param

### DIFF
--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -376,9 +376,10 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
 
     def init_scale(self):
-        self.restrict_inplace_preprocess(self.buffer)
-        inplace_tensor_mul(self.value.detach(), self.buffer)
-        self.counter = self.counter + 1
+        if self.counter <= self.collect_stats_steps:
+            self.restrict_inplace_preprocess(self.buffer)
+            inplace_tensor_mul(self.value.detach(), self.buffer)
+            self.counter = self.collect_stats_steps + 1
 
     @brevitas.jit.script_method
     def training_forward(self, stats_input: Tensor, threshold: Tensor) -> Tensor:

--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -374,7 +374,6 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
         self.restrict_inplace_preprocess = restrict_scaling_impl.restrict_init_inplace_module()
         self.restrict_scaling_pre = restrict_scaling_impl.restrict_init_module()
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
-        self.init_done: bool = brevitas.jit.Attribute(False, bool)
 
     def init_scale(self):
         self.restrict_inplace_preprocess(self.buffer)

--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -416,6 +416,7 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
         if threshold is None:
             threshold = torch.ones(1).type_as(stats_input)
         if self.training:
+            self.init_done = False
             # Threshold division handled inside the training_forward
             return self.training_forward(stats_input, threshold)
         else:

--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -397,7 +397,6 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
             self.counter = new_counter
             return abs_binary_sign_grad(clamped_stats / threshold)
         elif self.counter == self.collect_stats_steps:
-            self.init_done = True
             self.restrict_inplace_preprocess(self.buffer)
             inplace_tensor_mul(self.value.detach(), self.buffer)
             threshold = self.restrict_threshold(self.restrict_threshold_pre(threshold))
@@ -415,8 +414,7 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
     def forward(self, stats_input: Tensor, threshold: Optional[Tensor] = None) -> Tensor:
         if threshold is None:
             threshold = torch.ones(1).type_as(stats_input)
-        if self.training:
-            self.init_done = False
+        if self.training and not self.init_done:
             # Threshold division handled inside the training_forward
             return self.training_forward(stats_input, threshold)
         else:

--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -75,11 +75,6 @@ def set_collect_stats_to_average(module):
 
 
 def finalize_collect_stats(module):
-    if hasattr(module, 'collect_stats_steps') and hasattr(module, 'counter'):
-        # If the counter has already reached collect_stats_steps, we do not want to reset it
-        # otherwise the restrict_preprocess might be applied twice: during calibration
-        # (that happens in training mode) and then when the model is evaluated
-        module.counter = max(module.collect_stats_steps, module.counter)
     if hasattr(module, 'init_scale'):
         module.init_scale()
 

--- a/src/brevitas/graph/calibrate.py
+++ b/src/brevitas/graph/calibrate.py
@@ -65,7 +65,7 @@ def restore_return_quant_tensor(model, previous_state):
 def extend_collect_stats_steps(module):
     if hasattr(module, 'collect_stats_steps'):
         # We extend the collect steps in PTQ to match potentially long calibrations
-        module.collect_stats_steps = sys.maxsize
+        module.collect_stats_steps = sys.maxsize - 1
 
 
 def set_collect_stats_to_average(module):
@@ -80,6 +80,8 @@ def finalize_collect_stats(module):
         # otherwise the restrict_preprocess might be applied twice: during calibration
         # (that happens in training mode) and then when the model is evaluated
         module.counter = max(module.collect_stats_steps, module.counter)
+    if hasattr(module, 'init_scale'):
+        module.init_scale()
 
 
 class calibration_mode:

--- a/tests/brevitas/export/test_torch_qcdq.py
+++ b/tests/brevitas/export/test_torch_qcdq.py
@@ -13,6 +13,7 @@ from .quant_module_fixture import *
 
 @requires_pt_ge('1.9.1')
 @jit_disabled_for_export()
+@torch.no_grad()
 def test_torch_qcdq_wbiol_export(
         quant_module,
         quant_module_impl,
@@ -57,6 +58,7 @@ def test_torch_qcdq_wbiol_export(
 @requires_pt_ge('1.9.1')
 @jit_disabled_for_export()
 @parametrize('input_signed', [True, False])
+@torch.no_grad()
 def test_torch_qcdq_avgpool_export(input_signed, output_bit_width):
     in_size = (1, IN_CH, FEATURES, FEATURES)
     inp = torch.randn(in_size)


### PR DESCRIPTION
## Reason for this PR

Currently, if we switch from training to eval before `stats_collection_steps` is done, we never update the `value` parameter to store the buffer value. This has a few side effects:
- When applying learned round, we might keep the model in eval model but still accumulate gradients. If the value parameter is not being used, no gradients are accumulated
- When exporting state_dict, value is not exported
- When doing PTQ calibration, current setup is such that the buffer is never converted to its corresponding parameter `value`, causing some of the issues mentioned above.

## Changes Made in this PR

~~At eval time, during the first iteration the buffer is always converted to param.
The side effect of this happens in the case the user would want to switch multiple times between training/evaluation mode very early on in the training process. Although it is common to switch between training/eval to check loss on the validation set, it is usually done after enough iteration that the buffer has already been converted to parameter anyway.
I'd admit that it could be marked as breaking change for this edge cases.~~

~~This has been removed in a more recent commit. I believe there are no more breaking changes at this point.~~


All fixed, no more breaking changes.
After calibration, we forcefully convert the buffer to parameters.

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
