### PR TITLE
Fix (hadamard): remove hadamard loading warning

### DIFF
--- a/src/brevitas/graph/hadamard.py
+++ b/src/brevitas/graph/hadamard.py
@@ -19,7 +19,7 @@ def get_hadK(n, transpose=False):
     # hadamard matrices for had12, had36.pal2, had52,will,
     # # had60.pal, had108.pal, had140.pal, had156.will, had172.will:
     # http://www.neilsloane.com/hadamard/index.html
-    tensors = torch.load(str(parent) + '/hadamard_tensors.pt')
+    tensors = torch.load(str(parent) + '/hadamard_tensors.pt', weights_only=True)
     tensors = {k: v.to(torch.float) for k, v in tensors.items()}
     hadK, K = None, None
     if n % 172 == 0:  # llama-2-7b up


### PR DESCRIPTION
## Reason for this PR
There was a warning when loading the pre-computed hadamard matrices.

## Changes Made in this PR

Use `weights_only=True` to suppress the warning

## Testing Summary

NA

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [x] Post-review full CI/CD passing.
