### PR TITLE
Feat (llm/learned_round): fast block update

### DIFF
--- a/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
+++ b/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
@@ -693,7 +693,6 @@ class LearnedRoundOptimizer:
         # The second is a quantized one to create the quantized input of the next blocks
 
         # We use the cache output to generate a new temporary dataloder for the next block
-        # and to update our floating_point_dataset
         tmp_data_loader = []
         for i in range(len(cache)):
             (args, kwargs), output = cache.sample_batch([i])

--- a/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
+++ b/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
@@ -722,7 +722,8 @@ class LearnedRoundOptimizer:
 
         # Finally (!), we compute the quantized input of the next block
         block.eval()
-        block.cuda()
+        if torch.cuda.is_available():
+          block.cuda()
         next_quant_input = []
         pbar = tqdm(range(len(cache)), desc='', leave=False)
         with torch.no_grad():
@@ -731,8 +732,8 @@ class LearnedRoundOptimizer:
                 out = block_forward(block, (args, kwargs))
                 out = send_to_device(out, 'cpu')
                 next_quant_input.append((out,))
+        pbar.close()
         cache['args'] = next_quant_input
         block.cpu()
-        pbar.close()
 
         return cache

--- a/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
+++ b/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
@@ -707,13 +707,13 @@ class LearnedRoundOptimizer:
                 (args, kwargs), _ = cache.sample_batch([i])
                 floating_point_datasets.append((args, kwargs))
 
-        # We use this new output to generate a new temporary dataloder for the next block
+        # We use the cache output to generate a new temporary dataloder for the next block
         # and to update our floating_point_dataset
         new_data_loader = []
         for i in range(len(cache)):
             (args, kwargs), output = cache.sample_batch([i])
-            new_data_loader.append(((output,), kwargs))
 
+            new_data_loader.append(((output,), kwargs))
             floating_point_datasets[i] = ((output,), kwargs)
 
         # Temporary cache

--- a/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
+++ b/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
@@ -723,7 +723,7 @@ class LearnedRoundOptimizer:
         # Finally (!), we compute the quantized input of the next block
         block.eval()
         if torch.cuda.is_available():
-          block.cuda()
+            block.cuda()
         next_quant_input = []
         pbar = tqdm(range(len(cache)), desc='', leave=False)
         with torch.no_grad():

--- a/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
+++ b/src/brevitas_examples/common/learned_round/learned_round_optimizer.py
@@ -690,14 +690,8 @@ class LearnedRoundOptimizer:
 
     def skip_full_execution(self, block, next_block, floating_point_datasets, block_forward, cache):
 
-        # We need to propagate two datasets, one is a floating point dataset to compute float out
-        # The second is a quantized dataset to create the quantized input of the next blocks
-
-        # First, we disable quantization
-        disable_quant_class = DisableEnableQuantization()
-        disable_quant_class.disable_act_quantization(block, False)
-        disable_quant_class.disable_param_quantization(block, False)
-        return_quant_tensor_state = disable_return_quant_tensor(block)
+        # We need to compute two inputs, one is a floating point one to compute float out
+        # The second is a quantized one to create the quantized input of the next blocks
 
         # If we don't have a floating_point_dataset, we retrieve it from the cache
         # The idea is that the cache contains the input to the very first block, and there is nothing
@@ -736,11 +730,6 @@ class LearnedRoundOptimizer:
         next_block.cpu()
 
         cache['output'] = tmp_cache['output']
-
-        # Re-enable quantization
-        disable_quant_class.enable_act_quantization(block, False)
-        disable_quant_class.enable_param_quantization(block, False)
-        restore_return_quant_tensor(block, return_quant_tensor_state)
 
         # Finally (!), we compute the quantized input of the next block
         block.eval()

--- a/src/brevitas_examples/imagenet_classification/ptq/learned_round_utils.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/learned_round_utils.py
@@ -69,6 +69,7 @@ class CacheVision(Cache, dict):
     def __init__(self) -> None:
         super().__init__()
         self.batch_dim = 0
+        self.initialize_cache()
 
     def store_inputs(self, args, kwargs) -> None:
         input_batch = args[0]

--- a/src/brevitas_examples/llm/README.md
+++ b/src/brevitas_examples/llm/README.md
@@ -54,6 +54,7 @@ usage: main.py [-h] [--model MODEL] [--seed SEED] [--nsamples NSAMPLES]
                [--export-prefix EXPORT_PREFIX]
                [--checkpoint-name CHECKPOINT_NAME] [--fuse-sequences]
                [--learned-round {None,linear_round}]
+               [--learned-round-fast-update]
 
 options:
   -h, --help            show this help message and exit
@@ -196,5 +197,8 @@ options:
   --learned-round {None,linear_round}
                         Whether to use learned round. If `None`, RTN is used
                         (default: None)
+  --learned-round-fast-update
+                        Whether to use fast update with learned round.
+                        Prototype (default: False)
 
 ```

--- a/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
@@ -23,9 +23,7 @@ class CacheLLM(Cache, dict):
 
     def __init__(self) -> None:
         super().__init__()
-        self["args"] = []
-        self["kwargs"] = []
-        self["output"] = []
+        self.initialize_cache()
 
     def store_inputs(self, args, kwargs) -> None:
         self["args"].append(args)

--- a/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
@@ -169,4 +169,4 @@ def apply_learned_round(
         model_prepare_fn=llm_learned_round_prepare_fn,
         model_finish_fn=llm_learned_round_finish_fn,
         keep_gpu=False,
-        partial_update=fast_update)
+        fast_update=fast_update)

--- a/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
@@ -110,25 +110,25 @@ def get_blocks(model: nn.Module, block_name_attribute: str) -> List[nn.Module]:
 
 
 def apply_learned_round(
-    model: nn.Module,
-    calibration_loader: DataLoader,
-    iters: int = 200,
-    learned_round: str = "linear_round",
-    learned_round_loss: str = "mse",
-    block_name_attribute: str = "layers",
-    optimizer: str = "sign_sgd",
-    batch_size: int = 8,
-    learn_scale: bool = False,
-    use_best_model: bool = True,
-    amp_dtype: torch.dtype = torch.float16,
-    loss_scaling_factor: float = 1000,
-    lr_scheduler: Optional[str] = "linear",
-    optimizer_kwargs: Optional[Dict] = None,
-    lr_scheduler_kwargs: Optional[Dict] = None,
-    learned_round_loss_kwargs: Optional[Dict] = None,
-    scale_optimizer_class: Optional[str] = None,
-    scale_optimizer_kwargs: Optional[Dict] = None,
-) -> None:
+        model: nn.Module,
+        calibration_loader: DataLoader,
+        iters: int = 200,
+        learned_round: str = "linear_round",
+        learned_round_loss: str = "mse",
+        block_name_attribute: str = "layers",
+        optimizer: str = "sign_sgd",
+        batch_size: int = 8,
+        learn_scale: bool = False,
+        use_best_model: bool = True,
+        amp_dtype: torch.dtype = torch.float16,
+        loss_scaling_factor: float = 1000,
+        lr_scheduler: Optional[str] = "linear",
+        optimizer_kwargs: Optional[Dict] = None,
+        lr_scheduler_kwargs: Optional[Dict] = None,
+        learned_round_loss_kwargs: Optional[Dict] = None,
+        scale_optimizer_class: Optional[str] = None,
+        scale_optimizer_kwargs: Optional[Dict] = None,
+        fast_update: bool = False) -> None:
     # Parse strings to obtain the arguments for the optimizer
     learned_round = parse_learned_round(learned_round)
     learned_round_loss_class = parse_learned_round_loss_class(learned_round_loss)
@@ -169,4 +169,4 @@ def apply_learned_round(
         model_prepare_fn=llm_learned_round_prepare_fn,
         model_finish_fn=llm_learned_round_finish_fn,
         keep_gpu=False,
-        partial_update=True)
+        partial_update=fast_update)

--- a/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
@@ -166,4 +166,4 @@ def apply_learned_round(
         model_prepare_fn=llm_learned_round_prepare_fn,
         model_finish_fn=llm_learned_round_finish_fn,
         keep_gpu=False,
-    )
+        partial_update=True)

--- a/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/learned_round_utils.py
@@ -23,6 +23,9 @@ class CacheLLM(Cache, dict):
 
     def __init__(self) -> None:
         super().__init__()
+        self["args"] = []
+        self["kwargs"] = []
+        self["output"] = []
 
     def store_inputs(self, args, kwargs) -> None:
         self["args"].append(args)

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -385,7 +385,8 @@ def main(args):
             scale_optimizer_class='sgd',
             optimizer_kwargs={'lr': args.learned_round_lr},
             scale_optimizer_kwargs={
-                'lr': args.learned_round_scale_lr, 'momentum': args.learned_round_scale_momentum})
+                'lr': args.learned_round_scale_lr, 'momentum': args.learned_round_scale_momentum},
+            fast_update=args.learned_round_fast_update)
         print("Learned round applied.")
 
         model = offload_model(model)
@@ -705,6 +706,11 @@ def parse_args(args):
         default=None,
         choices=[None, 'linear_round'],
         help='Whether to use learned round. If `None`, RTN is used (default: %(default)s)')
+    parser.add_argument(
+        '--learned-round-fast-update',
+        default=False,
+        type=bool,
+        help='Whether to use fast update with learned round. Prototype (default: %(default)s)')
     return parser.parse_args(args)
 
 

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -709,7 +709,7 @@ def parse_args(args):
     parser.add_argument(
         '--learned-round-fast-update',
         default=False,
-        type=bool,
+        action="store_true",
         help='Whether to use fast update with learned round. Prototype (default: %(default)s)')
     return parser.parse_args(args)
 


### PR DESCRIPTION
## Reason for this PR

Inter-block update in learned round might be super slow for big models

## Changes Made in this PR

We assume that blocks are sequential, so the output of each block is the input to the next.
Furthermore, we assume all kwargs don't change (typical in LLM).

We can run 2 block forwards instead of going through the entire model all over twice.

## Testing Summary

NA

## Risk Highlight

Limitations described above. Flag should be set to False unless the user knows what they're doing. Potentially to improve in the future.

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
