### PR TITLE
Feat (scaling): no tracked_parameter_list with individual quantizer

### DIFF
--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -30,6 +30,7 @@ class StatsFromParameterScaling(brevitas.jit.ScriptModule):
             scaling_stats_input_concat_dim: int,
             tracked_parameter_list: List[torch.nn.Parameter],
             scaling_shape: Tuple[int, ...],
+            force_parameter: bool = False,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
             affine_rescaling: bool = False,
@@ -48,7 +49,8 @@ class StatsFromParameterScaling(brevitas.jit.ScriptModule):
             scaling_shape,
             scaling_stats_input_view_shape_impl,
             scaling_stats_input_concat_dim,
-            tracked_parameter_list)
+            tracked_parameter_list,
+            force_parameter)
         self.stats_scaling_impl = _StatsScaling(
             restrict_scaling_impl,
             restrict_threshold_impl,

--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -207,6 +207,7 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
             scaling_stats_input_concat_dim: int,
             tracked_parameter_list: List[torch.nn.Parameter],
             scaling_shape: Tuple[int, ...],
+            force_parameter: bool = False,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
             scaling_min_val: Optional[float] = None,
@@ -218,7 +219,8 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
             scaling_shape,
             scaling_stats_input_view_shape_impl,
             scaling_stats_input_concat_dim,
-            tracked_parameter_list)
+            tracked_parameter_list,
+            force_parameter)
 
         # Ensure retro-compatibility with shared threshold/scaling restrict
         if restrict_threshold_impl is None:

--- a/src/brevitas/core/stats/stats_wrapper.py
+++ b/src/brevitas/core/stats/stats_wrapper.py
@@ -93,11 +93,12 @@ class _ParameterListStats(brevitas.jit.ScriptModule):
             stats_output_shape: Tuple[int, ...],
             stats_input_view_shape_impl: nn.Module,
             stats_input_concat_dim: int,
-            tracked_parameter_list: List[torch.nn.Parameter]) -> None:
+            tracked_parameter_list: List[torch.nn.Parameter],
+            force_parameter: bool = False) -> None:
         super(_ParameterListStats, self).__init__()
 
         self.stats_input_concat_dim = stats_input_concat_dim
-        if len(tracked_parameter_list) >= 1:
+        if len(tracked_parameter_list) > 1 or force_parameter:
             self.first_tracked_param = _ViewParameterWrapper(
                 tracked_parameter_list[0], stats_input_view_shape_impl)
         else:

--- a/src/brevitas/core/stats/stats_wrapper.py
+++ b/src/brevitas/core/stats/stats_wrapper.py
@@ -120,9 +120,7 @@ class _ParameterListStats(brevitas.jit.ScriptModule):
             stats_input = self.first_tracked_param(None)
             for extra_tracked_param in self.extra_tracked_params_list:
                 stats_input = extra_tracked_param(stats_input)
-        elif x is not None:
-            stats_input = self.first_tracked_param(x)
         else:
-            raise RuntimeError("An input is needed to compute the statistics")
+            stats_input = self.first_tracked_param(x)
         out = self.stats(stats_input)
         return out

--- a/src/brevitas/core/stats/stats_wrapper.py
+++ b/src/brevitas/core/stats/stats_wrapper.py
@@ -120,7 +120,9 @@ class _ParameterListStats(brevitas.jit.ScriptModule):
             stats_input = self.first_tracked_param(None)
             for extra_tracked_param in self.extra_tracked_params_list:
                 stats_input = extra_tracked_param(stats_input)
-        else:
+        elif x is not None:
             stats_input = self.first_tracked_param(x)
+        else:
+            raise RuntimeError("An input is needed to compute the statistics")
         out = self.stats(stats_input)
         return out

--- a/src/brevitas/core/stats/view_wrapper.py
+++ b/src/brevitas/core/stats/view_wrapper.py
@@ -52,7 +52,7 @@ class _ViewParameter(brevitas.jit.ScriptModule):
         self.view_shape_impl = view_shape_impl
 
     @brevitas.jit.script_method
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: Optional[Tensor]) -> Tensor:
         return self.view_shape_impl(x)
 
 

--- a/src/brevitas/core/stats/view_wrapper.py
+++ b/src/brevitas/core/stats/view_wrapper.py
@@ -52,7 +52,7 @@ class _ViewParameter(brevitas.jit.ScriptModule):
         self.view_shape_impl = view_shape_impl
 
     @brevitas.jit.script_method
-    def forward(self, x: Optional[Tensor]) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         return self.view_shape_impl(x)
 
 

--- a/src/brevitas/core/stats/view_wrapper.py
+++ b/src/brevitas/core/stats/view_wrapper.py
@@ -52,8 +52,11 @@ class _ViewParameter(brevitas.jit.ScriptModule):
         self.view_shape_impl = view_shape_impl
 
     @brevitas.jit.script_method
-    def forward(self, x: Tensor) -> Tensor:
-        return self.view_shape_impl(x)
+    def forward(self, x: Optional[Tensor]) -> Tensor:
+        if x is not None:
+            return self.view_shape_impl(x)
+        else:
+            raise RuntimeError("Input cannot be None")
 
 
 class _ViewCatParameterWrapper(brevitas.jit.ScriptModule):

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -418,7 +418,9 @@ class WeightNormPerChannelFloatDecoupled(SolvePostScaleGranularity,
         return scales
 
     per_channel_pre_norm = PerChannelPreNorm
-
+    # Even if we have a single parameter per quantizer,
+    # we want to force the use of tracker_parameter_list for the scale computation because of the initialization
+    force_parameter = True
     proxy_class = DecoupledWeightQuantProxyFromInjector
     tensor_quant = DecoupledRescalingIntQuant
     decoupled_int_quant = DecoupledIntQuant


### PR DESCRIPTION
## Reason for this PR

ViewParameterWrapper creates a shared weight within the quantizer. This doesn't play nice with accelerate.
We don't need this unless with shared quantizers which is not something we are currently using in combination with accelerate.


## Changes Made in this PR

ViewWrapper can fill for this. However, we need to fallback to ViewParameterWrapper for some cases DecoupledWeightQuantization, so we have a special flag to enable that.

## Testing Summary

NA

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
