### PR TITLE
Feat (brevitas_examples/llm): correct scale init with CPU offloading

### DIFF
--- a/src/brevitas/utils/python_utils.py
+++ b/src/brevitas/utils/python_utils.py
@@ -54,3 +54,13 @@ def recurse_getattr(obj, attr: str):
         return getattr(obj, attr)
 
     return functools.reduce(_getattr, [obj] + attr.split("."))
+
+
+def hooked_on_a_function(function, prefunction):
+
+    @functools.wraps(function)
+    def run(*args, **kwargs):
+        prefunction()
+        return function(*args, **kwargs)
+
+    return run

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -399,7 +399,7 @@ def main(args):
     with torch.no_grad():
         model(**calibration_loader[0])
 
-    # We restore the original behaviour of the post-forward. 
+    # We restore the original behaviour of the post-forward.
     for k, v in dict_hooks.items():
         k._hf_hook.post_forward = v
 


### PR DESCRIPTION
## Reason for this PR

Offload might cause models to end up on CPU + GPU.
If that is the case, the initialization of scale factor is not correct, since the scales that are on CPU are forgotten because of the offload.
This allows to initialize and fix the scales correctly.

## Changes Made in this PR

`post_forward` has now a hook that stores the new parameters, if these have been updated, like the scale post initialization.

## Testing Summary

NA 

## Risk Highlight

NA

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
