### PR TITLE
Fix (float/clamp): Bugfix when unsigned

### DIFF
--- a/src/brevitas/core/function_wrapper/clamp.py
+++ b/src/brevitas/core/function_wrapper/clamp.py
@@ -152,7 +152,7 @@ class FloatClamp(brevitas.jit.ScriptModule):
         # Compute masks
         inf_mask = x.isinf()
         p_max_val_mask = x > max_value
-        n_max_val_mask = -x > max_value
+        n_max_val_mask = x < min_value
 
         # first clamp everything to +- max_value, basically the saturating case
         x = self.saturating_clamp(x, max_value, min_value)


### PR DESCRIPTION
Fixes `min_value` clamp when the input is [unsigned](https://github.com/Xilinx/brevitas/issues/1126#issuecomment-2545903489) for float values.