### PR TITLE
Feat (mx): unpadding during dequantization

### DIFF
--- a/notebooks/minifloat_mx_tutorial.ipynb
+++ b/notebooks/minifloat_mx_tutorial.ipynb
@@ -206,15 +206,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Non padding weights shape torch.Size([64, 8, 3, 3])\n",
-      "Padded weights shape torch.Size([64, 32, 3, 3])\n"
+      "Non padding weights shape torch.Size([64, 1, 8, 3, 3])\n",
+      "Padded weights shape torch.Size([64, 1, 32, 3, 3])\n"
      ]
     }
    ],
@@ -257,8 +257,8 @@
     "o = mx_model(x)\n",
     "\n",
     "# The quant weight of the padded model is different from the non padding one\n",
-    "print(f\"Non padding weights shape {mx_model_no_padding.conv.quant_weight().value.shape}\")\n",
-    "print(f\"Padded weights shape {mx_model.conv.quant_weight().value.shape}\")\n",
+    "print(f\"Non padding weights shape {mx_model_no_padding.conv.quant_weight().value_.shape}\")\n",
+    "print(f\"Padded weights shape {mx_model.conv.quant_weight().value_.shape}\")\n",
     "\n",
     "# However, results are still the same \n",
     "assert torch.allclose(o, o_no_padding)"

--- a/src/brevitas/export/inference/handler.py
+++ b/src/brevitas/export/inference/handler.py
@@ -296,6 +296,7 @@ class GroupwiseFloatWeightInferenceHandler(FloatWeightInferencetHandler):
         if module.is_quant_enabled:
             self.input_view = module.input_view_impl
             self.flattened_view = module.apply_input_view
+            self.group_dim = module.group_dim
             if module._cached_weight is not None and not module.cache_inference_quant_weight_metadata_only:
                 self.cached_weight = module._cached_weight.quant_tensor.value_
             else:

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -187,12 +187,6 @@ class GPxQ(ABC):
         self.layer = layer
         self.name = name
         self.act_order = act_order
-        if self.layer.weight_quant.is_groupwise:
-            weight = self.layer.weight_quant.apply_input_view(self.layer.weight)
-            weight = weight.view(self.layer.weight_quant.quant_injector.reshaped_groupwise_shape)
-            self.layer.weight.data = weight.data
-            self.layer.in_channels = weight.shape[1] if is_conv_transposed(
-                self.layer) else weight.shape[0]
 
         weight_shape = torch.tensor(layer.weight.shape)
 

--- a/src/brevitas/proxy/float_runtime_quant.py
+++ b/src/brevitas/proxy/float_runtime_quant.py
@@ -77,7 +77,7 @@ class ActFloatQuantProxyFromInjector(ActFloatQuantProxyFromInjectorBase):
             self,
             qt_args: Union[torch.Tensor, Tuple[Any]],
             x: Optional[FloatQuantTensor] = None) -> FloatQuantTensor:
-        if x is None:
+        if isinstance(qt_args, tuple):
             out = FloatQuantTensor(*qt_args, signed=self.is_signed, training=self.training)
         else:
             out = FloatQuantTensor(

--- a/src/brevitas/proxy/groupwise_float_parameter_quant.py
+++ b/src/brevitas/proxy/groupwise_float_parameter_quant.py
@@ -34,6 +34,7 @@ class GroupwiseWeightFloatQuantProxyFromInjector(WeightFloatQuantProxyFromInject
         return x.flatten(start_dim, start_dim + 1)
 
     def create_quant_tensor(self, qt_args: Tuple[Any]) -> GroupwiseFloatQuantTensor:
+        shape = self.tracked_parameter_list[0].shape
         out, scale, zero_point, exponent_bit_width, mantissa_bit_width, exponent_bias, saturating, inf_values, nan_values = qt_args
         return GroupwiseFloatQuantTensor(
             out,
@@ -48,4 +49,5 @@ class GroupwiseWeightFloatQuantProxyFromInjector(WeightFloatQuantProxyFromInject
             inf_values,
             nan_values,
             self.is_signed,
-            self.training)
+            self.training,
+            shape)

--- a/src/brevitas/proxy/groupwise_float_runtime_quant.py
+++ b/src/brevitas/proxy/groupwise_float_runtime_quant.py
@@ -30,7 +30,7 @@ class GroupwiseActFloatQuantProxyFromInjector(ActFloatQuantProxyFromInjectorBase
             self,
             qt_args: Union[torch.Tensor, Tuple[Any]],
             x: Optional[GroupwiseFloatQuantTensor] = None) -> GroupwiseFloatQuantTensor:
-        if x is None:
+        if isinstance(qt_args, tuple):
             value, scale, zero_point, exponent_bit_width, mantissa_bit_width, exponent_bias, saturating, inf_values, nan_values = qt_args
             out = GroupwiseFloatQuantTensor(
                 value,
@@ -45,7 +45,8 @@ class GroupwiseActFloatQuantProxyFromInjector(ActFloatQuantProxyFromInjectorBase
                 inf_values,
                 nan_values,
                 self.is_signed,
-                self.training)
+                self.training,
+                dequant_shape=x.shape)
         else:
             out = GroupwiseFloatQuantTensor(
                 qt_args,
@@ -60,5 +61,6 @@ class GroupwiseActFloatQuantProxyFromInjector(ActFloatQuantProxyFromInjectorBase
                 x.inf_values,
                 x.nan_values,
                 x.signed,
-                self.training)
+                self.training,
+                x.shape)
         return out

--- a/src/brevitas/proxy/groupwise_float_runtime_quant.py
+++ b/src/brevitas/proxy/groupwise_float_runtime_quant.py
@@ -29,7 +29,7 @@ class GroupwiseActFloatQuantProxyFromInjector(ActFloatQuantProxyFromInjectorBase
     def create_quant_tensor(
             self,
             qt_args: Union[torch.Tensor, Tuple[Any]],
-            x: Optional[GroupwiseFloatQuantTensor] = None) -> GroupwiseFloatQuantTensor:
+            x: Union[torch.Tensor, GroupwiseFloatQuantTensor]) -> GroupwiseFloatQuantTensor:
         if isinstance(qt_args, tuple):
             value, scale, zero_point, exponent_bit_width, mantissa_bit_width, exponent_bias, saturating, inf_values, nan_values = qt_args
             out = GroupwiseFloatQuantTensor(

--- a/src/brevitas/proxy/groupwise_int_parameter_quant.py
+++ b/src/brevitas/proxy/groupwise_int_parameter_quant.py
@@ -34,6 +34,7 @@ class GroupwiseWeightQuantProxyFromInjector(WeightQuantProxyFromInjector):
         return x.flatten(start_dim, start_dim + 1)
 
     def create_quant_tensor(self, qt_args: Tuple[Any]) -> GroupwiseIntQuantTensor:
+        shape = self.tracked_parameter_list[0].shape
         out, scale, zero_point, bit_width = qt_args
         return GroupwiseIntQuantTensor(
             out,
@@ -43,4 +44,5 @@ class GroupwiseWeightQuantProxyFromInjector(WeightQuantProxyFromInjector):
             self.group_dim,
             bit_width,
             self.is_signed,
-            self.training)
+            self.training,
+            shape)

--- a/src/brevitas/proxy/groupwise_int_runtime_quant.py
+++ b/src/brevitas/proxy/groupwise_int_runtime_quant.py
@@ -30,7 +30,7 @@ class GroupwiseActQuantProxyFromInjector(ActQuantProxyFromInjector):
             self,
             qt_args: Union[torch.Tensor, Tuple[Any]],
             x: Optional[GroupwiseIntQuantTensor] = None) -> GroupwiseIntQuantTensor:
-        if x is None:
+        if isinstance(qt_args, tuple):
             value, scale, zero_point, bit_width = qt_args
             out = GroupwiseIntQuantTensor(
                 value,
@@ -40,7 +40,8 @@ class GroupwiseActQuantProxyFromInjector(ActQuantProxyFromInjector):
                 self.group_dim,
                 bit_width,
                 self.is_signed,
-                self.training)
+                self.training,
+                x.shape)
         else:
             out = GroupwiseIntQuantTensor(
                 qt_args,
@@ -50,5 +51,6 @@ class GroupwiseActQuantProxyFromInjector(ActQuantProxyFromInjector):
                 self.group_dim,
                 x.bit_width,
                 x.signed,
-                self.training)
+                self.training,
+                x.shape)
         return out

--- a/src/brevitas/proxy/groupwise_int_runtime_quant.py
+++ b/src/brevitas/proxy/groupwise_int_runtime_quant.py
@@ -29,7 +29,7 @@ class GroupwiseActQuantProxyFromInjector(ActQuantProxyFromInjector):
     def create_quant_tensor(
             self,
             qt_args: Union[torch.Tensor, Tuple[Any]],
-            x: Optional[GroupwiseIntQuantTensor] = None) -> GroupwiseIntQuantTensor:
+            x: Union[torch.Tensor, GroupwiseIntQuantTensor]) -> GroupwiseIntQuantTensor:
         if isinstance(qt_args, tuple):
             value, scale, zero_point, bit_width = qt_args
             out = GroupwiseIntQuantTensor(

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -157,7 +157,7 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
                             out.detach(),
                             metadata_only=self.cache_inference_quant_weight_metadata_only)
         else:  # quantization disabled
-            out = self.apply_input_view(x)
+            out = x
         return out
 
 

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -157,9 +157,8 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
 
     @abstractmethod
     def create_quant_tensor(
-            self,
-            qt_args: Union[torch.Tensor, Tuple[Any]],
-            x: Optional[QuantTensor] = None) -> QuantTensor:
+            self, qt_args: Union[torch.Tensor, Tuple[Any]], x: Union[Tensor,
+                                                                     QuantTensor]) -> QuantTensor:
         # Supports the following:
         # - qt_args as tuple of Tensors and bools = standard quant activations
         # - qt_args as Tensor and x as QuantTensor = passthrough activation
@@ -194,7 +193,7 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         else:
             # If the second value (i.e., scale) is None, then quant is disabled
             if y[1] is not None:
-                out = self.create_quant_tensor(y)
+                out = self.create_quant_tensor(y, x=x)
             elif self.is_passthrough_act and isinstance(x, QuantTensor):
                 # preserve scale/zp/bit/sign even without output quant
                 y = y[0]

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -180,8 +180,7 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         elif not self.is_quant_enabled:
             # A tuple helps later with control flows
             # The second None value is used later
-            # If quant is not enabled, we still apply input_view in the case of groupwise + padding
-            y = self.apply_input_view(self.fused_activation_quant_proxy.activation_impl(y))
+            y = self.fused_activation_quant_proxy.activation_impl(y)
             y = (y, None)
         else:
             y = self.fused_activation_quant_proxy(y)

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -222,10 +222,8 @@ class ActQuantProxyFromInjector(ActQuantProxyFromInjectorBase):
         return self.retrieve_attribute('bit_width', force_eval)
 
     def create_quant_tensor(
-            self,
-            qt_args: Union[Tensor, Tuple[Any]],
-            x: Optional[IntQuantTensor] = None) -> IntQuantTensor:
-
+            self, qt_args: Union[torch.Tensor, Tuple[Any]],
+            x: Union[Tensor, IntQuantTensor]) -> IntQuantTensor:
         if isinstance(qt_args, tuple):
             out = IntQuantTensor(*qt_args, self.is_signed, self.training)
         else:

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -227,7 +227,7 @@ class ActQuantProxyFromInjector(ActQuantProxyFromInjectorBase):
             qt_args: Union[Tensor, Tuple[Any]],
             x: Optional[IntQuantTensor] = None) -> IntQuantTensor:
 
-        if x is None:
+        if isinstance(qt_args, tuple):
             out = IntQuantTensor(*qt_args, self.is_signed, self.training)
         else:
             out = IntQuantTensor(

--- a/src/brevitas/quant_tensor/base_quant_tensor.py
+++ b/src/brevitas/quant_tensor/base_quant_tensor.py
@@ -1,4 +1,4 @@
-from typing import List, NamedTuple, Optional
+from typing import List, NamedTuple, Optional, Tuple
 
 from torch import Tensor
 
@@ -129,6 +129,7 @@ class GroupwiseFloatQuantTensorBase(NamedTuple):
     nan_values: List[str]
     signed_t: Tensor
     training_t: Tensor
+    dequant_shape: Optional[Tuple] = None
 
 
 class GroupwisIntQuantTensorBase(NamedTuple):
@@ -140,6 +141,7 @@ class GroupwisIntQuantTensorBase(NamedTuple):
     bit_width: Tensor
     signed_t: Tensor
     training_t: Tensor
+    dequant_shape: Optional[Tuple] = None
 
 
 def _unpack_quant_tensor(input_data):

--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -109,7 +109,7 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, QuantTensor):
         # Then, we unbind the tensor along the group_dim shape, and drop the padded columns
         # Finally, we stack the remaining tensors
         unpadding_shape = final_shape[self.group_dim]
-        residual = curr_shape[self.group_dim] - unpadding_shape
+        residual = new_value.shape[self.group_dim] - unpadding_shape
 
         if residual > 0:
             new_value = torch.stack(

--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -113,12 +113,12 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, QuantTensor):
 
         if residual > 0:
             new_value = torch.stack(
-                torch.unbind(new_value, dim=self.group_dim)[residual:], dim=self.group_dim)
+                torch.unbind(new_value, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
             new_scale = torch.stack(
-                torch.unbind(new_scale, dim=self.group_dim)[residual:], dim=self.group_dim)
+                torch.unbind(new_scale, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
             if self.zero_point_.shape != ():
                 new_zp = torch.stack(
-                    torch.unbind(new_zp, dim=self.group_dim)[residual:], dim=self.group_dim)
+                    torch.unbind(new_zp, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
 
         return new_value, new_scale, new_zp
 

--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -91,8 +91,8 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, QuantTensor):
             return func(*args, **kwargs)
 
     def expand(self):
-        from brevitas.utils.quant_utils import groupwise_dequant
-        return groupwise_dequant(
+        from brevitas.utils.quant_utils import groupwise_dequant_expand
+        return groupwise_dequant_expand(
             self.value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
 
     @staticmethod

--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -91,36 +91,9 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, QuantTensor):
             return func(*args, **kwargs)
 
     def expand(self):
-        final_shape = self.dequant_shape
-        curr_shape = self.value_.shape
-        start_dim = self.group_dim if self.group_dim != -1 else -2
-        new_value = self.value_.flatten(start_dim, start_dim + 1)
-        if self.scale_.shape != ():
-            new_scale = self.scale_.expand(curr_shape).flatten(start_dim, start_dim + 1)
-        else:
-            new_scale = self.scale_
-        if self.zero_point_.shape != ():
-            new_zp = self.zero_point_.expand(curr_shape).flatten(start_dim, start_dim + 1)
-        else:
-            new_zp = self.zero_point_
-
-        # If we padded during quantization, we unpad here:
-        # First, we compute how much we padded along the group_dim shape
-        # Then, we unbind the tensor along the group_dim shape, and drop the padded columns
-        # Finally, we stack the remaining tensors
-        unpadding_shape = final_shape[self.group_dim]
-        residual = new_value.shape[self.group_dim] - unpadding_shape
-
-        if residual > 0:
-            new_value = torch.stack(
-                torch.unbind(new_value, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
-            new_scale = torch.stack(
-                torch.unbind(new_scale, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
-            if self.zero_point_.shape != ():
-                new_zp = torch.stack(
-                    torch.unbind(new_zp, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
-
-        return new_value, new_scale, new_zp
+        from brevitas.utils.quant_utils import groupwise_dequant
+        return groupwise_dequant(
+            self.value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
 
     @staticmethod
     def from_expanded(value, group_size, group_dim, compress=False):

--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -116,8 +116,9 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, QuantTensor):
                 torch.unbind(new_value, dim=self.group_dim)[residual:], dim=self.group_dim)
             new_scale = torch.stack(
                 torch.unbind(new_scale, dim=self.group_dim)[residual:], dim=self.group_dim)
-            new_zp = torch.stack(
-                torch.unbind(new_zp, dim=self.group_dim)[residual:], dim=self.group_dim)
+            if self.zero_point_.shape != ():
+                new_zp = torch.stack(
+                    torch.unbind(new_zp, dim=self.group_dim)[residual:], dim=self.group_dim)
 
         return new_value, new_scale, new_zp
 

--- a/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
@@ -99,12 +99,12 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, QuantTensor):
 
         if residual > 0:
             new_value = torch.stack(
-                torch.unbind(new_value, dim=self.group_dim)[residual:], dim=self.group_dim)
+                torch.unbind(new_value, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
             new_scale = torch.stack(
-                torch.unbind(new_scale, dim=self.group_dim)[residual:], dim=self.group_dim)
+                torch.unbind(new_scale, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
             if self.zero_point_.shape != ():
                 new_zp = torch.stack(
-                    torch.unbind(new_zp, dim=self.group_dim)[residual:], dim=self.group_dim)
+                    torch.unbind(new_zp, dim=self.group_dim)[:unpadding_shape], dim=self.group_dim)
 
         return new_value, new_scale, new_zp
 

--- a/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
@@ -77,8 +77,8 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, QuantTensor):
             return func(*args, **kwargs)
 
     def expand(self):
-        from brevitas.utils.quant_utils import groupwise_dequant
-        return groupwise_dequant(
+        from brevitas.utils.quant_utils import groupwise_dequant_expand
+        return groupwise_dequant_expand(
             self.value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
 
     @staticmethod

--- a/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
@@ -102,8 +102,9 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, QuantTensor):
                 torch.unbind(new_value, dim=self.group_dim)[residual:], dim=self.group_dim)
             new_scale = torch.stack(
                 torch.unbind(new_scale, dim=self.group_dim)[residual:], dim=self.group_dim)
-            new_zp = torch.stack(
-                torch.unbind(new_zp, dim=self.group_dim)[residual:], dim=self.group_dim)
+            if self.zero_point_.shape != ():
+                new_zp = torch.stack(
+                    torch.unbind(new_zp, dim=self.group_dim)[residual:], dim=self.group_dim)
 
         return new_value, new_scale, new_zp
 

--- a/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
@@ -95,7 +95,7 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, QuantTensor):
         # Then, we unbind the tensor along the group_dim shape, and drop the padded columns
         # Finally, we stack the remaining tensors
         unpadding_shape = final_shape[self.group_dim]
-        residual = curr_shape[self.group_dim] - unpadding_shape
+        residual = new_value.shape[self.group_dim] - unpadding_shape
 
         if residual > 0:
             new_value = torch.stack(

--- a/src/brevitas/utils/quant_utils.py
+++ b/src/brevitas/utils/quant_utils.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import torch
+
 from brevitas.core.bit_width import BitWidthParameter
 from brevitas.core.function_wrapper import *
 from brevitas.core.quant import RescalingIntQuant
@@ -215,3 +217,36 @@ def float_to_int_impl_to_enum(module):
             return FloatToIntImplType.STOCHASTIC_ROUND
     else:
         return None
+
+
+def groupwise_dequant(value_, scale_, zero_point_, group_dim, dequant_shape):
+    final_shape = dequant_shape
+    curr_shape = value_.shape
+    start_dim = group_dim if group_dim != -1 else -2
+    new_value = value_.flatten(start_dim, start_dim + 1)
+    if scale_.shape != ():
+        new_scale = scale_.expand(curr_shape).flatten(start_dim, start_dim + 1)
+    else:
+        new_scale = scale_
+    if zero_point_.shape != ():
+        new_zp = zero_point_.expand(curr_shape).flatten(start_dim, start_dim + 1)
+    else:
+        new_zp = zero_point_
+
+    # If we padded during quantization, we unpad here:
+    # First, we compute how much we padded along the group_dim shape
+    # Then, we unbind the tensor along the group_dim shape, and drop the padded columns
+    # Finally, we stack the remaining tensors
+    unpadding_shape = final_shape[group_dim]
+    residual = new_value.shape[group_dim] - unpadding_shape
+
+    if residual > 0:
+        new_value = torch.stack(
+            torch.unbind(new_value, dim=group_dim)[:unpadding_shape], dim=group_dim)
+        new_scale = torch.stack(
+            torch.unbind(new_scale, dim=group_dim)[:unpadding_shape], dim=group_dim)
+        if zero_point_.shape != ():
+            new_zp = torch.stack(
+                torch.unbind(new_zp, dim=group_dim)[:unpadding_shape], dim=group_dim)
+
+    return new_value, new_scale, new_zp

--- a/src/brevitas/utils/quant_utils.py
+++ b/src/brevitas/utils/quant_utils.py
@@ -219,7 +219,7 @@ def float_to_int_impl_to_enum(module):
         return None
 
 
-def groupwise_dequant(value_, scale_, zero_point_, group_dim, dequant_shape):
+def groupwise_dequant_expand(value_, scale_, zero_point_, group_dim, dequant_shape):
     final_shape = dequant_shape
     curr_shape = value_.shape
     start_dim = group_dim if group_dim != -1 else -2

--- a/tests/brevitas/graph/test_gpxq.py
+++ b/tests/brevitas/graph/test_gpxq.py
@@ -89,18 +89,8 @@ def test_toymodels(toy_quant_model, act_order, use_quant_activations, apply_gpxq
     dataset = TensorDataset(inp, inp)
     calib_loader = DataLoader(dataset, batch_size=16, num_workers=0, pin_memory=True, shuffle=True)
 
-    if ((name == 'gptq' or name == 'gpfq2') and torch_version < version.parse('1.10')):
-        # Usage of linalg_cholesky() is not compatible with torch 1.9.1 and below
-        with pytest.raises(AssertionError):
-            apply_gpxq(
-                calib_loader=calib_loader,
-                model=model,
-                act_order=act_order,
-                use_quant_activations=use_quant_activations)
-
-    else:
-        apply_gpxq(
-            calib_loader=calib_loader,
-            model=model,
-            act_order=act_order,
-            use_quant_activations=use_quant_activations)
+    apply_gpxq(
+        calib_loader=calib_loader,
+        model=model,
+        act_order=act_order,
+        use_quant_activations=use_quant_activations)


### PR DESCRIPTION
## Reason for this PR

Groupwise quantization requires padding when the input channel shape is not divisible by groupsize.

Padding works well until it doesn't, and there are important edge cases that were not covered by the previous implementation.
 (e.g., weight only quantization where padding was required. Until now, we also had to force activation quantization because otherwise we had shape mismatch).

## Changes Made in this PR
With the current implementation, we un-pad when dequantizing, taking care of all the edge cases

Few todos:
- [x] Consolidate dequantization for groupwise tensors + inference export
- [x] Fix typing in runtime activations
- [x] Testing

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [x] Post-review full CI/CD passing.
