### PR TITLE
test (core/float): Enhanced testing of minifloat formats

### DIFF
--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy
+from functools import wraps
 from typing import List, Optional, Tuple
 
 import torch
@@ -127,3 +128,21 @@ def is_broadcastable(tensor, other):
         else:
             return False
     return True
+
+
+def torch_dtype(dtype):
+
+    def decorator(fn):
+
+        @wraps(fn)
+        def wrapped_fn(*args, **kwargs):
+            cur_dtype = torch.get_default_dtype()
+            try:
+                torch.set_default_dtype(dtype)
+                fn(*args, **kwargs)
+            finally:
+                torch.set_default_dtype(cur_dtype)
+
+        return wrapped_fn
+
+    return decorator

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -237,7 +237,9 @@ def test_inner_scale(inp, minifloat_format, scale):
             assert torch.equal(out[~out_nans], expected_out[~expected_out_nans])
 
 
-@given(minifloat_format_and_value=random_minifloat_format_and_value(min_bit_width=4, max_bit_with=10, rand_exp_bias=True))
+@given(
+    minifloat_format_and_value=random_minifloat_format_and_value(
+        min_bit_width=4, max_bit_with=10, rand_exp_bias=True))
 @settings(max_examples=10000)
 @jit_disabled_for_mock()
 @torch.no_grad()

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -18,6 +18,7 @@ from brevitas.utils.torch_utils import float_internal_scale
 from tests.brevitas.hyp_helper import float_st
 from tests.brevitas.hyp_helper import float_tensor_random_shape_st
 from tests.brevitas.hyp_helper import random_minifloat_format
+from tests.brevitas.hyp_helper import random_minifloat_format_and_value
 from tests.marker import jit_disabled_for_mock
 
 
@@ -233,3 +234,44 @@ def test_inner_scale(inp, minifloat_format, scale):
             out_nans = out.isnan()
             expected_out_nans = expected_out.isnan()
             assert torch.equal(out[~out_nans], expected_out[~expected_out_nans])
+
+
+@given(minifloat_format_and_value=random_minifloat_format_and_value(min_bit_width=4, max_bit_with=10, rand_exp_bias=True))
+@jit_disabled_for_mock()
+@torch.no_grad()
+def test_valid_float_values(minifloat_format_and_value):
+    minifloat_value, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = minifloat_format_and_value
+    scaling_impl = mock.Mock(side_effect=lambda x, y: 1.0)
+    float_scaling = FloatScaling(None, None, True)
+    if exponent_bit_width == 0 or mantissa_bit_width == 0:
+        with pytest.raises(RuntimeError):
+            float_quant = FloatQuant(
+                bit_width=bit_width,
+                exponent_bit_width=exponent_bit_width,
+                mantissa_bit_width=mantissa_bit_width,
+                exponent_bias=exponent_bias,
+                signed=signed,
+                input_view_impl=Identity(),
+                scaling_impl=scaling_impl,
+                float_scaling_impl=float_scaling,
+                float_clamp_impl=None)
+    else:
+        float_clamp = FloatClamp(
+            tensor_clamp_impl=TensorClamp(),
+            signed=signed,
+            inf_values=None,
+            nan_values=None,
+            saturating=True)
+        float_quant = FloatQuant(
+            bit_width=bit_width,
+            exponent_bit_width=exponent_bit_width,
+            mantissa_bit_width=mantissa_bit_width,
+            exponent_bias=exponent_bias,
+            signed=signed,
+            input_view_impl=Identity(),
+            scaling_impl=scaling_impl,
+            float_scaling_impl=float_scaling,
+            float_clamp_impl=float_clamp)
+        inp = torch.tensor(minifloat_value)
+        quant_value, *_ = float_quant(inp)
+        assert torch.equal(inp, quant_value)

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -240,6 +240,7 @@ def test_inner_scale(inp, minifloat_format, scale):
 @jit_disabled_for_mock()
 @torch.no_grad()
 def test_valid_float_values(minifloat_format_and_value):
+    torch.set_default_dtype(torch.float64)
     minifloat_value, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = minifloat_format_and_value
     scaling_impl = mock.Mock(side_effect=lambda x, y: 1.0)
     float_scaling = FloatScaling(None, None, True)

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -249,35 +249,22 @@ def test_valid_float_values(minifloat_format_and_value):
     minifloat_value, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = minifloat_format_and_value
     scaling_impl = mock.Mock(side_effect=lambda x, y: 1.0)
     float_scaling = FloatScaling(None, None, True)
-    if exponent_bit_width == 0 or mantissa_bit_width == 0:
-        with pytest.raises(RuntimeError):
-            float_quant = FloatQuant(
-                bit_width=bit_width,
-                exponent_bit_width=exponent_bit_width,
-                mantissa_bit_width=mantissa_bit_width,
-                exponent_bias=exponent_bias,
-                signed=signed,
-                input_view_impl=Identity(),
-                scaling_impl=scaling_impl,
-                float_scaling_impl=float_scaling,
-                float_clamp_impl=None)
-    else:
-        float_clamp = FloatClamp(
-            tensor_clamp_impl=TensorClamp(),
-            signed=signed,
-            inf_values=None,
-            nan_values=None,
-            saturating=True)
-        float_quant = FloatQuant(
-            bit_width=bit_width,
-            exponent_bit_width=exponent_bit_width,
-            mantissa_bit_width=mantissa_bit_width,
-            exponent_bias=exponent_bias,
-            signed=signed,
-            input_view_impl=Identity(),
-            scaling_impl=scaling_impl,
-            float_scaling_impl=float_scaling,
-            float_clamp_impl=float_clamp)
-        inp = torch.tensor(minifloat_value)
-        quant_value, *_ = float_quant(inp)
-        assert torch.equal(inp, quant_value)
+    float_clamp = FloatClamp(
+        tensor_clamp_impl=TensorClamp(),
+        signed=signed,
+        inf_values=None,
+        nan_values=None,
+        saturating=True)
+    float_quant = FloatQuant(
+        bit_width=bit_width,
+        exponent_bit_width=exponent_bit_width,
+        mantissa_bit_width=mantissa_bit_width,
+        exponent_bias=exponent_bias,
+        signed=signed,
+        input_view_impl=Identity(),
+        scaling_impl=scaling_impl,
+        float_scaling_impl=float_scaling,
+        float_clamp_impl=float_clamp)
+    inp = torch.tensor(minifloat_value)
+    quant_value, *_ = float_quant(inp)
+    assert torch.equal(inp, quant_value)

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from hypothesis import given
+from hypothesis import settings
 import mock
 import pytest
 import torch
@@ -237,6 +238,7 @@ def test_inner_scale(inp, minifloat_format, scale):
 
 
 @given(minifloat_format_and_value=random_minifloat_format_and_value(min_bit_width=4, max_bit_with=10, rand_exp_bias=True))
+@settings(max_examples=10000)
 @jit_disabled_for_mock()
 @torch.no_grad()
 def test_valid_float_values(minifloat_format_and_value):

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -241,7 +241,7 @@ def test_inner_scale(inp, minifloat_format, scale):
 @given(
     minifloat_format_and_value=random_minifloat_format_and_value(
         min_bit_width=4, max_bit_with=10, rand_exp_bias=True))
-@settings(max_examples=10000)
+@settings(max_examples=1000)
 @jit_disabled_for_mock()
 @torch_dtype(torch.float64)
 @torch.no_grad()

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -243,35 +243,22 @@ def test_valid_float_values(minifloat_format_and_value):
     minifloat_value, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = minifloat_format_and_value
     scaling_impl = mock.Mock(side_effect=lambda x, y: 1.0)
     float_scaling = FloatScaling(None, None, True)
-    if exponent_bit_width == 0 or mantissa_bit_width == 0:
-        with pytest.raises(RuntimeError):
-            float_quant = FloatQuant(
-                bit_width=bit_width,
-                exponent_bit_width=exponent_bit_width,
-                mantissa_bit_width=mantissa_bit_width,
-                exponent_bias=exponent_bias,
-                signed=signed,
-                input_view_impl=Identity(),
-                scaling_impl=scaling_impl,
-                float_scaling_impl=float_scaling,
-                float_clamp_impl=None)
-    else:
-        float_clamp = FloatClamp(
-            tensor_clamp_impl=TensorClamp(),
-            signed=signed,
-            inf_values=None,
-            nan_values=None,
-            saturating=True)
-        float_quant = FloatQuant(
-            bit_width=bit_width,
-            exponent_bit_width=exponent_bit_width,
-            mantissa_bit_width=mantissa_bit_width,
-            exponent_bias=exponent_bias,
-            signed=signed,
-            input_view_impl=Identity(),
-            scaling_impl=scaling_impl,
-            float_scaling_impl=float_scaling,
-            float_clamp_impl=float_clamp)
-        inp = torch.tensor(minifloat_value)
-        quant_value, *_ = float_quant(inp)
-        assert torch.equal(inp, quant_value)
+    float_clamp = FloatClamp(
+        tensor_clamp_impl=TensorClamp(),
+        signed=signed,
+        inf_values=None,
+        nan_values=None,
+        saturating=True)
+    float_quant = FloatQuant(
+        bit_width=bit_width,
+        exponent_bit_width=exponent_bit_width,
+        mantissa_bit_width=mantissa_bit_width,
+        exponent_bias=exponent_bias,
+        signed=signed,
+        input_view_impl=Identity(),
+        scaling_impl=scaling_impl,
+        float_scaling_impl=float_scaling,
+        float_clamp_impl=float_clamp)
+    inp = torch.tensor(minifloat_value)
+    quant_value, *_ = float_quant(inp)
+    assert torch.equal(inp, quant_value)

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -16,6 +16,7 @@ from brevitas.core.scaling import ConstScaling
 from brevitas.core.scaling import FloatScaling
 from brevitas.function.ops import max_float
 from brevitas.utils.torch_utils import float_internal_scale
+from brevitas.utils.torch_utils import torch_dtype
 from tests.brevitas.hyp_helper import float_st
 from tests.brevitas.hyp_helper import float_tensor_random_shape_st
 from tests.brevitas.hyp_helper import random_minifloat_format
@@ -242,9 +243,9 @@ def test_inner_scale(inp, minifloat_format, scale):
         min_bit_width=4, max_bit_with=10, rand_exp_bias=True))
 @settings(max_examples=10000)
 @jit_disabled_for_mock()
+@torch_dtype(torch.float64)
 @torch.no_grad()
 def test_valid_float_values(minifloat_format_and_value):
-    torch.set_default_dtype(torch.float64)
     minifloat_value, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = minifloat_format_and_value
     scaling_impl = mock.Mock(side_effect=lambda x, y: 1.0)
     float_scaling = FloatScaling(None, None, True)

--- a/tests/brevitas/hyp_helper.py
+++ b/tests/brevitas/hyp_helper.py
@@ -227,17 +227,18 @@ def min_max_tensor_random_shape_st(draw, min_dims=1, max_dims=4, max_size=3, wid
 
 
 @st.composite
-def random_minifloat_format(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False):
+def random_minifloat_format(
+        draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False):
     """"
     Generate a minifloat format. Returns bit_width, exponent, mantissa, and signed.
     """
     # TODO: add support for new minifloat format that comes with FloatQuantTensor
     bit_width = draw(st.integers(min_value=min_bit_width, max_value=max_bit_with))
     signed = draw(st.booleans())
-    exponent_bit_width = draw(st.integers(min_value=1, max_value=bit_width-1-int(signed)))
+    exponent_bit_width = draw(st.integers(min_value=1, max_value=bit_width - 1 - int(signed)))
 
     if rand_exp_bias:
-        exponent_bias =  draw(st.integers(min_value=-127, max_value=127))
+        exponent_bias = draw(st.integers(min_value=-127, max_value=127))
     else:
         exponent_bias = 2 ** (exponent_bit_width - 1) - 1
 
@@ -250,7 +251,8 @@ def random_minifloat_format(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=
 
 
 @st.composite
-def random_valid_minifloat(draw, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias):
+def random_valid_minifloat(
+        draw, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias):
     """"
     Generate a valid minifloat value, from the given format. Returns a valid minifloat value
     """
@@ -258,20 +260,21 @@ def random_valid_minifloat(draw, bit_width, exponent_bit_width, mantissa_bit_wid
     assert bit_width == exponent_bit_width + mantissa_bit_width + int(signed)
     # Generate int values of the minifloat components
     sign = draw(st.integers(min_value=0, max_value=int(signed)))
-    mantissa = draw(st.integers(min_value=0, max_value=int(2**mantissa_bit_width-1)))
-    exponent = draw(st.integers(min_value=0, max_value=int(2**exponent_bit_width-1)))
+    mantissa = draw(st.integers(min_value=0, max_value=int(2 ** mantissa_bit_width - 1)))
+    exponent = draw(st.integers(min_value=0, max_value=int(2 ** exponent_bit_width - 1)))
     # Scale mantissa between 0-1
-    mantissa_fixed = mantissa / 2**mantissa_bit_width
+    mantissa_fixed = mantissa / 2 ** mantissa_bit_width
     # Add 1 unless denormalised
     mantissa_fixed += 0. if exponent == 0 else 1.
     # Adjust exponent if denormalised, otherwise leave it unchanged
     exponent_value = 1 if exponent == 0 else exponent
-    valid_minifloat = ((-1.)**sign) * (mantissa_fixed * 2**(exponent_value-exponent_bias))
+    valid_minifloat = ((-1.) ** sign) * (mantissa_fixed * 2 ** (exponent_value - exponent_bias))
     return valid_minifloat, exponent, mantissa, sign
 
 
 @st.composite
-def random_minifloat_format_and_value(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False):
+def random_minifloat_format_and_value(
+        draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False):
     bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = draw(random_minifloat_format(min_bit_width=min_bit_width, max_bit_with=max_bit_with, rand_exp_bias=rand_exp_bias))
     valid_minifloat, exponent, mantissa, sign = draw(random_valid_minifloat(bit_width=bit_width, exponent_bit_width=exponent_bit_width, mantissa_bit_width=mantissa_bit_width, signed=signed, exponent_bias=exponent_bias))
     return valid_minifloat, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias

--- a/tests/brevitas/hyp_helper.py
+++ b/tests/brevitas/hyp_helper.py
@@ -227,7 +227,7 @@ def min_max_tensor_random_shape_st(draw, min_dims=1, max_dims=4, max_size=3, wid
 
 
 @st.composite
-def random_minifloat_format(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH):
+def random_minifloat_format(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False):
     """"
     Generate a minifloat format. Returns bit_width, exponent, mantissa, and signed.
     """
@@ -236,7 +236,10 @@ def random_minifloat_format(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=
     exponent_bit_width = draw(st.integers(min_value=0, max_value=bit_width))
     signed = draw(st.booleans())
 
-    exponent_bias = 2 ** (exponent_bit_width - 1) - 1
+    if rand_exp_bias:
+        exponent_bias =  draw(st.integers(min_value=-127, max_value=127))
+    else:
+        exponent_bias = 2 ** (exponent_bit_width - 1) - 1
 
     # if no budget is left, return
     if bit_width == exponent_bit_width:
@@ -246,3 +249,31 @@ def random_minifloat_format(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=
     mantissa_bit_width = bit_width - exponent_bit_width - int(signed)
 
     return bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias
+
+
+@st.composite
+def random_valid_minifloat(draw, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias):
+    """"
+    Generate a valid minifloat value, from the given format. Returns a valid minifloat value
+    """
+    # Sanity-check that the format is valid
+    assert bit_width == exponent_bit_width + mantissa_bit_width + int(signed)
+    # Generate int values of the minifloat components
+    sign = draw(st.integers(min_value=0, max_value=int(signed)))
+    mantissa = draw(st.integers(min_value=0, max_value=int(2**mantissa_bit_width-1)))
+    exponent = draw(st.integers(min_value=0, max_value=int(2**exponent_bit_width-1)))
+    # Scale mantissa between 0-1
+    mantissa_fixed = mantissa / 2**mantissa
+    # Add 1 unless denormalised
+    mantissa_fixed += 0. if exponent == 0 else 1.
+    # Adjust exponent if denormalised, otherwise leave it unchanged
+    exponent_value = 1 if exponent == 0 else exponent
+    valid_minifloat = ((-1.)**sign) * (mantissa_fixed * 2**(exponent_value-exponent_bias))
+    return valid_minifloat, exponent, mantissa, sign
+
+
+@st.composite
+def random_minifloat_format_and_value(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False):
+    bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = draw(random_minifloat_format(min_bit_width=min_bit_width, max_bit_with=max_bit_with, rand_exp_bias=rand_exp_bias))
+    valid_minifloat, exponent, mantissa, sign = draw(random_valid_minifloat(bit_width=bit_width, exponent_bit_width=exponent_bit_width, mantissa_bit_width=mantissa_bit_width, signed=signed, exponent_bias=exponent_bias))
+    return valid_minifloat, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias

--- a/tests/brevitas/hyp_helper.py
+++ b/tests/brevitas/hyp_helper.py
@@ -228,7 +228,11 @@ def min_max_tensor_random_shape_st(draw, min_dims=1, max_dims=4, max_size=3, wid
 
 @st.composite
 def random_minifloat_format(
-        draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False, valid_only=False):
+        draw,
+        min_bit_width=MIN_INT_BIT_WIDTH,
+        max_bit_with=MAX_INT_BIT_WIDTH,
+        rand_exp_bias=False,
+        valid_only=False):
     """"
     Generate a minifloat format. Returns bit_width, exponent, mantissa, and signed.
     """
@@ -281,7 +285,11 @@ def random_valid_minifloat(
 
 @st.composite
 def random_minifloat_format_and_value(
-        draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False, valid_format_only=True):
+        draw,
+        min_bit_width=MIN_INT_BIT_WIDTH,
+        max_bit_with=MAX_INT_BIT_WIDTH,
+        rand_exp_bias=False,
+        valid_format_only=True):
     bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = draw(random_minifloat_format(min_bit_width=min_bit_width, max_bit_with=max_bit_with, rand_exp_bias=rand_exp_bias, valid_only=valid_format_only))
     valid_minifloat, exponent, mantissa, sign = draw(random_valid_minifloat(bit_width=bit_width, exponent_bit_width=exponent_bit_width, mantissa_bit_width=mantissa_bit_width, signed=signed, exponent_bias=exponent_bias))
     return valid_minifloat, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias

--- a/tests/brevitas/hyp_helper.py
+++ b/tests/brevitas/hyp_helper.py
@@ -254,7 +254,7 @@ def random_minifloat_format(
 def random_valid_minifloat(
         draw, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias):
     """"
-    Generate a valid minifloat value, from the given format. Returns a valid minifloat value
+    Generate a random floating-point value that can be represented in the specified minifloat format.
     """
     # Sanity-check that the format is valid
     assert bit_width == exponent_bit_width + mantissa_bit_width + int(signed)

--- a/tests/brevitas/hyp_helper.py
+++ b/tests/brevitas/hyp_helper.py
@@ -233,8 +233,8 @@ def random_minifloat_format(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=
     """
     # TODO: add support for new minifloat format that comes with FloatQuantTensor
     bit_width = draw(st.integers(min_value=min_bit_width, max_value=max_bit_with))
-    exponent_bit_width = draw(st.integers(min_value=0, max_value=bit_width))
     signed = draw(st.booleans())
+    exponent_bit_width = draw(st.integers(min_value=1, max_value=bit_width-1-int(signed)))
 
     if rand_exp_bias:
         exponent_bias =  draw(st.integers(min_value=-127, max_value=127))
@@ -242,9 +242,7 @@ def random_minifloat_format(draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=
         exponent_bias = 2 ** (exponent_bit_width - 1) - 1
 
     # if no budget is left, return
-    if bit_width == exponent_bit_width:
-        return bit_width, exponent_bit_width, 0, False, exponent_bias
-    elif bit_width == (exponent_bit_width + int(signed)):
+    if bit_width == (exponent_bit_width + int(signed)):
         return bit_width, exponent_bit_width, 0, signed, exponent_bias
     mantissa_bit_width = bit_width - exponent_bit_width - int(signed)
 

--- a/tests/brevitas/hyp_helper.py
+++ b/tests/brevitas/hyp_helper.py
@@ -261,7 +261,7 @@ def random_valid_minifloat(draw, bit_width, exponent_bit_width, mantissa_bit_wid
     mantissa = draw(st.integers(min_value=0, max_value=int(2**mantissa_bit_width-1)))
     exponent = draw(st.integers(min_value=0, max_value=int(2**exponent_bit_width-1)))
     # Scale mantissa between 0-1
-    mantissa_fixed = mantissa / 2**mantissa
+    mantissa_fixed = mantissa / 2**mantissa_bit_width
     # Add 1 unless denormalised
     mantissa_fixed += 0. if exponent == 0 else 1.
     # Adjust exponent if denormalised, otherwise leave it unchanged

--- a/tests/brevitas/hyp_helper.py
+++ b/tests/brevitas/hyp_helper.py
@@ -234,8 +234,8 @@ def random_minifloat_format(
     """
     # TODO: add support for new minifloat format that comes with FloatQuantTensor
     bit_width = draw(st.integers(min_value=min_bit_width, max_value=max_bit_with))
+    exponent_bit_width = draw(st.integers(min_value=0, max_value=bit_width))
     signed = draw(st.booleans())
-    exponent_bit_width = draw(st.integers(min_value=1, max_value=bit_width - 1 - int(signed)))
 
     if rand_exp_bias:
         exponent_bias = draw(st.integers(min_value=-127, max_value=127))
@@ -243,7 +243,9 @@ def random_minifloat_format(
         exponent_bias = 2 ** (exponent_bit_width - 1) - 1
 
     # if no budget is left, return
-    if bit_width == (exponent_bit_width + int(signed)):
+    if bit_width == exponent_bit_width:
+        return bit_width, exponent_bit_width, 0, False, exponent_bias
+    elif bit_width == (exponent_bit_width + int(signed)):
         return bit_width, exponent_bit_width, 0, signed, exponent_bias
     mantissa_bit_width = bit_width - exponent_bit_width - int(signed)
 

--- a/tests/brevitas/hyp_helper.py
+++ b/tests/brevitas/hyp_helper.py
@@ -281,7 +281,7 @@ def random_valid_minifloat(
 
 @st.composite
 def random_minifloat_format_and_value(
-        draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False, valid_only=True):
-    bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = draw(random_minifloat_format(min_bit_width=min_bit_width, max_bit_with=max_bit_with, rand_exp_bias=rand_exp_bias))
+        draw, min_bit_width=MIN_INT_BIT_WIDTH, max_bit_with=MAX_INT_BIT_WIDTH, rand_exp_bias=False, valid_format_only=True):
+    bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias = draw(random_minifloat_format(min_bit_width=min_bit_width, max_bit_with=max_bit_with, rand_exp_bias=rand_exp_bias, valid_only=valid_format_only))
     valid_minifloat, exponent, mantissa, sign = draw(random_valid_minifloat(bit_width=bit_width, exponent_bit_width=exponent_bit_width, mantissa_bit_width=mantissa_bit_width, signed=signed, exponent_bias=exponent_bias))
     return valid_minifloat, exponent, mantissa, sign, bit_width, exponent_bit_width, mantissa_bit_width, signed, exponent_bias


### PR DESCRIPTION
## Reason for this PR

An enhanced test suite of minifloat formats to address #1126.

## Changes Made in this PR

The enhanced test suite generates 10000 random valid minifloat formats / values and checks that Brevitas produces the identical output. Float64 is used for arithmetic to avoid rounding errors in `log2`, `exp2` computations.

## Testing Summary

Tests run and pass locally, e.g.:

```
pytest --hypothesis-verbosity=verbose --hypothesis-show-statistics -n logical tests/brevitas/core/test_float_quant.py::test_valid_float_values
tests/brevitas/core/test_float_quant.py::test_valid_float_values
[gw0] [100%] PASSED tests/brevitas/core/test_float_quant.py::test_valid_float_values
tests/brevitas/core/test_float_quant.py::test_valid_float_values:

  - during generate phase (25.89 seconds):
    - Typical runtimes: ~ 1-2 ms, of which < 1ms in data generation
    - 10000 passing examples, 0 failing examples, 0 invalid examples

  - Stopped because settings.max_examples=10000
```

## Risk Highlight

Only tests added. No change in brevitas code itself. Zero risks IMO.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [x] 1+ reviews given, and any review issues addressed and approved.
- [x] Post-review full CI/CD passing.
