### PR TITLE
Fix: pytree warning

### DIFF
--- a/src/brevitas/backport/fx/immutable_collections.py
+++ b/src/brevitas/backport/fx/immutable_collections.py
@@ -43,7 +43,12 @@ Forked as-is from PyTorch 2.0.1
 
 from typing import Any, Dict, List, Tuple
 
-from torch.utils._pytree import register_pytree_node
+try:
+    from torch.utils._pytree import register_pytree_node
+except:
+    # Deprecated as of 2.3, but keeping for backportability
+    from torch.utils._pytree import _register_pytree_node
+    register_pytree_node = _register_pytree_node
 from torch.utils._pytree import Context
 
 from ._compatibility import compatibility

--- a/src/brevitas/backport/fx/immutable_collections.py
+++ b/src/brevitas/backport/fx/immutable_collections.py
@@ -43,7 +43,7 @@ Forked as-is from PyTorch 2.0.1
 
 from typing import Any, Dict, List, Tuple
 
-from torch.utils._pytree import _register_pytree_node
+from torch.utils._pytree import register_pytree_node
 from torch.utils._pytree import Context
 
 from ._compatibility import compatibility
@@ -111,5 +111,5 @@ def _immutable_list_unflatten(values: List[Any], context: Context) -> List[Any]:
     return immutable_list(values)
 
 
-_register_pytree_node(immutable_dict, _immutable_dict_flatten, _immutable_dict_unflatten)
-_register_pytree_node(immutable_list, _immutable_list_flatten, _immutable_list_unflatten)
+register_pytree_node(immutable_dict, _immutable_dict_flatten, _immutable_dict_unflatten)
+register_pytree_node(immutable_list, _immutable_list_flatten, _immutable_list_unflatten)


### PR DESCRIPTION
## Reason for this PR

Warning from `torch 2.4.0+rocm6.1`

```shell
FutureWarning: `torch.utils._pytree._register_pytree_node` is deprecated. Please use `torch.utils._pytree.register_pytree_node` instead.
  _register_pytree_node(immutable_dict, _immutable_dict_flatten, _immutable_dict_unflatten)
```

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

Using `torch.utils._pytree.register_pytree_node` instead.

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
