### PR TITLE
fix (examples/benchmark): Fix when `run_results.yaml` does not exist.

### DIFF
--- a/src/brevitas_examples/common/benchmark/utils.py
+++ b/src/brevitas_examples/common/benchmark/utils.py
@@ -256,8 +256,7 @@ def parse_results(entrypoint_utils: BenchmarkUtils, results_folder: str) -> pd.D
                     "elapsed_time": -1.,
                     "retry_number": -1.,
                     "brevitas_version": -1.,
-                    "torch_version": -1.,
-                }
+                    "torch_version": -1.,}
             # If the job was not succesful, try parsing the log
             if job_results["status"] == "crashed":
                 # Load the log file

--- a/src/brevitas_examples/common/benchmark/utils.py
+++ b/src/brevitas_examples/common/benchmark/utils.py
@@ -246,8 +246,18 @@ def parse_results(entrypoint_utils: BenchmarkUtils, results_folder: str) -> pd.D
             # Retrieve the configuration from the YAML file
             with open(f"{results_folder}/{job_name}/config.yaml", 'r') as f:
                 job_config = yaml.safe_load(f)
-            with open(f"{results_folder}/{job_name}/run_results.yaml", 'r') as f:
-                job_results = yaml.safe_load(f)
+            try:
+                with open(f"{results_folder}/{job_name}/run_results.yaml", 'r') as f:
+                    job_results = yaml.safe_load(f)
+            except Exception:
+                # Failsafe if entrypoint failed in a way that brings down the whole process
+                job_results = {
+                    "status": "crashed",
+                    "elapsed_time": -1.,
+                    "retry_number": -1.,
+                    "brevitas_version": -1.,
+                    "torch_version": -1.,
+                }
             # If the job was not succesful, try parsing the log
             if job_results["status"] == "crashed":
                 # Load the log file


### PR DESCRIPTION
Occasionally, `quantize_llm` can fail in a way that also kills `run_args_bucket_process` (e.g., it goes OOM). If this is the case, `run_results.yaml` will never be created and the `"crashed"` status will never be set.

This PR introduces a workaround for this case.