### PR TITLE
Feat (magr): initial implementation of MagR

### DIFF
--- a/src/brevitas/graph/base.py
+++ b/src/brevitas/graph/base.py
@@ -193,7 +193,7 @@ class ModuleToModule(GraphTransform, ABC):
         if load_state_dict:
             # work-around since weight_orig is from a previous quantization algorithm
             if hasattr(old_module, 'weight_orig'):
-                new_module.register_buffer('weight_orig', old_module.weight_orig.data)
+                new_module.register_buffer('weight_orig', old_module.weight_orig.data.cpu())
             if not is_parametrized(old_module):
                 new_module.load_state_dict(old_module.state_dict())
             else:

--- a/src/brevitas/graph/base.py
+++ b/src/brevitas/graph/base.py
@@ -191,6 +191,9 @@ class ModuleToModule(GraphTransform, ABC):
     def _replace_old_module(self, model, old_module, new_module, load_state_dict=True):
         replace_module(model, old_module, new_module)
         if load_state_dict:
+            # work-around since weight_orig is from a previous quantization algorithm
+            if hasattr(old_module, 'weight_orig'):
+                new_module.register_buffer('weight_orig', old_module.weight_orig.data)
             if not is_parametrized(old_module):
                 new_module.load_state_dict(old_module.state_dict())
             else:

--- a/src/brevitas/graph/gpfq.py
+++ b/src/brevitas/graph/gpfq.py
@@ -15,7 +15,7 @@ from brevitas.graph.calibrate import disable_return_quant_tensor
 from brevitas.graph.calibrate import restore_return_quant_tensor
 from brevitas.graph.gpxq import GPxQ
 from brevitas.graph.gpxq import gpxq_mode
-from brevitas.graph.gpxq import SUPPORTED_CONV_QUANT_MODULE
+from brevitas.graph.gpxq import SUPPORTED_CONV_OP
 from brevitas.graph.utils import is_conv_transposed
 import brevitas.nn as qnn
 from brevitas.utils.torch_utils import StopFwdException
@@ -70,7 +70,7 @@ class GPFQ(GPxQ):
             # For QuantLinear layer, groups will be 1
             inp_processed = inp.unsqueeze(0)
 
-        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+        if isinstance(self.layer, SUPPORTED_CONV_OP):
             # Pick the correct unfoldNd class
             if is_conv_transposed(self.layer):
                 unfold_impl = unfoldNd.UnfoldTransposeNd
@@ -146,7 +146,7 @@ class GPFQ(GPxQ):
         # When the weights are updated, we cast everything back to the original dtype
         dtype = weight.dtype
 
-        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+        if isinstance(self.layer, SUPPORTED_CONV_OP):
             if is_conv_transposed(self.layer):
                 weight = weight.transpose(1, 0)  # This performs a view
                 weight_orig = weight_orig.transpose(1, 0)

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -18,7 +18,7 @@ import unfoldNd
 from brevitas import torch_version
 from brevitas.graph.gpxq import GPxQ
 from brevitas.graph.gpxq import gpxq_mode
-from brevitas.graph.gpxq import SUPPORTED_CONV_QUANT_MODULE
+from brevitas.graph.gpxq import SUPPORTED_CONV_OP
 from brevitas.graph.utils import is_conv_transposed
 import brevitas.nn as qnn
 from brevitas.utils.torch_utils import StopFwdException
@@ -81,7 +81,7 @@ class GPTQ(GPxQ):
             # For QuantLinear layer, groups will be 1
             inp_processed = inp.unsqueeze(0)
 
-        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+        if isinstance(self.layer, SUPPORTED_CONV_OP):
             # Pick the correct unfoldNd class
             if is_conv_transposed(self.layer):
                 unfold_impl = unfoldNd.UnfoldTransposeNd
@@ -132,7 +132,7 @@ class GPTQ(GPxQ):
         # When the weights are updated, we cast everything back to the original dtype
         dtype = weight.dtype
 
-        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+        if isinstance(self.layer, SUPPORTED_CONV_OP):
             if is_conv_transposed(self.layer):
                 weight = weight.transpose(1, 0)  # This performs a view
             weight = weight.flatten(1)

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -25,7 +25,9 @@ import brevitas.nn as qnn
 from brevitas.quant_tensor import _unpack_quant_tensor
 from brevitas.quant_tensor import QuantTensor
 
-SUPPORTED_CONV_OP = (nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d)
+SUPPORTED_CONV_OP = (
+    nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d)
+
 
 @dataclass
 class LayerHandler:

--- a/src/brevitas/graph/magr.py
+++ b/src/brevitas/graph/magr.py
@@ -1,0 +1,272 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from copy import deepcopy
+import math
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+import unfoldNd
+
+from brevitas.graph.gpxq import GPxQ
+from brevitas.graph.gpxq import gpxq_mode
+from brevitas.graph.gpxq import SUPPORTED_CONV_TORCH_MODULE
+from brevitas.graph.utils import is_conv_transposed
+
+
+def _project_onto_l1_ball(x, eps=1.0):
+    """
+    Vectorized L1 ball projection.
+
+    Adapted from https://github.com/AozhongZhang/MagR, released under the following LICENSE:
+
+    MIT License
+
+    Copyright (c) 2025 Aozhong Zhang
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """
+    mask = (torch.norm(x, p=1, dim=1) < eps).float().unsqueeze(1)
+    mu, _ = torch.sort(torch.abs(x), dim=1, descending=True)
+    cumsum = torch.cumsum(mu, dim=1)
+    arange = torch.arange(1, x.shape[1] + 1, device=x.device)
+    rho, _ = torch.max((mu * arange > (cumsum - eps)) * arange, dim=1)
+    theta = (cumsum[torch.arange(x.shape[0]), rho.cpu() - 1] - eps) / rho
+    proj = (torch.abs(x) - theta.unsqueeze(1)).clamp(min=0)
+    x = mask * x + (1 - mask) * proj * torch.sign(x)
+    return x
+
+
+def _power_iteration(H, steps: int, eps: float = 1e-12):
+    """
+    Power iteration to compute the maximum singular value for the Hessian.
+    """
+    b_k = torch.rand(H.shape[1], device=H.device)
+    for _ in range(steps):
+        b_k1 = torch.mv(H, b_k)  # Calculate the matrix-by-vector product H*b_k
+        b_k1_norm = torch.norm(b_k1)  # Calculate the norm
+        b_k = b_k1 / (b_k1_norm + eps)  # Re normalize the vector
+    max_singular_value = torch.dot(b_k, torch.mv(H, b_k))
+    return max_singular_value
+
+
+class MagR(GPxQ):
+    """
+    Implementation of MagR algorithm for PTQ pre-processing.
+    """
+
+    def __init__(
+            self,
+            layer,
+            name,
+            len_parallel_layers,
+            create_weight_orig,
+            gradient_steps: int = 10,
+            power_steps: int = 30,
+            alpha: float = 0.1) -> None:
+        super().__init__(layer, name, None, len_parallel_layers, create_weight_orig)
+        self.gradient_steps = gradient_steps
+        self.power_steps = power_steps
+        self.alpha = alpha
+
+        # Initialize covariance matrix and counter. We need it in float32 to compute the inverse
+        self.H = torch.zeros((self.groups, self.columns, self.columns),
+                             device='cpu',
+                             dtype=torch.float32,
+                             pin_memory=torch.cuda.is_available())
+        self.B = torch.zeros((self.groups, self.columns, self.columns),
+                             device='cpu',
+                             dtype=torch.float32,
+                             pin_memory=torch.cuda.is_available())
+        self.nsamples = 0
+
+    def update_batch(self, module, input, current_layer):
+        if self.disable_pre_forward_hook:
+            return input
+
+        # Update reference to current layer
+        current_layer.layer_names.add(self.name)
+        inp = self.process_input(input)
+        batch_size = inp.shape[0]
+
+        # Preprocess the input to compute the Hessian
+        if isinstance(self.layer, nn.Linear):
+            if len(inp.shape) > 2:
+                inp = inp.reshape((-1, sum(inp.shape[2:])))
+            inp = inp.t()
+            # For Linear layer, groups will be 1
+            inp_processed = inp.unsqueeze(0)
+
+        if isinstance(self.layer, SUPPORTED_CONV_TORCH_MODULE):
+            # Pick the correct unfoldNd class
+            if is_conv_transposed(self.layer):
+                unfold_impl = unfoldNd.UnfoldTransposeNd
+            else:
+                unfold_impl = unfoldNd.UnfoldNd
+
+            unfold = unfold_impl(
+                self.layer.kernel_size,
+                dilation=self.layer.dilation,
+                padding=self.layer.padding,
+                stride=self.layer.stride)
+
+            # Split input based on how many groups in convolution
+            inp_by_group = torch.chunk(inp, self.groups, 1)
+            inp_processed = []
+            # Preprocess input by group
+            for i, inp in enumerate(inp_by_group):
+                inp = unfold(inp)
+                inp = inp.transpose(1, 0)
+                inp = inp.flatten(1)
+                inp_processed.append(inp)
+            inp_processed = torch.stack(inp_processed)
+
+        # Hessian computation
+        self.H *= self.nsamples / (self.nsamples + batch_size)
+        self.nsamples += batch_size
+        inp_processed = math.sqrt(1 / self.nsamples) * inp_processed.to(torch.float32)
+        # optimizing CPU to GPU transfer using in-place copy to pinned memory
+        self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
+        self.H += self.B
+
+    def single_layer_update(self):
+        if hasattr(self.layer, 'allocate_params'):
+            self.layer.allocate_params(self.layer)
+        weight = self.layer.weight.data
+        if self.create_weight_orig:
+            weight_orig = self.layer.weight_orig.data
+        else:
+            weight_orig = weight.detach().clone()
+
+        dev = weight.device
+
+        # Store the original dtype of the weights
+        # During computation, everything is converted to float32.
+        # When the weights are updated, we cast everything back to the original dtype
+        dtype = weight.dtype
+
+        if isinstance(self.layer, SUPPORTED_CONV_TORCH_MODULE):
+            if is_conv_transposed(self.layer):
+                weight = weight.transpose(1, 0)  # This performs a view
+                weight_orig = weight_orig.transpose(1, 0)
+            weight = weight.flatten(1)
+            weight_orig = weight_orig.flatten(1)
+        weight = weight.view(self.groups, -1, weight.shape[-1])  # [Groups, OC/Groups, IC]
+        weight_orig = weight_orig.view(
+            self.groups, -1, weight_orig.shape[-1])  # [Groups, OC/Groups, IC]
+        self.H = self.H.to(dev)
+        for group_index in range(self.groups):
+            # approximate maximum singular value (ie, matrix L2 norm)
+            eta = 1. / _power_iteration(self.H[group_index], steps=self.power_steps)
+            alpha = self.alpha / (eta * torch.linalg.norm(self.H[group_index], ord=1))
+            wk = weight[group_index].to(torch.float32)
+            gk = weight_orig[group_index].to(torch.float32)  # ground
+            for _ in tqdm(range(self.gradient_steps), leave=False):
+                vk = wk - eta * (wk - gk).matmul(
+                    self.H[group_index])  # argument of the proximal operator
+                wk = vk - alpha * _project_onto_l1_ball(vk / alpha)  # update via proximal operator
+                weight[group_index] = wk.to(dtype)  # downcast
+                assert torch.isfinite(weight[group_index]).all()
+        del self.H  # free memory
+        if hasattr(self.layer, 'offload_params'):
+            self.layer.offload_params(self.layer)
+
+
+class magr_mode(gpxq_mode):
+    """
+    Apply MagR algorithm, https://arxiv.org/abs/2406.00800
+
+    Args:
+        model (Module): The model to pre-process with MagR
+        alpha (float): The L-infty norm penalty for MagR. Default: 0.1
+        num_steps (int): The number of gradient steps for MagR algorithm. Default: 10
+        group_of_parallel_layers (Optional, List[str]): List of lists where each inner list is a group
+            of layer names that can be optimized in parallel. Default: None
+        inplace (bool): Wheter to apply MagR inplace or perform a deepcopy. Default: True
+        create_weight_orig (bool): If True, store the original floating point weights before applying
+            MagR. These weights will be used anytime quantization is disabled. Default: True
+        return_forward_output (bool): If True, returns the output of the forward pass. Otherwise the
+            forward call inside the context manager returns None. Default: False
+
+    Example:
+        >>> with torch.no_grad():
+        >>>     with magr_mode(model) as magr:
+        >>>         magr_model = magr.model
+        >>>         for i in tqdm(range(magr.num_layers)):
+        >>>             for img, t in calib_loader:
+        >>>                 img = img.cuda()
+        >>>                 magr_model(img)
+        >>>             magr.update()
+    """
+
+    def __init__(
+            self,
+            model,
+            alpha: float = 0.1,
+            num_steps: int = 10,
+            group_of_parallel_layers: Optional[List[str]] = None,
+            inplace: bool = True,
+            create_weight_orig: bool = True,
+            return_forward_output: bool = False) -> None:
+        if not inplace:
+            model = deepcopy(model)
+        super().__init__(
+            model=model,
+            group_of_parallel_layers=group_of_parallel_layers,
+            inplace=inplace,
+            create_weight_orig=create_weight_orig,
+            return_forward_output=return_forward_output)
+        self.num_steps = num_steps
+        self.alpha = alpha
+
+    def _is_module_supported(self, module):
+        if isinstance(module, SUPPORTED_CONV_TORCH_MODULE):
+            return True
+        elif isinstance(module, nn.Linear):
+            return True
+        else:
+            return False
+
+    def update(self):
+        for name in tqdm(self.current_layer.layer_names, desc='Updating weights...', leave=True):
+            self.gpxq_layers[name].single_layer_update()
+            self.hook_dict[name].remove()
+        self.current_layer.layer_names.clear()
+
+    def catch_stopfwd(self, *args, **kwargs):
+        self.orig_forward(*args, **kwargs)
+        if self.return_forward_output:
+            # If we want to return the output of the network, we need to disable all hooks
+            for name, gpxq_class in self.gpxq_layers.items():
+                gpxq_class.disable_pre_forward_hook = True
+            out = self.orig_forward(*args, **kwargs)
+            for name, gpxq_class in self.gpxq_layers.items():
+                gpxq_class.disable_pre_forward_hook = False
+            return out
+
+    def initialize_module_optimizer(self, layer, name, len_parallel_layers, create_weight_orig):
+        return MagR(
+            layer=layer,
+            name=name,
+            len_parallel_layers=len_parallel_layers,
+            create_weight_orig=create_weight_orig,
+            gradient_steps=self.num_steps,
+            alpha=self.alpha)

--- a/src/brevitas/graph/utils.py
+++ b/src/brevitas/graph/utils.py
@@ -10,6 +10,7 @@ from torch import nn
 from brevitas import nn as qnn
 from brevitas.fx import map_arg
 from brevitas.fx import Node
+from brevitas.nn.quant_layer import QuantWeightBiasInputOutputLayer as QuantWBIOL
 
 __all__ = [
     'module_class_name',
@@ -166,3 +167,7 @@ def get_node(graph_model, name):
     for node in graph_model.graph.nodes:
         if node.target == name:
             return node
+
+
+def is_quant_module(module):
+    return isinstance(module, QuantWBIOL)

--- a/src/brevitas/nn/mixin/parameter.py
+++ b/src/brevitas/nn/mixin/parameter.py
@@ -44,7 +44,7 @@ class QuantWeightMixin(QuantProxyMixin):
             subtensor_slice_list: List[Optional[Tuple[int, int]]] = None):
         weights_to_quantize = self.weight
         if not self.weight_quant.is_quant_enabled and hasattr(self, 'weight_orig'):
-            weights_to_quantize = self.weight_orig
+            weights_to_quantize = self.weight_orig.to(self.weight.device)
         if subtensor_slice_list is not None:
             # prepare the quantizer for a subtensor input, if any modifications are required
             # we set a list of tuples rather than a list of slices so that it's jit friendly

--- a/src/brevitas_examples/common/axe.py
+++ b/src/brevitas_examples/common/axe.py
@@ -18,8 +18,8 @@ from brevitas.function.ops import max_int
 from brevitas.function.ops import min_int
 from brevitas.graph.gpfq import GPFQ
 from brevitas.graph.gptq import GPTQ
-from brevitas.graph.gpxq import SUPPORTED_CONV_OP
-from brevitas.graph.gpxq import SUPPORTED_TCONV_OP
+from brevitas.graph.gpxq import SUPPORTED_CONV_QUANT_MODULE
+from brevitas.graph.utils import is_conv_transposed
 from brevitas.utils.quant_utils import _CachedIO
 
 
@@ -134,7 +134,7 @@ class _AXE:
 
         scales: Tensor = self.layer.weight_quant.scale()
         if isinstance(self.layer, SUPPORTED_CONV_OP):
-            if isinstance(self.layer, SUPPORTED_TCONV_OP):
+            if is_c:
                 scales = scales.transpose(1, 0)  # This performs a view
             scales = scales.flatten(1)
 
@@ -212,8 +212,8 @@ class A2GPTQ(_AXE, GPTQ):
         # original dtype
         dtype = weight.dtype
 
-        if isinstance(self.layer, SUPPORTED_CONV_OP):
-            if isinstance(self.layer, SUPPORTED_TCONV_OP):
+        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+            if is_conv_transposed(self.layer):
                 weight = weight.transpose(1, 0)  # This performs a view
             weight = weight.flatten(1)
 
@@ -400,8 +400,8 @@ class A2GPFQ(_AXE, GPFQ):
         # When the weights are updated, we cast everything back to the original dtype
         dtype = weight.dtype
 
-        if isinstance(self.layer, SUPPORTED_CONV_OP):
-            if isinstance(self.layer, SUPPORTED_TCONV_OP):
+        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+            if is_conv_transposed(self.layer):
                 weight = weight.transpose(1, 0)  # This performs a view
                 weight_orig = weight_orig.transpose(1, 0)
             weight = weight.flatten(1)

--- a/src/brevitas_examples/common/axe.py
+++ b/src/brevitas_examples/common/axe.py
@@ -133,8 +133,8 @@ class _AXE:
         n_tiles = math.ceil(weight.shape[-1] / self.max_accumulator_tile_size)
 
         scales: Tensor = self.layer.weight_quant.scale()
-        if isinstance(self.layer, SUPPORTED_CONV_OP):
-            if is_c:
+        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+            if is_conv_transposed(self.layer):
                 scales = scales.transpose(1, 0)  # This performs a view
             scales = scales.flatten(1)
 

--- a/src/brevitas_examples/common/axe.py
+++ b/src/brevitas_examples/common/axe.py
@@ -18,7 +18,7 @@ from brevitas.function.ops import max_int
 from brevitas.function.ops import min_int
 from brevitas.graph.gpfq import GPFQ
 from brevitas.graph.gptq import GPTQ
-from brevitas.graph.gpxq import SUPPORTED_CONV_QUANT_MODULE
+from brevitas.graph.gpxq import SUPPORTED_CONV_OP
 from brevitas.graph.utils import is_conv_transposed
 from brevitas.utils.quant_utils import _CachedIO
 
@@ -133,7 +133,7 @@ class _AXE:
         n_tiles = math.ceil(weight.shape[-1] / self.max_accumulator_tile_size)
 
         scales: Tensor = self.layer.weight_quant.scale()
-        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+        if isinstance(self.layer, SUPPORTED_CONV_OP):
             if is_conv_transposed(self.layer):
                 scales = scales.transpose(1, 0)  # This performs a view
             scales = scales.flatten(1)
@@ -212,7 +212,7 @@ class A2GPTQ(_AXE, GPTQ):
         # original dtype
         dtype = weight.dtype
 
-        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+        if isinstance(self.layer, SUPPORTED_CONV_OP):
             if is_conv_transposed(self.layer):
                 weight = weight.transpose(1, 0)  # This performs a view
             weight = weight.flatten(1)
@@ -400,7 +400,7 @@ class A2GPFQ(_AXE, GPFQ):
         # When the weights are updated, we cast everything back to the original dtype
         dtype = weight.dtype
 
-        if isinstance(self.layer, SUPPORTED_CONV_QUANT_MODULE):
+        if isinstance(self.layer, SUPPORTED_CONV_OP):
             if is_conv_transposed(self.layer):
                 weight = weight.transpose(1, 0)  # This performs a view
                 weight_orig = weight_orig.transpose(1, 0)

--- a/src/brevitas_examples/llm/README.md
+++ b/src/brevitas_examples/llm/README.md
@@ -75,23 +75,20 @@ usage: main.py [-h] [--config CONFIG] [--model MODEL]
 
 options:
   -h, --help            show this help message and exit
-  --config CONFIG       Specify alternative default commandline args (e.g.,
-                        config/default_template.yml). Default: None.
+  --config CONFIG       Specify alternative default commandline args (e.g., config/default_template.yml). Default: None.
   --model MODEL         HF model name. Default: facebook/opt-125m.
   --dtype {float32,float16,bfloat16}
                         Data type for model. Default: float16
   --seed SEED           Seed for sampling the calibration data. Default: 0.
   --nsamples NSAMPLES   Number of calibration data samples. Default: 128.
   --nsamples-rot-calibration NSAMPLES_ROT_CALIBRATION
-                        Number of calibration data samples for rotation.
-                        Default: 800.
+                        Number of calibration data samples for rotation. Default: 800.
   --seqlen SEQLEN       Sequence length. Default: 2048.
   --eval                Eval model PPL on the chosen Dataset.
   --dataset {wikitext2,c4,pile}
                         Dataset to use for quantization (default: wikitext2)
   --gpxq-block-name GPXQ_BLOCK_NAME
-                        Block name for faster GPxQ optimization. It works only
-                        if FX is not needed (default: None)
+                        Block name for faster GPxQ optimization. It works only if FX is not needed (default: None)
   --weight-bit-width WEIGHT_BIT_WIDTH
                         Weight bit width. Default: 8.
   --weight-param-method {stats,mse,hqo}
@@ -101,66 +98,43 @@ options:
   --weight-quant-type {sym,asym}
                         Weight quantization type. Default: asym.
   --weight-quant-format WEIGHT_QUANT_FORMAT
-                        Weight quantization type. Either int or eXmY, with
-                        X+Y==weight_bit_width-1. It's possible to add
-                        float_ocp_ or float_fnuz_ before the exponent/mantissa
-                        bitwidth. Default: int.
+                        Weight quantization type. Either int or eXmY, with X+Y==weight_bit_width-1. It's possible to add float_ocp_ or float_fnuz_ before the exponent/mantissa bitwidth. Default: int.
   --weight-quant-granularity {per_channel,per_tensor,per_group}
-                        Granularity for scales/zero-point of weights. Default:
-                        per_group.
+                        Granularity for scales/zero-point of weights. Default: per_group.
   --scale-rounding-func-type {round,ceil,floor}
-                        Rounding function to use with Po2 scale. Default:
-                        None.
+                        Rounding function to use with Po2 scale. Default: None.
   --weight-group-dim {1,0}
-                        Override default group_dim for groupsize quantization.
-                        Default: layer-dependant
+                        Override default group_dim for groupsize quantization. Default: layer-dependant
   --weight-group-size WEIGHT_GROUP_SIZE
-                        Group size for per_group weight quantization. Default:
-                        128.
+                        Group size for per_group weight quantization. Default: 128.
   --quantize-weight-zero-point
                         Quantize weight zero-point.
   --input-bit-width INPUT_BIT_WIDTH
-                        Input bit width. Default: None (disables input
-                        quantization).
+                        Input bit width. Default: None (disables input quantization).
   --input-quant-format INPUT_QUANT_FORMAT
-                        Input quantization type. Either int or eXmY, with
-                        X+Y==weight_bit_width-1. It's possible to add
-                        float_ocp_ or float_fnuz_ before the exponent/mantissa
-                        bitwidth. Default: int.
+                        Input quantization type. Either int or eXmY, with X+Y==weight_bit_width-1. It's possible to add float_ocp_ or float_fnuz_ before the exponent/mantissa bitwidth. Default: int.
   --input-param-method {stats,mse}
-                        How scales/zero-point are determined. Default: stats
-                        (percentile for static, absmax or minmax for dynamic).
+                        How scales/zero-point are determined. Default: stats (percentile for static, absmax or minmax for dynamic).
   --input-scale-precision {float_scale,po2_scale}
-                        Whether input scale is a float value or a po2.
-                        Default: float.
+                        Whether input scale is a float value or a po2. Default: float.
   --input-scale-type {static,dynamic,no_scale}
-                        Whether input scale is a static value or a dynamic
-                        value.
+                        Whether input scale is a static value or a dynamic value.
   --input-quant-type {sym,asym}
                         Input quantization type. Default: asym.
   --kv-quant-type {sym,asym}
-                        KV quantization type. If None, it will follow input
-                        quant type. If set, will perform only KV cache
-                        quantization. Default: None
+                        KV quantization type. If None, it will follow input quant type. If set, will perform only KV cache quantization. Default: None
   --input-quant-granularity {per_tensor,per_row,per_group}
-                        Granularity for scales/zero-point of inputs. Default:
-                        per_tensor.
+                        Granularity for scales/zero-point of inputs. Default: per_tensor.
   --kv-quant-granularity {per_tensor,per_row,per_group}
-                        Granularity for scales/zero-point of KV cache. If not
-                        set, it will use input-quant-granularity. Default:
-                        None
+                        Granularity for scales/zero-point of KV cache. If not set, it will use input-quant-granularity. Default: None
   --input-group-size INPUT_GROUP_SIZE
-                        Group size for per_group input quantization. Default:
-                        64.
+                        Group size for per_group input quantization. Default: 64.
   --learned-round-lr LEARNED_ROUND_LR
-                        Learning rate for learned round parameter
-                        optimization. Default: 0.005
+                        Learning rate for learned round parameter optimization. Default: 0.005
   --learned-round-scale-lr LEARNED_ROUND_SCALE_LR
-                        Learning rate for scale optimization during round
-                        learning. Default: 0.01
+                        Learning rate for scale optimization during round learning. Default: 0.01
   --learned-round-scale-momentum LEARNED_ROUND_SCALE_MOMENTUM
-                        Learning rate for scale optimization during round
-                        learning. Default: 0.9
+                        Learning rate for scale optimization during round learning. Default: 0.9
   --learned-round-iters LEARNED_ROUND_ITERS
                         Number of iterations for learned round. Default: 200.
   --learned-round-scale
@@ -169,6 +143,11 @@ options:
                         Quantize input zero-point.
   --quantize-last-layer
                         Quantize last nn.Linear layer.
+  --magr                Apply MagR.
+  --magr-alpha MAGR_ALPHA
+                        Alpha for MagR.
+  --magr-num-steps MAGR_NUM_STEPS
+                        Number of steps for MagR.
   --gptq                Apply GPTQ.
   --gpfq                Apply GPFQ.
   --gpxq-act-order      Apply GPxQ activation ordering.
@@ -188,28 +167,20 @@ options:
   --replace-rmsnorm     Replace HF RMSNorms with Torch one.
   --no-quantize         Disable quantization.
   --scaling-min-val SCALING_MIN_VAL
-                        Minimum value to clamp scale to when using bf16 or
-                        fp16 quantization.
-  --quant-sdpa          Quantize `F.scaled_dot_product_attention` (default:
-                        False)
+                        Minimum value to clamp scale to when using bf16 or fp16 quantization.
+  --quant-sdpa          Quantize `F.scaled_dot_product_attention` (default: False)
   --functional-sdpa-quant
-                        Quantize `F.scaled_dot_product_attention` with
-                        stateless module and torch_function (default: False)
-  --replace-mha         Replace HuggingFace Attention with a quantizable
-                        version
+                        Quantize `F.scaled_dot_product_attention` with stateless module and torch_function (default: False)
+  --replace-mha         Replace HuggingFace Attention with a quantizable version
   --weight-equalization
-                        Apply weight equalization. Relevant to ReLU based
-                        models (e.g. OPT).
+                        Apply weight equalization. Relevant to ReLU based models (e.g. OPT).
   --rotation {fx,layerwise,fused_no_fx}
                         Apply graph rotation equalization
   --optimize-rotations  Whether to optimize the rotations (default: False).
   --rotation-mode {had,ort}
-                        If GraphRotation is enabled, decide how to compute the
-                        random rotation matrix that is fully fused. Online or
-                        partial rotation will always be Hadamard
+                        If GraphRotation is enabled, decide how to compute the random rotation matrix that is fully fused. Online or partial rotation will always be Hadamard
   --rotation-orphan-sink
-                        If GraphRotation is enabled, decide wheter to add
-                        standalone hadamard matrices for the unfused layers
+                        If GraphRotation is enabled, decide wheter to add standalone hadamard matrices for the unfused layers
   --rotation-sdpa-regions
                         If GraphRotation is enabled, decide wheter to equalize
                         across SDPA
@@ -219,42 +190,28 @@ options:
   --svd-quant-iters SVD_QUANT_ITERS
                         Number of iterations to use for SVDQuant (default: 1).
   --act-equalization {None,layerwise,fx}
-                        Apply activation equalization (SmoothQuant). Layerwise
-                        introduces standalone mul nodes,while fx merges them
-                        whenever possible into previous tensors, which is
-                        possible on ReLU based models (e.g. OPT).
+                        Apply activation equalization (SmoothQuant). Layerwise introduces standalone mul nodes,while fx merges them whenever possible into previous tensors, which is possible on ReLU based
+                        models (e.g. OPT).
   --act-equalization-alpha ACT_EQUALIZATION_ALPHA
-                        If activation equalization is enabled, decide what
-                        alpha to use
+                        If activation equalization is enabled, decide what alpha to use
   --load-awq LOAD_AWQ   Load the awq search results.
   --export-target {None,onnx_qcdq,torch_qcdq,sharded_torchmlir_group_weight,sharded_packed_torchmlir_group_weight}
                         Model export.
   --export-prefix EXPORT_PREFIX
-                        Path prefix to use for the various export flows. If
-                        None, a path will be derived from the model name
-                        (default: None)
+                        Path prefix to use for the various export flows. If None, a path will be derived from the model name (default: None)
   --checkpoint-name CHECKPOINT_NAME
-                        Filename to save checkpoint. If `None`, no checkpoint
-                        is saved (default: None)
-  --load-checkpoint     Boolean flag to load_checkpoint, uses checkpoint_name.
-                        Default False)
-  --fuse-sequences      Whether to merge the dataset sequences in case they
-                        are shorter than the requested number of samples per
-                        sequence. This is useful in case you would like to
-                        quantize or evaluate on long sequences (default:
-                        False).
+                        Filename to save checkpoint. If `None`, no checkpoint is saved (default: None)
+  --load-checkpoint     Boolean flag to load_checkpoint, uses checkpoint_name. Default False)
+  --fuse-sequences      Whether to merge the dataset sequences in case they are shorter than the requested number of samples per sequence. This is useful in case you would like to quantize or evaluate on
+                        long sequences (default: False).
   --learned-round {None,linear_round}
-                        Whether to use learned round. If `None`, RTN is used
-                        (default: None)
+                        Whether to use learned round. If `None`, RTN is used (default: None)
   --learned-round-fast-update
-                        Whether to use fast update with learned round.
-                        Prototype (default: False)
+                        Whether to use fast update with learned round. Prototype (default: False)
   --few-shot-eval {lm_eval,lighteval}
-                        Perform zero_shot evaluation with lm_eval or
-                        lighteval. Default None)
+                        Perform zero_shot evaluation with lm_eval or lighteval. Default None)
   --few-shot-override-batch-size FEW_SHOT_OVERRIDE_BATCH_SIZE
-  --compile-ptq         Compile for PTQ algorithms. Default False)
-  --compile-eval        Compile during evaluation. Default False)
+  --few-shot-compile    Compile during zero_shot evaluation. Default False)
   --few-shot-zeroshot   Whether to do zero or few shot eval. Default False)
   --no-bos-preprocessing
                         Do not add BOS token during pre-processing. Default
@@ -262,10 +219,8 @@ options:
   --few-shot-limit FEW_SHOT_LIMIT
                         Few shot limit. Default None)
   --few-shot-tasks [FEW_SHOT_TASKS ...]
-                        A list of tasks for zero_shot evaluation. Default:
-                        ['arc_challenge', 'arc_easy', 'winogrande', 'piqa']
+                        A list of tasks for zero_shot evaluation. Default: ['arc_challenge', 'arc_easy', 'winogrande', 'piqa']
   --rotation-layers-to-expand [ROTATION_LAYERS_TO_EXPAND ...]
-                        A list of module names to expand with hadamard
-                        rotation. Default: []
+                        A list of module names to expand with hadamard rotation. Default: []
 
 ```

--- a/src/brevitas_examples/llm/README.md
+++ b/src/brevitas_examples/llm/README.md
@@ -15,63 +15,25 @@ Set the env variable `BREVITAS_JIT=1` to speed up the quantization process. Curr
 When using `--optimize-rotations`, the rotation training procedure relies on the Trainer class (https://huggingface.co/docs/transformers/en/main_classes/trainer). Therefore, training can be further configured by passing arguments accepted by the dataclass TrainingArguments (https://huggingface.co/docs/transformers/en/main_classes/trainer#transformers.TrainingArguments), e.g. `--learning_rate`, `--weight_decay`, `per_device_train_batch_size`.
 
 ```bash
-usage: main.py [-h] [--config CONFIG] [--model MODEL]
-               [--dtype {float32,float16,bfloat16}] [--seed SEED]
-               [--nsamples NSAMPLES]
-               [--nsamples-rot-calibration NSAMPLES_ROT_CALIBRATION]
-               [--seqlen SEQLEN] [--eval] [--dataset {wikitext2,c4,pile}]
-               [--gpxq-block-name GPXQ_BLOCK_NAME]
-               [--weight-bit-width WEIGHT_BIT_WIDTH]
-               [--weight-param-method {stats,mse,hqo}]
-               [--weight-scale-precision {float_scale,po2_scale}]
-               [--weight-quant-type {sym,asym}]
-               [--weight-quant-format WEIGHT_QUANT_FORMAT]
-               [--weight-quant-granularity {per_channel,per_tensor,per_group}]
-               [--scale-rounding-func-type {round,ceil,floor}]
-               [--weight-group-dim {1,0}]
-               [--weight-group-size WEIGHT_GROUP_SIZE]
-               [--quantize-weight-zero-point]
-               [--input-bit-width INPUT_BIT_WIDTH]
-               [--input-quant-format INPUT_QUANT_FORMAT]
-               [--input-param-method {stats,mse}]
-               [--input-scale-precision {float_scale,po2_scale}]
-               [--input-scale-type {static,dynamic,no_scale}]
-               [--input-quant-type {sym,asym}] [--kv-quant-type {sym,asym}]
-               [--input-quant-granularity {per_tensor,per_row,per_group}]
-               [--kv-quant-granularity {per_tensor,per_row,per_group}]
-               [--input-group-size INPUT_GROUP_SIZE]
-               [--learned-round-lr LEARNED_ROUND_LR]
-               [--learned-round-scale-lr LEARNED_ROUND_SCALE_LR]
-               [--learned-round-scale-momentum LEARNED_ROUND_SCALE_MOMENTUM]
-               [--learned-round-iters LEARNED_ROUND_ITERS]
-               [--learned-round-scale] [--quantize-input-zero-point]
-               [--quantize-last-layer] [--gptq] [--gpfq] [--gpxq-act-order]
-               [--gpxq-use-quant-activations] [--gpxq-create-weight-orig]
-               [--gpxq-max-accumulator-bit-width GPXQ_MAX_ACCUMULATOR_BIT_WIDTH]
-               [--gpxq-max-accumulator-tile-size GPXQ_MAX_ACCUMULATOR_TILE_SIZE]
-               [--act-calibration] [--bias-corr] [--ln-affine-merge]
-               [--convert-layernorm-to-rmsnorm] [--replace-rmsnorm]
-               [--no-quantize] [--scaling-min-val SCALING_MIN_VAL]
-               [--quant-sdpa] [--functional-sdpa-quant] [--replace-mha]
-               [--weight-equalization] [--rotation {fx,layerwise,fused_no_fx}]
-               [--optimize-rotations] [--rotation-mode {had,ort}]
-               [--rotation-orphan-sink] [--rotation-sdpa-regions]
-               [--svd-quant] [--svd-quant-rank SVD_QUANT_RANK]
-               [--svd-quant-iters SVD_QUANT_ITERS]
-               [--act-equalization {None,layerwise,fx}]
-               [--act-equalization-alpha ACT_EQUALIZATION_ALPHA]
-               [--load-awq LOAD_AWQ]
-               [--export-target {None,onnx_qcdq,torch_qcdq,sharded_torchmlir_group_weight,sharded_packed_torchmlir_group_weight}]
-               [--export-prefix EXPORT_PREFIX]
-               [--checkpoint-name CHECKPOINT_NAME] [--load-checkpoint]
-               [--fuse-sequences] [--learned-round {None,linear_round}]
-               [--learned-round-fast-update]
-               [--few-shot-eval {lm_eval,lighteval}]
-               [--few-shot-override-batch-size FEW_SHOT_OVERRIDE_BATCH_SIZE]
-               [--compile-ptq] [--compile-eval] [--few-shot-zeroshot]
-               [--no-bos-preprocessing] [--few-shot-limit FEW_SHOT_LIMIT]
-               [--few-shot-tasks [FEW_SHOT_TASKS ...]]
-               [--rotation-layers-to-expand [ROTATION_LAYERS_TO_EXPAND ...]]
+usage: main.py [-h] [--config CONFIG] [--model MODEL] [--dtype {float32,float16,bfloat16}] [--seed SEED] [--nsamples NSAMPLES] [--nsamples-rot-calibration NSAMPLES_ROT_CALIBRATION]
+               [--seqlen SEQLEN] [--eval] [--dataset {wikitext2,c4,pile}] [--gpxq-block-name GPXQ_BLOCK_NAME] [--weight-bit-width WEIGHT_BIT_WIDTH] [--weight-param-method {stats,mse,hqo}]
+               [--weight-scale-precision {float_scale,po2_scale}] [--weight-quant-type {sym,asym}] [--weight-quant-format WEIGHT_QUANT_FORMAT]
+               [--weight-quant-granularity {per_channel,per_tensor,per_group}] [--scale-rounding-func-type {round,ceil,floor}] [--weight-group-dim {1,0}]
+               [--weight-group-size WEIGHT_GROUP_SIZE] [--quantize-weight-zero-point] [--input-bit-width INPUT_BIT_WIDTH] [--input-quant-format INPUT_QUANT_FORMAT]
+               [--input-param-method {stats,mse}] [--input-scale-precision {float_scale,po2_scale}] [--input-scale-type {static,dynamic,no_scale}] [--input-quant-type {sym,asym}]
+               [--kv-quant-type {sym,asym}] [--input-quant-granularity {per_tensor,per_row,per_group}] [--kv-quant-granularity {per_tensor,per_row,per_group}]
+               [--input-group-size INPUT_GROUP_SIZE] [--learned-round-lr LEARNED_ROUND_LR] [--learned-round-scale-lr LEARNED_ROUND_SCALE_LR]
+               [--learned-round-scale-momentum LEARNED_ROUND_SCALE_MOMENTUM] [--learned-round-iters LEARNED_ROUND_ITERS] [--learned-round-scale] [--quantize-input-zero-point]
+               [--quantize-last-layer] [--magr] [--magr-alpha MAGR_ALPHA] [--gptq] [--gpfq] [--gpxq-act-order] [--gpxq-use-quant-activations] [--gpxq-create-weight-orig]
+               [--gpxq-max-accumulator-bit-width GPXQ_MAX_ACCUMULATOR_BIT_WIDTH] [--gpxq-max-accumulator-tile-size GPXQ_MAX_ACCUMULATOR_TILE_SIZE] [--act-calibration] [--bias-corr]
+               [--ln-affine-merge] [--convert-layernorm-to-rmsnorm] [--replace-rmsnorm] [--no-quantize] [--scaling-min-val SCALING_MIN_VAL] [--quant-sdpa] [--functional-sdpa-quant]
+               [--replace-mha] [--weight-equalization] [--rotation {fx,layerwise,fused_no_fx}] [--optimize-rotations] [--rotation-mode {had,ort}] [--rotation-orphan-sink]
+               [--rotation-sdpa-regions] [--svd-quant] [--svd-quant-rank SVD_QUANT_RANK] [--svd-quant-iters SVD_QUANT_ITERS] [--act-equalization {None,layerwise,fx}]
+               [--act-equalization-alpha ACT_EQUALIZATION_ALPHA] [--load-awq LOAD_AWQ]
+               [--export-target {None,onnx_qcdq,torch_qcdq,sharded_torchmlir_group_weight,sharded_packed_torchmlir_group_weight}] [--export-prefix EXPORT_PREFIX]
+               [--checkpoint-name CHECKPOINT_NAME] [--load-checkpoint] [--fuse-sequences] [--learned-round {None,linear_round}] [--learned-round-fast-update]
+               [--few-shot-eval {lm_eval,lighteval}] [--few-shot-override-batch-size FEW_SHOT_OVERRIDE_BATCH_SIZE] [--compile-ptq] [--compile-eval] [--few-shot-zeroshot]
+               [--no-bos-preprocessing] [--few-shot-limit FEW_SHOT_LIMIT] [--few-shot-tasks [FEW_SHOT_TASKS ...]] [--rotation-layers-to-expand [ROTATION_LAYERS_TO_EXPAND ...]]
 
 options:
   -h, --help            show this help message and exit
@@ -98,7 +60,8 @@ options:
   --weight-quant-type {sym,asym}
                         Weight quantization type. Default: asym.
   --weight-quant-format WEIGHT_QUANT_FORMAT
-                        Weight quantization type. Either int or eXmY, with X+Y==weight_bit_width-1. It's possible to add float_ocp_ or float_fnuz_ before the exponent/mantissa bitwidth. Default: int.
+                        Weight quantization type. Either int or eXmY, with X+Y==weight_bit_width-1. It's possible to add float_ocp_ or float_fnuz_ before the exponent/mantissa bitwidth.
+                        Default: int.
   --weight-quant-granularity {per_channel,per_tensor,per_group}
                         Granularity for scales/zero-point of weights. Default: per_group.
   --scale-rounding-func-type {round,ceil,floor}
@@ -112,7 +75,8 @@ options:
   --input-bit-width INPUT_BIT_WIDTH
                         Input bit width. Default: None (disables input quantization).
   --input-quant-format INPUT_QUANT_FORMAT
-                        Input quantization type. Either int or eXmY, with X+Y==weight_bit_width-1. It's possible to add float_ocp_ or float_fnuz_ before the exponent/mantissa bitwidth. Default: int.
+                        Input quantization type. Either int or eXmY, with X+Y==weight_bit_width-1. It's possible to add float_ocp_ or float_fnuz_ before the exponent/mantissa bitwidth.
+                        Default: int.
   --input-param-method {stats,mse}
                         How scales/zero-point are determined. Default: stats (percentile for static, absmax or minmax for dynamic).
   --input-scale-precision {float_scale,po2_scale}
@@ -145,9 +109,7 @@ options:
                         Quantize last nn.Linear layer.
   --magr                Apply MagR.
   --magr-alpha MAGR_ALPHA
-                        Alpha for MagR.
-  --magr-num-steps MAGR_NUM_STEPS
-                        Number of steps for MagR.
+                        Alpha for MagR. Default: 0.01.
   --gptq                Apply GPTQ.
   --gpfq                Apply GPFQ.
   --gpxq-act-order      Apply GPxQ activation ordering.
@@ -182,16 +144,15 @@ options:
   --rotation-orphan-sink
                         If GraphRotation is enabled, decide wheter to add standalone hadamard matrices for the unfused layers
   --rotation-sdpa-regions
-                        If GraphRotation is enabled, decide wheter to equalize
-                        across SDPA
+                        If GraphRotation is enabled, decide wheter to equalize across SDPA
   --svd-quant           Apply SVDQuant.
   --svd-quant-rank SVD_QUANT_RANK
                         Rank to use for SVDQuant (default: 32).
   --svd-quant-iters SVD_QUANT_ITERS
                         Number of iterations to use for SVDQuant (default: 1).
   --act-equalization {None,layerwise,fx}
-                        Apply activation equalization (SmoothQuant). Layerwise introduces standalone mul nodes,while fx merges them whenever possible into previous tensors, which is possible on ReLU based
-                        models (e.g. OPT).
+                        Apply activation equalization (SmoothQuant). Layerwise introduces standalone mul nodes,while fx merges them whenever possible into previous tensors, which is
+                        possible on ReLU based models (e.g. OPT).
   --act-equalization-alpha ACT_EQUALIZATION_ALPHA
                         If activation equalization is enabled, decide what alpha to use
   --load-awq LOAD_AWQ   Load the awq search results.
@@ -202,8 +163,8 @@ options:
   --checkpoint-name CHECKPOINT_NAME
                         Filename to save checkpoint. If `None`, no checkpoint is saved (default: None)
   --load-checkpoint     Boolean flag to load_checkpoint, uses checkpoint_name. Default False)
-  --fuse-sequences      Whether to merge the dataset sequences in case they are shorter than the requested number of samples per sequence. This is useful in case you would like to quantize or evaluate on
-                        long sequences (default: False).
+  --fuse-sequences      Whether to merge the dataset sequences in case they are shorter than the requested number of samples per sequence. This is useful in case you would like to quantize
+                        or evaluate on long sequences (default: False).
   --learned-round {None,linear_round}
                         Whether to use learned round. If `None`, RTN is used (default: None)
   --learned-round-fast-update
@@ -215,8 +176,7 @@ options:
   --compile-eval        Compile during evaluation. Default False)
   --few-shot-zeroshot   Whether to do zero or few shot eval. Default False)
   --no-bos-preprocessing
-                        Do not add BOS token during pre-processing. Default
-                        False)
+                        Do not add BOS token during pre-processing. Default False)
   --few-shot-limit FEW_SHOT_LIMIT
                         Few shot limit. Default None)
   --few-shot-tasks [FEW_SHOT_TASKS ...]

--- a/src/brevitas_examples/llm/README.md
+++ b/src/brevitas_examples/llm/README.md
@@ -211,7 +211,8 @@ options:
   --few-shot-eval {lm_eval,lighteval}
                         Perform zero_shot evaluation with lm_eval or lighteval. Default None)
   --few-shot-override-batch-size FEW_SHOT_OVERRIDE_BATCH_SIZE
-  --few-shot-compile    Compile during zero_shot evaluation. Default False)
+  --compile-ptq         Compile for PTQ algorithms. Default False)
+  --compile-eval        Compile during evaluation. Default False)
   --few-shot-zeroshot   Whether to do zero or few shot eval. Default False)
   --no-bos-preprocessing
                         Do not add BOS token during pre-processing. Default

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -201,8 +201,8 @@ def create_llm_args_parser():
     parser.add_argument(
         '--quantize-last-layer', action='store_true', help='Quantize last nn.Linear layer.')
     parser.add_argument('--magr', action='store_true', help='Apply MagR.')
-    parser.add_argument('--magr-alpha', type=float, default=1e-3, help='Alpha for MagR.')
-    parser.add_argument('--magr-num-steps', type=int, default=200, help='Number of steps for MagR.')
+    parser.add_argument(
+        '--magr-alpha', type=float, default=0.01, help='Alpha for MagR. Default: 0.01.')
     parser.add_argument('--gptq', action='store_true', help='Apply GPTQ.')
     parser.add_argument('--gpfq', action='store_true', help='Apply GPFQ.')
     parser.add_argument(

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -200,6 +200,9 @@ def create_llm_args_parser():
         '--quantize-input-zero-point', action='store_true', help='Quantize input zero-point.')
     parser.add_argument(
         '--quantize-last-layer', action='store_true', help='Quantize last nn.Linear layer.')
+    parser.add_argument('--magr', action='store_true', help='Apply MagR.')
+    parser.add_argument('--magr-alpha', type=float, default=1e-3, help='Alpha for MagR.')
+    parser.add_argument('--magr-num-steps', type=int, default=200, help='Number of steps for MagR.')
     parser.add_argument('--gptq', action='store_true', help='Apply GPTQ.')
     parser.add_argument('--gpfq', action='store_true', help='Apply GPFQ.')
     parser.add_argument(

--- a/src/brevitas_examples/llm/llm_quant/gpxq.py
+++ b/src/brevitas_examples/llm/llm_quant/gpxq.py
@@ -210,8 +210,8 @@ def apply_magr(
         create_weight_orig=False,
         group_of_parallel_layers=None,
         block_name=None,
-        alpha=0.1,
-        num_steps=10):
+        alpha=0.01,
+        num_steps=200):
     if block_name is not None:
         context_manager_kwargs = {
             'group_of_parallel_layers': group_of_parallel_layers,

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -47,6 +47,7 @@ from brevitas_examples.llm.llm_quant.export import BlockQuantProxyLevelManager
 from brevitas_examples.llm.llm_quant.export import brevitas_proxy_export_mode
 from brevitas_examples.llm.llm_quant.gpxq import apply_gpfq
 from brevitas_examples.llm.llm_quant.gpxq import apply_gptq
+from brevitas_examples.llm.llm_quant.gpxq import apply_magr
 from brevitas_examples.llm.llm_quant.learned_round_utils import apply_learned_round
 from brevitas_examples.llm.llm_quant.ln_affine_merge import apply_layernorm_affine_merge
 from brevitas_examples.llm.llm_quant.ln_affine_merge import apply_layernorm_to_rmsnorm
@@ -67,7 +68,6 @@ def filter_results(results, tasks):
     # filter out what we actually want to track
     eval_results = dict()
     for task_name in tasks:
-        # log all result metrics we have for this task
         for key, val in results["results"][task_name].items():
             if not isinstance(val, str):
                 # for mmlu, we don't log results per subtask, but simply overall results
@@ -320,6 +320,19 @@ def quantize_llm(args, extra_args=None):
             model, args.act_equalization, loader, alpha=args.act_equalization_alpha)
         print("Act equalization applied.")
         remove_hooks(model)
+
+    if args.magr and not args.load_checkpoint:
+        print("Applying MagR...")
+        model = offload_model(model)
+        apply_magr(
+            model,
+            calibration_loader,
+            create_weight_orig=args.gpxq_create_weight_orig or
+            args.gpfq,  # save original weights for GPxQ
+            alpha=args.magr_alpha,
+            num_steps=args.magr_num_steps)
+        remove_hooks(model)
+        print(f"MagR applied.")
 
     if not args.no_quantize:
         name_blacklist = []

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -330,8 +330,7 @@ def quantize_llm(args, extra_args=None):
             calibration_loader,
             create_weight_orig=args.gpxq_create_weight_orig or
             args.gpfq,  # save original weights for GPxQ
-            alpha=args.magr_alpha,
-            num_steps=args.magr_num_steps)
+            alpha=args.magr_alpha)
         remove_hooks(model)
         print(f"MagR applied.")
 

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -68,6 +68,7 @@ def filter_results(results, tasks):
     # filter out what we actually want to track
     eval_results = dict()
     for task_name in tasks:
+        # log all result metrics we have for this task
         for key, val in results["results"][task_name].items():
             if not isinstance(val, str):
                 # for mmlu, we don't log results per subtask, but simply overall results


### PR DESCRIPTION
## Reason for this PR

Initial implementation of [MagR: Weight Magnitude Reduction for Enhancing Post-Training Quantization](https://arxiv.org/abs/2406.00800), adapted from https://github.com/AozhongZhang/MagR.

The [default config](https://github.com/Xilinx/brevitas/blob/0b763213d5c7d891bc5de17ef2bb6177e94630e5/src/brevitas_examples/llm/config/default_template.yml) gives the following INT4 weight-only quantization results

|  | OPT-125M | Llama3 1B |
|-------------|----------|-----------|
| Float16     | 23.77    | 8.77      |
| RTN | 27.78    | 11.05     |
| MagR        | 27.67    | 11.01     |
| GPTQ        | 26.72    | 10.84     |
| GPTQ+MagR   | 26.34    | 10.30     |

via
```shell
python main.py --config=config/default_template.yml --model=meta-llama/Llama-3.2-1B --weight-bit-width=4 --eval --gptq --magr
```
where RTN = round-to-nearest (i.e., no `--gptq` or `--magr`)

#### Notable differences

The paper claims that $\eta \alpha$ is used in Line 4 of Algorithm 1 to scale $\mathbf{V}^k$ before projection and $\alpha = 0.001$ for most experiments, but a constant $\alpha$ is used in the [official implementation](https://github.com/AozhongZhang/MagR/blob/ed40ef0edf58072b210258ab5b0d21adbb13b55e/MagR.py#L92). In our implementation, we scale the projection by $\alpha \cdot \Vert H \Vert_2 / \Vert H \Vert_1$, which effectively increases the $\ell_\infty$ penalty when $H$ is estimated to be lower rank. In this case, we may be able to hide more error in the null space when updating the weights. Experiments suggest this change is a net improvement.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

- Creating new `MagR` class with `magr_mode` using `GPxQ` and `gpxq_mode` backbones
- Adding new `apply_magr` function to Huggingface entry point in `brevitas_examples`
- Migrating transposed convolution checks to use same `is_conv_transpose` utility
- Extending `test_gpxq.py` to also test new APIs

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

Testing basic `apply_magr` function across all equalization fixtures.

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [x] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
