### PR TITLE
Fix (equalize): dtype fix in activation equalization

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -636,6 +636,7 @@ def _cross_layer_equalization(
     act_sink_axes = {}
     act_sources_axes = {}
     single_module = region.get_module_from_name(next(iter(region.sinks_names)))
+    device = next(single_module.parameters()).device
     dtype = next(single_module.parameters()).dtype
 
     # If region is not valid, don't equalize. If we are inserting a standalone mul, we don't need this check
@@ -766,7 +767,7 @@ def _cross_layer_equalization(
 
     srcs_range = torch.pow(srcs_range, alpha)
     sinks_range = torch.pow(sinks_range, 1 - alpha)
-    scaling_factors = sinks_range / srcs_range
+    scaling_factors = (sinks_range / srcs_range).to(device=device, dtype=dtype)
     # If the scaling factors are not fused, they are stored as a parameter instead
     if not fuse_scaling:
         scaling_factors = nn.Parameter(scaling_factors)

--- a/src/brevitas/nn/quant_scale_bias.py
+++ b/src/brevitas/nn/quant_scale_bias.py
@@ -31,10 +31,10 @@ class ScaleBias(Module):
         self.runtime_shape = runtime_shape
 
     def forward(self, input):
-        dtype = input.dtype
-        out = input * self.weight.view(self.runtime_shape).to(dtype=dtype)
+        out = input * self.weight.view(self.runtime_shape).to(
+            device=input.device, dtype=input.dtype)
         if self.bias:
-            out += self.bias.view(self.runtime_shape).to(dtype=dtype)
+            out += self.bias.view(self.runtime_shape).to(device=input.device, dtype=input.dtype)
         return out
 
 

--- a/src/brevitas/nn/quant_scale_bias.py
+++ b/src/brevitas/nn/quant_scale_bias.py
@@ -31,10 +31,9 @@ class ScaleBias(Module):
         self.runtime_shape = runtime_shape
 
     def forward(self, input):
-        out = input * self.weight.view(self.runtime_shape).to(
-            device=input.device, dtype=input.dtype)
+        out = input * self.weight.view(self.runtime_shape)
         if self.bias:
-            out += self.bias.view(self.runtime_shape).to(device=input.device, dtype=input.dtype)
+            out += self.bias.view(self.runtime_shape)
         return out
 
 

--- a/src/brevitas/nn/quant_scale_bias.py
+++ b/src/brevitas/nn/quant_scale_bias.py
@@ -31,9 +31,10 @@ class ScaleBias(Module):
         self.runtime_shape = runtime_shape
 
     def forward(self, input):
-        out = input * self.weight.view(self.runtime_shape)
+        dtype = input.dtype
+        out = input * self.weight.view(self.runtime_shape).to(dtype=dtype)
         if self.bias:
-            out += self.bias.view(self.runtime_shape)
+            out += self.bias.view(self.runtime_shape).to(dtype=dtype)
         return out
 
 

--- a/src/brevitas/utils/parametrization_utils.py
+++ b/src/brevitas/utils/parametrization_utils.py
@@ -107,8 +107,7 @@ class ScaleWeightParametrization(torch.nn.Module):
         # Reciprocal is done on the fly as to preserve the tie between scale and its reciprocal
         scaling_factor = torch.reciprocal(
             scaling_factor) if self.use_inverse_scaling else scaling_factor
-        return tensor * scaling_factor.reshape(broadcast_shape).to(
-            device=tensor.device, dtype=tensor.dtype)
+        return tensor * scaling_factor.reshape(broadcast_shape)
 
 
 def extract_trainable_rotation_matrices(model: nn.Module) -> List[nn.Parameter]:

--- a/tests/brevitas/graph/equalization_fixtures.py
+++ b/tests/brevitas/graph/equalization_fixtures.py
@@ -25,7 +25,7 @@ SEED = 123456
 ATOL_DICT = {
     torch.float32: 1e-3,
     torch.float16: 5e-2,
-    torch.bfloat16: 1e-1,}
+    torch.bfloat16: 3e-1,}
 ATOL = 1e-3
 
 MODELS = {

--- a/tests/brevitas/graph/equalization_fixtures.py
+++ b/tests/brevitas/graph/equalization_fixtures.py
@@ -22,6 +22,10 @@ from brevitas.quant.experimental.mx_quant_ocp import MXInt8Weight
 from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 
 SEED = 123456
+ATOL_DICT = {
+    torch.float32: 1e-3,
+    torch.float16: 5e-2,
+    torch.bfloat16: 1e-1,}
 ATOL = 1e-3
 
 MODELS = {

--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -198,6 +198,10 @@ def test_models(toy_model, merge_bias, request):
 def test_act_equalization_models(toy_model, layerwise, fuse_scaling, dtype, request):
     if not fuse_scaling and parse('1.9.0') > torch_version:
         pytest.skip("Parametrizations were not available in PyTorch versions below 1.9.0")
+    if dtype in [torch.float16, torch.bfloat16] and parse('2.3.0') > torch_version:
+        pytest.skip(
+            "Some operations are not implemented for float16/bfloat16 in PyTorch versions below 2.3.0"
+        )
     test_id = request.node.callspec.id
 
     if 'mha' in test_id:

--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -41,7 +41,6 @@ from brevitas.graph.utils import get_module
 from brevitas.nn.equalized_layer import RotatedModule
 from brevitas.utils.parametrization_utils import RotationWeightParametrization
 from brevitas.utils.python_utils import recurse_getattr
-from brevitas.utils.torch_utils import is_parametrized
 from tests.marker import requires_pt_ge
 
 from .equalization_fixtures import *
@@ -195,7 +194,10 @@ def test_models(toy_model, merge_bias, request):
 @pytest_cases.parametrize(
     "dtype", [torch.float32, torch.float16, torch.bfloat16],
     ids=lambda dtype: str(dtype).split(".")[-1])
-def test_act_equalization_models(toy_model, layerwise, fuse_scaling, dtype, request):
+@pytest_cases.parametrize(
+    "device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"],
+    ids=lambda dtype: str(dtype).split(".")[-1])
+def test_act_equalization_models(toy_model, layerwise, fuse_scaling, dtype, device, request):
     if not fuse_scaling and parse('1.9.0') > torch_version:
         pytest.skip("Parametrizations were not available in PyTorch versions below 1.9.0")
     if dtype in [torch.float16, torch.bfloat16] and parse('2.3.0') > torch_version:
@@ -211,8 +213,8 @@ def test_act_equalization_models(toy_model, layerwise, fuse_scaling, dtype, requ
 
     model_class = toy_model
     model = model_class()
-    model.to(dtype=dtype)
-    inp = torch.randn(in_shape, dtype=dtype)
+    model.to(device=device, dtype=dtype)
+    inp = torch.randn(in_shape, device=device, dtype=dtype)
 
     model.eval()
     expected_out = model(inp)


### PR DESCRIPTION
## Reason for this PR

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

Activation equalization crashes when using `bfloat16`.

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

Make `ScaleBias` output match the dtype of the input tensor.

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

Expanded tests for activation equalization with `float16` and `bfloat16`.

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
