### PR TITLE
Draft Sharkitas

### DIFF
--- a/src/brevitas/export/inference/manager.py
+++ b/src/brevitas/export/inference/manager.py
@@ -86,8 +86,7 @@ class quant_inference_mode:
         InferenceManager.set_export_mode(self.model, enabled=False)
         self.model.apply(
             lambda m: _override_bias_caching_mode(m, enabled=False, metadata_only=False))
-        self.model.apply(
-            lambda m: _override_act_caching_mode(m, enabled=False, metadata_only=False))
+        self.model.apply(lambda m: _override_act_caching_mode(m, enabled=False, metadata_only=True))
         if self.cache_quant_weight:
             self.model.apply(
                 lambda m: _override_weight_caching_mode(m, enabled=False, metadata_only=False))

--- a/src/brevitas/export/shark/handler.py
+++ b/src/brevitas/export/shark/handler.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from sharktank.types import StaticScaledQuantizer
+import torch
+import torch.nn as nn
+
+from brevitas.function.ops import max_int
+from brevitas.function.ops import min_int
+from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjector
+from brevitas.proxy.runtime_quant import ActQuantProxyFromInjector
+
+
+class SharkWeightQuant(nn.Module):
+    handled_layer = WeightQuantProxyFromInjector
+
+    def __init__(self):
+        super().__init__()
+        self.layer_name = None
+        self.shared_dict = None
+
+    def attach_debug_info(self, module: nn.Module):
+        pass
+
+    def prepare_for_export(self, module: nn.Module):
+        if module.is_quant_enabled:
+            # Continguous is used to be extra-safe with torch.compile
+            self.scale = module.scale().contiguous()
+            self.zero_point = module.zero_point().contiguous()
+            self.zero_point = self.zero_point.to(self.scale.device)
+            self.bit_width = module.bit_width()
+            self.min_clamp = min_int(module.is_signed, module.is_narrow_range, self.bit_width)
+            self.max_clamp = max_int(module.is_signed, module.is_narrow_range, self.bit_width)
+
+    def forward(self, x):
+        assert self.layer_name is not None
+        assert self.shared_dict is not None
+
+        zero_point = None if torch.count_nonzero(self.zero_point) == 0 else self.zero_point
+        if zero_point:
+            zero_point -= 128  # TODO: check
+        weight_quant = StaticScaledQuantizer(
+            scale=torch.reciprocal(self.scale),
+            reciprocal_scale=self.scale,
+            offset=zero_point,
+            dtype=torch.int8)
+        quant_weight = weight_quant.quantize(x)
+        self.shared_dict[self.layer_name + 'weight'] = quant_weight
+        return x, self.scale, self.zero_point, self.bit_width
+
+
+class SharkActQuant(nn.Module):
+    handled_layer = ActQuantProxyFromInjector
+
+    def __init__(self):
+        super().__init__()
+        self.layer_name = None
+        self.shared_dict = None
+
+    def prepare_for_export(self, module: nn.Module):
+        if module.is_quant_enabled:
+            # Continguous is used to be extra-safe with torch.compile
+            self.scale = module.scale().contiguous()
+            self.zero_point = module.zero_point().contiguous()
+            self.zero_point = self.zero_point.to(self.scale.device)
+            self.bit_width = module.bit_width()
+            self.min_clamp = min_int(module.is_signed, module.is_narrow_range, self.bit_width)
+            self.max_clamp = max_int(module.is_signed, module.is_narrow_range, self.bit_width)
+
+    def forward(self, x):
+        assert self.layer_name is not None
+        assert self.theta is not None
+
+        zero_point = None if torch.count_nonzero(self.zero_point) == 0 else self.zero_point
+        if zero_point:
+            zero_point -= 128  # TODO: check
+        input_quant = StaticScaledQuantizer(
+            scale=torch.repricocal(self.scale),
+            reciprocal_scale=self.scale,
+            offset=zero_point,
+            dtype=torch.int8)
+        self.shared_dict[self.layer_name + 'q_input'] = input_quant
+        return x, self.scale, self.zero_point, self.bit_width

--- a/src/brevitas/export/shark/handler.py
+++ b/src/brevitas/export/shark/handler.py
@@ -57,6 +57,9 @@ class SharkActQuant(nn.Module):
         self.layer_name = None
         self.shared_dict = None
 
+    def attach_debug_info(self, module: nn.Module):
+        pass
+
     def prepare_for_export(self, module: nn.Module):
         if module.is_quant_enabled:
             # Continguous is used to be extra-safe with torch.compile
@@ -69,13 +72,13 @@ class SharkActQuant(nn.Module):
 
     def forward(self, x):
         assert self.layer_name is not None
-        assert self.theta is not None
+        assert self.shared_dict is not None
 
         zero_point = None if torch.count_nonzero(self.zero_point) == 0 else self.zero_point
         if zero_point:
             zero_point -= 128  # TODO: check
         input_quant = StaticScaledQuantizer(
-            scale=torch.repricocal(self.scale),
+            scale=torch.reciprocal(self.scale),
             reciprocal_scale=self.scale,
             offset=zero_point,
             dtype=torch.int8)

--- a/src/brevitas/export/shark/manager.py
+++ b/src/brevitas/export/shark/manager.py
@@ -15,6 +15,7 @@ from brevitas.export.manager import _set_proxy_export_mode
 from brevitas.export.manager import _set_recurrent_layer_export_handler
 from brevitas.export.manager import _set_recurrent_layer_export_mode
 from brevitas.export.manager import BaseManager
+from brevitas.export.shark.handler import SharkActQuant
 from brevitas.export.shark.handler import SharkWeightQuant
 from brevitas.graph.equalize import EqualizedModule
 from brevitas.nn.quant_layer import QuantNonLinearActLayer
@@ -49,8 +50,7 @@ def _override_create_quant_tensor(m: nn.Module, state: bool):
 def _quant_wbiol_handler(layer, layer_name, shared_dict):
     if layer.weight_quant.is_quant_enabled:
         _quant_handler(layer, layer_name, 'weight_quant', shared_dict)
-
-    elif layer.input_quant.is_quant_enabled:
+    if layer.input_quant.is_quant_enabled:
         _quant_handler(layer, layer_name, 'input_quant', shared_dict)
 
 
@@ -67,7 +67,7 @@ def _quant_handler(layer, layer_name, quant_name, shared_dict):
 
 # Inheritance from BaseManager is not techincally needed
 class SharkManager(BaseManager):
-    handlers = [SharkWeightQuant]
+    handlers = [SharkWeightQuant, SharkActQuant]
 
     @classmethod
     def set_export_mode(cls, model: Module, enabled: bool):

--- a/src/brevitas/export/shark/manager.py
+++ b/src/brevitas/export/shark/manager.py
@@ -1,0 +1,133 @@
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from functools import partial
+
+from sharktank.types import Dataset
+from sharktank.types import DefaultPrimitiveTensor
+from sharktank.types import Theta
+import torch
+from torch.nn import Module
+import torch.nn as nn
+
+from brevitas.export.manager import _set_proxy_export_handler
+from brevitas.export.manager import _set_proxy_export_mode
+from brevitas.export.manager import _set_recurrent_layer_export_handler
+from brevitas.export.manager import _set_recurrent_layer_export_mode
+from brevitas.export.manager import BaseManager
+from brevitas.export.shark.handler import SharkWeightQuant
+from brevitas.graph.equalize import EqualizedModule
+from brevitas.nn.quant_layer import QuantNonLinearActLayer
+from brevitas.nn.quant_layer import QuantWeightBiasInputOutputLayer
+
+
+def _override_caching_mode(m: nn.Module, attr: str, enabled: bool, metadata_only: bool = True):
+    cache_var = 'cache_inference_quant_' + attr
+    cache_var_metadata_only = cache_var + '_metadata_only'
+    if hasattr(m, cache_var):
+        setattr(m, cache_var, enabled)
+        setattr(m, cache_var_metadata_only, metadata_only)
+
+
+def _override_bias_caching_mode(m: nn.Module, enabled: bool, metadata_only: bool = True):
+    _override_caching_mode(m, 'bias', enabled, metadata_only)
+
+
+def _override_act_caching_mode(m: nn.Module, enabled: bool, metadata_only: bool = True):
+    _override_caching_mode(m, 'act', enabled, metadata_only)
+
+
+def _override_weight_caching_mode(m: nn.Module, enabled: bool, metadata_only: bool = False):
+    _override_caching_mode(m, 'weight', enabled, metadata_only)
+
+
+def _override_create_quant_tensor(m: nn.Module, state: bool):
+    if hasattr(m, 'skip_create_quant_tensor'):
+        m.skip_create_quant_tensor = state
+
+
+def _quant_wbiol_handler(layer, layer_name, shared_dict):
+    if layer.weight_quant.is_quant_enabled:
+        _quant_handler(layer, layer_name, 'weight_quant', shared_dict)
+
+    elif layer.input_quant.is_quant_enabled:
+        _quant_handler(layer, layer_name, 'input_quant', shared_dict)
+
+
+def _quant_act_handler(layer, layer_name, shared_dict):
+    if layer.act_quant.is_quant_enabled:
+        _quant_handler(layer, layer_name, 'act_quant', shared_dict)
+
+
+def _quant_handler(layer, layer_name, quant_name, shared_dict):
+    handler = getattr(layer, quant_name).export_handler
+    handler.layer_name = layer_name
+    handler.shared_dict = shared_dict
+
+
+# Inheritance from BaseManager is not techincally needed
+class SharkManager(BaseManager):
+    handlers = [SharkWeightQuant]
+
+    @classmethod
+    def set_export_mode(cls, model: Module, enabled: bool):
+        _set_proxy_export_mode(model, enabled)
+        _set_recurrent_layer_export_mode(model, enabled)
+
+    @classmethod
+    def set_export_handler(cls, module: Module):
+        _set_proxy_export_handler(cls, module)
+        _set_recurrent_layer_export_handler(cls, module)
+
+    def export(self, model, *model_args, **model_kwargs):
+
+        shared_dict = {}
+        # TODO:
+        # - Create a base state dict with all layers
+        # - Unwrap equalized layer
+        # - Flatten equalized layer parameters as part of the "main layer"
+        # - Populate layer_name and shared dict fields
+        # - ...
+        # - Profit (?)
+
+        shared_dict.update(model.state_dict())
+
+        # Cache quant metadata
+        model.apply(lambda m: _override_bias_caching_mode(m, enabled=True, metadata_only=True))
+        model.apply(lambda m: _override_act_caching_mode(m, enabled=True))
+        model.apply(lambda m: _override_weight_caching_mode(m, enabled=True, metadata_only=False))
+        model(*model_args, **model_kwargs)
+
+        model.apply(lambda m: _override_bias_caching_mode(m, enabled=False))
+        model.apply(lambda m: _override_act_caching_mode(m, enabled=False))
+        model.apply(lambda m: _override_weight_caching_mode(m, enabled=False))
+
+        model.apply(self.set_export_handler)
+        self.set_export_mode(model, enabled=True)
+
+        for n, m in model.named_modules():
+            if isinstance(m, EqualizedModule):
+                premul_input = m.scale
+                premul_input = DefaultPrimitiveTensor(
+                    name=f"{n}.premul_input",
+                    data=premul_input,
+                )
+                shared_dict[premul_input.name] = premul_input
+                _quant_wbiol_handler(m.layer, n, shared_dict)
+                # add check to avoid looping again into m.layer
+            if isinstance(m, QuantWeightBiasInputOutputLayer):
+                print(n)
+                _quant_wbiol_handler(m, n, shared_dict)
+
+            elif isinstance(m, QuantNonLinearActLayer):
+                _quant_act_handler(m, n, shared_dict)
+
+        model(*model_args, **model_kwargs)
+
+        self.set_export_mode(model, enabled=False)
+        print(shared_dict)
+
+        theta = Theta(shared_dict)
+        ds = Dataset(dict(), theta)
+
+        return ds

--- a/src/brevitas/export/shark/test.py
+++ b/src/brevitas/export/shark/test.py
@@ -1,0 +1,13 @@
+import torch
+
+from brevitas.export.shark.manager import SharkManager
+import brevitas.nn as qnn
+
+n = qnn.QuantLinear(3, 5, bias=False)
+n.eval()
+
+export = SharkManager()
+
+ds = export.export(n, torch.randn(1, 3))
+print(ds)
+ds.save('test_dataset.irpa')

--- a/src/brevitas/export/shark/test.py
+++ b/src/brevitas/export/shark/test.py
@@ -2,8 +2,9 @@ import torch
 
 from brevitas.export.shark.manager import SharkManager
 import brevitas.nn as qnn
+from brevitas.quant import Int8ActPerTensorFloat
 
-n = qnn.QuantLinear(3, 5, bias=False)
+n = qnn.QuantLinear(3, 5, input_quant=Int8ActPerTensorFloat, bias=False)
 n.eval()
 
 export = SharkManager()


### PR DESCRIPTION
## Reason for this PR

Improved export flow from Brevitas to Shark

## Changes Made in this PR

The good:

- Individual layer export is flexible enough to export in principle any model
- Easily expandable to support different data-types (fp8, groupwise quantization, etc.)

The bad:

- We cannot modify the compute graph (only exception is smoothquant)
- We rely on a forward pass + op tracing for our export, while Theta is mostly state-dict based
- The exception is activation quantization, where a quantizer is directly stored in Theta

The ugly:
- Export happens at three different levels at the same time: Proxy, QuantLayer, and "Wrapped Layer" (e.g., EqualizedModule)
- Since it relies on keys matching, we need to flatten/revert some state_dict modifications (e.g., flatten EqualizedModule)

## Testing Summary

TBD

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
