### PR TITLE
Feat (brevitas_examples/llm): BOS preprocessing for calibration data

### DIFF
--- a/src/brevitas_examples/llm/README.md
+++ b/src/brevitas_examples/llm/README.md
@@ -19,7 +19,8 @@ usage: main.py [-h] [--config CONFIG] [--model MODEL]
                [--dtype {float32,float16,bfloat16}] [--seed SEED]
                [--nsamples NSAMPLES]
                [--nsamples-rot-calibration NSAMPLES_ROT_CALIBRATION]
-               [--seqlen SEQLEN] [--eval] [--dataset {wikitext2,c4}]
+               [--seqlen SEQLEN] [--eval]
+               [--dataset {wikitext2,c4,wikitext2_clm,c4_clm,pile_clm}]
                [--gpxq-block-name GPXQ_BLOCK_NAME]
                [--weight-bit-width WEIGHT_BIT_WIDTH]
                [--weight-param-method {stats,mse,hqo}]
@@ -56,6 +57,8 @@ usage: main.py [-h] [--config CONFIG] [--model MODEL]
                [--weight-equalization] [--rotation {fx,layerwise,fused_no_fx}]
                [--optimize-rotations] [--rotation-mode {had,ort}]
                [--rotation-orphan-sink] [--rotation-sdpa-regions]
+               [--svd-quant] [--svd-quant-rank SVD_QUANT_RANK]
+               [--svd-quant-iters SVD_QUANT_ITERS]
                [--act-equalization {None,layerwise,fx}]
                [--act-equalization-alpha ACT_EQUALIZATION_ALPHA]
                [--load-awq LOAD_AWQ]
@@ -67,7 +70,7 @@ usage: main.py [-h] [--config CONFIG] [--model MODEL]
                [--few-shot-eval {lm_eval,lighteval}]
                [--few-shot-override-batch-size FEW_SHOT_OVERRIDE_BATCH_SIZE]
                [--compile-ptq] [--compile-eval] [--few-shot-zeroshot]
-               [--few-shot-limit FEW_SHOT_LIMIT]
+               [--no-bos-preprocessing] [--few-shot-limit FEW_SHOT_LIMIT]
                [--few-shot-tasks [FEW_SHOT_TASKS ...]]
                [--rotation-layers-to-expand [ROTATION_LAYERS_TO_EXPAND ...]]
 
@@ -85,7 +88,7 @@ options:
                         Default: 800.
   --seqlen SEQLEN       Sequence length. Default: 2048.
   --eval                Eval model PPL on the chosen Dataset.
-  --dataset {wikitext2,c4}
+  --dataset {wikitext2,c4,wikitext2_clm,c4_clm,pile_clm}
                         Dataset to use for quantization (default: wikitext2)
   --gpxq-block-name GPXQ_BLOCK_NAME
                         Block name for faster GPxQ optimization. It works only
@@ -211,6 +214,11 @@ options:
   --rotation-sdpa-regions
                         If GraphRotation is enabled, decide wheter to equalize
                         across SDPA
+  --svd-quant           Apply SVDQuant.
+  --svd-quant-rank SVD_QUANT_RANK
+                        Rank to use for SVDQuant (default: 32).
+  --svd-quant-iters SVD_QUANT_ITERS
+                        Number of iterations to use for SVDQuant (default: 1).
   --act-equalization {None,layerwise,fx}
                         Apply activation equalization (SmoothQuant). Layerwise
                         introduces standalone mul nodes,while fx merges them
@@ -249,6 +257,9 @@ options:
   --compile-ptq         Compile for PTQ algorithms. Default False)
   --compile-eval        Compile during evaluation. Default False)
   --few-shot-zeroshot   Whether to do zero or few shot eval. Default False)
+  --no-bos-preprocessing
+                        Do not add BOS token during pre-processing. Default
+                        False)
   --few-shot-limit FEW_SHOT_LIMIT
                         Few shot limit. Default None)
   --few-shot-tasks [FEW_SHOT_TASKS ...]

--- a/src/brevitas_examples/llm/README.md
+++ b/src/brevitas_examples/llm/README.md
@@ -19,8 +19,7 @@ usage: main.py [-h] [--config CONFIG] [--model MODEL]
                [--dtype {float32,float16,bfloat16}] [--seed SEED]
                [--nsamples NSAMPLES]
                [--nsamples-rot-calibration NSAMPLES_ROT_CALIBRATION]
-               [--seqlen SEQLEN] [--eval]
-               [--dataset {wikitext2,c4,wikitext2_clm,c4_clm,pile_clm}]
+               [--seqlen SEQLEN] [--eval] [--dataset {wikitext2,c4,pile}]
                [--gpxq-block-name GPXQ_BLOCK_NAME]
                [--weight-bit-width WEIGHT_BIT_WIDTH]
                [--weight-param-method {stats,mse,hqo}]
@@ -88,7 +87,7 @@ options:
                         Default: 800.
   --seqlen SEQLEN       Sequence length. Default: 2048.
   --eval                Eval model PPL on the chosen Dataset.
-  --dataset {wikitext2,c4,wikitext2_clm,c4_clm,pile_clm}
+  --dataset {wikitext2,c4,pile}
                         Dataset to use for quantization (default: wikitext2)
   --gpxq-block-name GPXQ_BLOCK_NAME
                         Block name for faster GPxQ optimization. It works only

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -45,7 +45,7 @@ def create_llm_args_parser():
     parser.add_argument(
         '--dataset',
         type=str,
-        choices=['wikitext2', 'c4', 'wikitext2_clm', 'c4_clm', 'pile_clm'],
+        choices=['wikitext2', 'c4', 'pile'],
         default='wikitext2',
         help='Dataset to use for quantization (default: %(default)s)')
     parser.add_argument(

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -45,7 +45,7 @@ def create_llm_args_parser():
     parser.add_argument(
         '--dataset',
         type=str,
-        choices=['wikitext2', 'c4'],
+        choices=['wikitext2', 'c4', 'wikitext2_clm', 'c4_clm', 'pile_clm'],
         default='wikitext2',
         help='Dataset to use for quantization (default: %(default)s)')
     parser.add_argument(
@@ -368,6 +368,8 @@ def create_llm_args_parser():
         '--few-shot-zeroshot',
         action="store_true",
         help='Whether to do zero or few shot eval. Default %(default)s)')
+    parser.add_argument(
+        '--add-bos-token', action="store_true", help='Add BOS token. Default %(default)s)')
     parser.add_argument(
         '--few-shot-limit', type=int, default=None, help='Few shot limit. Default %(default)s)')
     parser.add_argument(

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -369,7 +369,9 @@ def create_llm_args_parser():
         action="store_true",
         help='Whether to do zero or few shot eval. Default %(default)s)')
     parser.add_argument(
-        '--add-bos-token', action="store_true", help='Add BOS token. Default %(default)s)')
+        '--no-bos-preprocessing',
+        action="store_true",
+        help='Do not add BOS token during pre-processing. Default %(default)s)')
     parser.add_argument(
         '--few-shot-limit', type=int, default=None, help='Few shot limit. Default %(default)s)')
     parser.add_argument(
@@ -450,10 +452,3 @@ def validate(args, extra_args: Optional[List[str]] = None):
                 assert args.export_target != 'onnx_qcdq', "Cannot export ONNX QCDQ with FX + MHA replacing"
             else:
                 assert args.export_target != 'torch_qcdq', "Cannot export Torch QCDQ with FX"
-
-    if not args.fuse_sequences:
-        # 350 is approximately the 99% percentile for the sequence length in WikiText2 (train partition, using AutoTokenizer)
-        if args.seqlen >= 350:
-            warn(
-                "Data loading can take a long time or, potentially, enter an infinite loop. Consider setting --args.fuse_sequences "
-                "or decreasing the sequence length (seqlen)")

--- a/src/brevitas_examples/llm/llm_quant/data.py
+++ b/src/brevitas_examples/llm/llm_quant/data.py
@@ -171,7 +171,7 @@ def get_dataset_clm(
         features=Features({"input_ids": Sequence(feature=Value(dtype="int64"), length=seqlen)}),
         batched=True,
         num_proc=dataset_processing_num_proc_per_process,
-        load_from_cache_file=False,
+        load_from_cache_file=True,
         desc=f"Grouping texts in chunks of {seqlen}",
     )
     # Retrieve a random subset of sequences

--- a/src/brevitas_examples/llm/llm_quant/data.py
+++ b/src/brevitas_examples/llm/llm_quant/data.py
@@ -24,12 +24,19 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from functools import partial
 import random
-from typing import Any
+from typing import Any, Dict, List
 
+from datasets import Dataset
+from datasets import Features
 from datasets import load_dataset
+from datasets import Sequence
+from datasets import Value
+import numpy as np
 import torch
 from tqdm import tqdm
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 
 def get_c4(
@@ -87,6 +94,100 @@ def get_c4(
                 pbar.update(1)
 
     return dataset
+
+
+def group_texts(examples: Dict[str, List[np.ndarray]],
+                sequence_length: int) -> Dict[str, List[np.ndarray]]:
+    # Concatenate all texts.
+    concatenated_examples = {k: np.concatenate(v) for k, v in examples.items()}
+    total_length = len(concatenated_examples[next(iter(examples.keys()))])
+    # WARNING: We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
+    # customize this part to your needs.
+    if total_length >= sequence_length:
+        total_length = ((total_length) // sequence_length) * sequence_length
+    # Split by chunks of sequence_length.
+    result = {
+        k: [
+            t[i:i + sequence_length]
+            for i in range(0, total_length - (sequence_length), sequence_length)] for k,
+        t in concatenated_examples.items()}
+    return result
+
+
+def _tokenize_and_group_texts(
+        texts: List[str],
+        tokenizer: PreTrainedTokenizerBase,
+        sequence_length: int,
+        filter_empty_sequences: bool = True) -> Dict[str, List[np.ndarray]]:
+    # Filter empty sequences
+    if filter_empty_sequences:
+        texts = [text for text in texts if len(texts) > 0]
+    tokenized_batch = tokenizer.batch_encode_plus(
+        texts, return_attention_mask=False, return_token_type_ids=False)
+    tokenized_batch = {
+        k: [np.array(tokenized_texts) for tokenized_texts in v] for k, v in tokenized_batch.items()}
+    return group_texts(tokenized_batch, sequence_length)
+
+
+def _load_dataset(dataset_name: str, seed: int = 42) -> Dataset:
+    if dataset_name == "wikitext2":
+        data = load_dataset('wikitext', 'wikitext-2-raw-v1', split='train')
+    elif dataset_name == "c4":
+        data = load_dataset(
+            "allenai/c4", split="train", data_files={"train": "en/c4-train.00000-of-01024.json.gz"})
+        data = data.shuffle(seed=seed).select(range(10000))  # c4 is too big.
+    elif dataset_name == "pile":
+        data = load_dataset("mit-han-lab/pile-val-backup", split="validation")
+    else:
+        raise ValueError(f"Dataset {dataset_name} is not available.")
+    return data
+
+
+def _clm_dataset_to_list(row: np.ndarray,) -> Dict[str, torch.Tensor]:
+    input_ids = torch.tensor(row["input_ids"], dtype=torch.int64).unsqueeze(0)
+    attention_mask = torch.ones_like(input_ids)
+    return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+def get_dataset_clm(
+    dataset_name: str,
+    tokenizer: PreTrainedTokenizerBase,
+    nsamples: int,
+    seqlen: int,
+    split: str,
+    fuse_sequences: bool,
+    seed: int = 42,
+    filter_empty_sequences: bool = True,
+    dataset_processing_num_proc_per_process: int = 1,
+    dataset_overwrite_cache: bool = False,
+    text_column_name: str = "text",
+):
+    random.seed(seed)
+    # Load given dataset
+    raw_dataset = _load_dataset(dataset_name, seed)
+    # Preprocess dataset
+    dataset = raw_dataset.map(
+        partial(
+            _tokenize_and_group_texts,
+            tokenizer=tokenizer,
+            sequence_length=seqlen,
+            filter_empty_sequences=filter_empty_sequences),
+        input_columns=text_column_name,
+        remove_columns=raw_dataset.column_names,
+        features=Features({"input_ids": Sequence(feature=Value(dtype="int64"), length=seqlen)}),
+        batched=True,
+        num_proc=dataset_processing_num_proc_per_process,
+        load_from_cache_file=False,
+        desc=f"Grouping texts in chunks of {seqlen}",
+    )
+    # Retrieve a random subset of sequences
+    random_indices = [i for i in range(len(dataset))]
+    random.shuffle(random_indices)
+    random_indices = random_indices[:nsamples]
+    # Retrive random slice of dataset
+    dataset = dataset.select(random_indices)
+    # Now return the slice in a format that can be converted to a DatasetToDevice
+    return list(map(_clm_dataset_to_list, dataset))
 
 
 def get_wikitext2(

--- a/src/brevitas_examples/llm/llm_quant/data_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/data_utils.py
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from functools import partial
 import random
 from typing import Any, Iterable, List, Optional, Union
 
@@ -33,6 +34,7 @@ import torch
 from transformers import AutoConfig
 
 from .data import get_c4
+from .data import get_dataset_clm
 from .data import get_wikitext2
 
 
@@ -89,7 +91,10 @@ def get_dataset_for_model(
     torch.random.manual_seed(seed)
     get_dataset_map = {
         "wikitext2": get_wikitext2,
-        "c4": get_c4,}
+        "c4": get_c4,
+        "wikitext2_clm": partial(get_dataset_clm, dataset_name="wikitext2"),
+        "c4_clm": partial(get_dataset_clm, dataset_name="c4"),
+        "pile_clm": partial(get_dataset_clm, dataset_name="pile"),}
     if split not in ["train", "validation"]:
         raise ValueError(f"The split need to be 'train' or 'validation' but found {split}")
     if dataset_name not in get_dataset_map:

--- a/src/brevitas_examples/llm/llm_quant/data_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/data_utils.py
@@ -35,6 +35,7 @@ from transformers import AutoConfig
 
 from .data import get_c4
 from .data import get_dataset_clm
+from .data import get_pile
 from .data import get_wikitext2
 
 
@@ -82,19 +83,14 @@ def get_dataset_for_model(
     seqlen: int = 2048,
     seed: int = 0,
     split: str = "train",
-    fuse_sequences: bool = True,
+    bos_preprocessing: bool = True,
     require_fx: bool = False,
     device: Optional[Union[str, torch.device]] = None,
 ):
     random.seed(seed)
     np.random.seed(seed)
     torch.random.manual_seed(seed)
-    get_dataset_map = {
-        "wikitext2": get_wikitext2,
-        "c4": get_c4,
-        "wikitext2_clm": partial(get_dataset_clm, dataset_name="wikitext2"),
-        "c4_clm": partial(get_dataset_clm, dataset_name="c4"),
-        "pile_clm": partial(get_dataset_clm, dataset_name="pile"),}
+    get_dataset_map = {"wikitext2": get_wikitext2, "c4": get_c4, "pile": get_pile}
     if split not in ["train", "validation"]:
         raise ValueError(f"The split need to be 'train' or 'validation' but found {split}")
     if dataset_name not in get_dataset_map:
@@ -107,8 +103,8 @@ def get_dataset_for_model(
         nsamples=nsamples,
         seqlen=seqlen,
         split=split,
-        fuse_sequences=fuse_sequences,
-        seed=seed)
+        seed=seed,
+        bos_preprocessing=bos_preprocessing)
 
     # In case the dataset is loaded to be used with an fx.GraphModule, we need to add empty past_key_values inputs in the dataset.
     if require_fx:

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -190,6 +190,7 @@ def quantize_llm(args, extra_args=None):
     # Load the data for calibration and evaluation.
     calibration_loader = get_dataset_for_model(
         args.model,
+        bos_preprocessing=not args.no_bos_preprocessing,
         dataset_name=args.dataset,
         tokenizer=tokenizer,
         nsamples=args.nsamples,
@@ -197,11 +198,11 @@ def quantize_llm(args, extra_args=None):
         split="train",
         seed=args.seed,
         require_fx=require_fx and args.export_target is not None,
-        device=None,
-        fuse_sequences=args.fuse_sequences)
+        device=None)
 
     validation_loader = get_dataset_for_model(
         args.model,
+        bos_preprocessing=not args.no_bos_preprocessing,
         dataset_name=args.dataset,
         tokenizer=tokenizer,
         nsamples=args.nsamples,
@@ -209,8 +210,7 @@ def quantize_llm(args, extra_args=None):
         split="validation",
         seed=args.seed,
         require_fx=require_fx and args.export_target is not None,
-        device=None,
-        fuse_sequences=args.fuse_sequences)
+        device=None)
 
     if args.optimize_rotations:
         # Extra arguments should be used as training arguments for rotation optimization
@@ -225,8 +225,7 @@ def quantize_llm(args, extra_args=None):
             split="train",
             seed=args.seed,
             require_fx=require_fx and args.export_target is not None,
-            device=None,
-            fuse_sequences=args.fuse_sequences)
+            device=None)
 
     device = next(iter(model.parameters())).device
     print("Data loaded.")

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -202,7 +202,7 @@ def quantize_llm(args, extra_args=None):
 
     validation_loader = get_dataset_for_model(
         args.model,
-        dataset_name=args.dataset,
+        dataset_name="wikitext2",
         tokenizer=tokenizer,
         nsamples=args.nsamples,
         seqlen=args.seqlen,
@@ -543,7 +543,8 @@ def quantize_llm(args, extra_args=None):
             with torch.no_grad(), quant_inference_mode(model, compile=args.compile_eval):
                 model(**calibration_loader[0])
 
-                wrapped_model = HFLM(pretrained=model)  # need to wrap for LLM eval
+                wrapped_model = HFLM(
+                    pretrained=model, add_bos_token=args.add_bos_token)  # need to wrap for LLM eval
                 few_shot_eval_results = evaluator.simple_evaluate(
                     model=wrapped_model,
                     model_args=None,

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -543,7 +543,7 @@ def quantize_llm(args, extra_args=None):
                 model(**calibration_loader[0])
 
                 wrapped_model = HFLM(
-                    pretrained=model, add_bos_token=args.add_bos_token)  # need to wrap for LLM eval
+                    pretrained=model, add_bos_token=True)  # need to wrap for LLM eval
                 few_shot_eval_results = evaluator.simple_evaluate(
                     model=wrapped_model,
                     model_args=None,

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -202,7 +202,7 @@ def quantize_llm(args, extra_args=None):
 
     validation_loader = get_dataset_for_model(
         args.model,
-        dataset_name="wikitext2",
+        dataset_name=args.dataset,
         tokenizer=tokenizer,
         nsamples=args.nsamples,
         seqlen=args.seqlen,

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -224,7 +224,7 @@ def test_small_models_toggle_run_args_pt_ge_2_4(
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "act_equalization": "fx",
             "bias_corr": True,
-            "float_ppl": 33312.0 if transformers_version_ge('4.46.0') else 33239.5,
+            "float_ppl": 33312.0 if transformers_version_ge('4.46.0') else 31136.918,
             "quant_ppl": 33056.0 if transformers_version_ge('4.46.0') else 33283.75390625},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -235,13 +235,13 @@ def test_small_models_toggle_run_args_pt_ge_2_4(
             "input_quant_granularity": "per_row",
             "input_scale_type": "dynamic",
             "input_quant_type": "sym",
-            "float_ppl": 33312.0 if transformers_version_ge('4.46.0') else 33239.5,
+            "float_ppl": 33312.0 if transformers_version_ge('4.46.0') else 31136.918,
             "quant_ppl": 33056.0 if transformers_version_ge('4.46.0') else 33234.398},
         {
             "model": "hf-internal-testing/tiny-random-MistralForCausalLM",
             "act_equalization": "layerwise",
             "gptq": True,
-            "float_ppl": 31056.0 if transformers_version_ge('4.46.0') else 31274.05078125,
+            "float_ppl": 31056.0 if transformers_version_ge('4.46.0') else 27792.436,
             "quant_ppl": 33056.0 if transformers_version_ge('4.46.0') else 33117.71484375},])
 def acc_args_and_acc(default_run_args, request):
     args = default_run_args
@@ -278,14 +278,14 @@ def test_small_models_acc(caplog, acc_args_and_acc):
             "weight_equalization": True,
             "ln_affine_merge": True,
             "replace_mha": True,
-            "float_ppl": 49941.7734375,
+            "float_ppl": 47967.746,
             "quant_ppl": 49941.578125},
         {
             "model": "hf-internal-testing/tiny-random-OPTForCausalLM",  # Requires PT>=2.4 to run
             "weight_equalization": True,
             "ln_affine_merge": True,
             "quant_sdpa": True,
-            "float_ppl": 49941.7734375,
+            "float_ppl": 47967.746,
             "quant_ppl": 49941.578125},])
 def acc_args_and_acc_pt_ge_2_4(default_run_args, request):
     args = default_run_args
@@ -804,7 +804,7 @@ def test_small_models_torch_export(caplog, torch_export_args):
             "learned_round": "linear_round",
             "learned_round_iters": 1,
             "gpxq_block_name": "model.layers",
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33252.21484375},
         {
             "model": "hf-internal-testing/tiny-random-MistralForCausalLM",
@@ -814,7 +814,7 @@ def test_small_models_torch_export(caplog, torch_export_args):
             "learned_round": "linear_round",
             "learned_round_iters": 1,
             "gpxq_block_name": "model.layers",
-            "float_ppl": 31275.958984375,
+            "float_ppl": 27792.436,
             "quant_ppl": 31337.4921875},])
 def learned_round_ppl_args_and_ppl(default_run_args, request):
     args = default_run_args
@@ -857,7 +857,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation": "fused_no_fx",
             "rotation_orphan_sink": True,
             "rotation_mode": "ort",
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33232.65234375,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -868,7 +868,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation": "fused_no_fx",
             "rotation_orphan_sink": False,
             "rotation_mode": "ort",
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33420.65234375,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -879,7 +879,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation": "fused_no_fx",
             "rotation_orphan_sink": True,
             "rotation_mode": "had",
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33290.48046875,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -890,7 +890,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation": "fused_no_fx",
             "rotation_orphan_sink": False,
             "rotation_mode": "had",
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33204.80859375,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -899,7 +899,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "input_bit_width": None,
             "replace_rmsnorm": True,
             "rotation": "layerwise",
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33446.734375,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -911,7 +911,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation_orphan_sink": False,
             "rotation_mode": "had",
             "rotation_layers_to_expand": ["down_proj"],
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33216.3671875,},])
 def rotation_ppl_args_and_ppl(default_run_args, request):
     args = default_run_args
@@ -965,7 +965,7 @@ def test_small_models_rotation_ppl(caplog, rotation_ppl_args_and_ppl):
                 "1",
                 "--gradient_accumulation_steps",
                 "1"],
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33239.33984375,
             "exp_layer_types_count": {
                 "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 4,
@@ -993,7 +993,7 @@ def test_small_models_rotation_ppl(caplog, rotation_ppl_args_and_ppl):
                 "1",
                 "--gradient_accumulation_steps",
                 "1"],
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33423.0390625,
             "exp_layer_types_count": {
                 "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 0,
@@ -1021,7 +1021,7 @@ def test_small_models_rotation_ppl(caplog, rotation_ppl_args_and_ppl):
                 "1",
                 "--gradient_accumulation_steps",
                 "1"],
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33286.98828125,
             "exp_layer_types_count": {
                 "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 4,
@@ -1049,7 +1049,7 @@ def test_small_models_rotation_ppl(caplog, rotation_ppl_args_and_ppl):
                 "1",
                 "--gradient_accumulation_steps",
                 "1"],
-            "float_ppl": 33238.8984375,
+            "float_ppl": 31136.918,
             "quant_ppl": 33175.3046875,
             "exp_layer_types_count": {
                 "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 0,

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -225,7 +225,7 @@ def test_small_models_toggle_run_args_pt_ge_2_4(
             "act_equalization": "fx",
             "bias_corr": True,
             "float_ppl": 33312.0 if transformers_version_ge('4.46.0') else 31136.918,
-            "quant_ppl": 31314.102 if transformers_version_ge('4.46.0') else 33283.75390625},
+            "quant_ppl": 31314.102 if transformers_version_ge('4.46.0') else 31314.102},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "act_equalization": "fx",
@@ -236,13 +236,13 @@ def test_small_models_toggle_run_args_pt_ge_2_4(
             "input_scale_type": "dynamic",
             "input_quant_type": "sym",
             "float_ppl": 33312.0 if transformers_version_ge('4.46.0') else 31136.918,
-            "quant_ppl": 31073.258 if transformers_version_ge('4.46.0') else 33234.398},
+            "quant_ppl": 31073.258 if transformers_version_ge('4.46.0') else 31073.258},
         {
             "model": "hf-internal-testing/tiny-random-MistralForCausalLM",
             "act_equalization": "layerwise",
             "gptq": True,
             "float_ppl": 31056.0 if transformers_version_ge('4.46.0') else 27792.436,
-            "quant_ppl": 28608.725 if transformers_version_ge('4.46.0') else 33117.71484375},])
+            "quant_ppl": 28608.725 if transformers_version_ge('4.46.0') else 28608.725},])
 def acc_args_and_acc(default_run_args, request):
     args = default_run_args
     run_dict = request.param

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -225,7 +225,7 @@ def test_small_models_toggle_run_args_pt_ge_2_4(
             "act_equalization": "fx",
             "bias_corr": True,
             "float_ppl": 33312.0 if transformers_version_ge('4.46.0') else 31136.918,
-            "quant_ppl": 33056.0 if transformers_version_ge('4.46.0') else 33283.75390625},
+            "quant_ppl": 31314.102 if transformers_version_ge('4.46.0') else 33283.75390625},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "act_equalization": "fx",
@@ -236,13 +236,13 @@ def test_small_models_toggle_run_args_pt_ge_2_4(
             "input_scale_type": "dynamic",
             "input_quant_type": "sym",
             "float_ppl": 33312.0 if transformers_version_ge('4.46.0') else 31136.918,
-            "quant_ppl": 33056.0 if transformers_version_ge('4.46.0') else 33234.398},
+            "quant_ppl": 31073.258 if transformers_version_ge('4.46.0') else 33234.398},
         {
             "model": "hf-internal-testing/tiny-random-MistralForCausalLM",
             "act_equalization": "layerwise",
             "gptq": True,
             "float_ppl": 31056.0 if transformers_version_ge('4.46.0') else 27792.436,
-            "quant_ppl": 33056.0 if transformers_version_ge('4.46.0') else 33117.71484375},])
+            "quant_ppl": 28608.725 if transformers_version_ge('4.46.0') else 33117.71484375},])
 def acc_args_and_acc(default_run_args, request):
     args = default_run_args
     run_dict = request.param
@@ -279,14 +279,14 @@ def test_small_models_acc(caplog, acc_args_and_acc):
             "ln_affine_merge": True,
             "replace_mha": True,
             "float_ppl": 47967.746,
-            "quant_ppl": 49941.578125},
+            "quant_ppl": 47869.035},
         {
             "model": "hf-internal-testing/tiny-random-OPTForCausalLM",  # Requires PT>=2.4 to run
             "weight_equalization": True,
             "ln_affine_merge": True,
             "quant_sdpa": True,
             "float_ppl": 47967.746,
-            "quant_ppl": 49941.578125},])
+            "quant_ppl": 47869.035},])
 def acc_args_and_acc_pt_ge_2_4(default_run_args, request):
     args = default_run_args
     run_dict = request.param
@@ -805,7 +805,7 @@ def test_small_models_torch_export(caplog, torch_export_args):
             "learned_round_iters": 1,
             "gpxq_block_name": "model.layers",
             "float_ppl": 31136.918,
-            "quant_ppl": 33252.21484375},
+            "quant_ppl": 31322.375},
         {
             "model": "hf-internal-testing/tiny-random-MistralForCausalLM",
             "act_calibration": False,
@@ -815,7 +815,7 @@ def test_small_models_torch_export(caplog, torch_export_args):
             "learned_round_iters": 1,
             "gpxq_block_name": "model.layers",
             "float_ppl": 27792.436,
-            "quant_ppl": 31337.4921875},])
+            "quant_ppl": 28161.56},])
 def learned_round_ppl_args_and_ppl(default_run_args, request):
     args = default_run_args
     run_dict = request.param
@@ -858,7 +858,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation_orphan_sink": True,
             "rotation_mode": "ort",
             "float_ppl": 31136.918,
-            "quant_ppl": 33232.65234375,},
+            "quant_ppl": 31272.172,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "act_calibration": False,
@@ -869,7 +869,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation_orphan_sink": False,
             "rotation_mode": "ort",
             "float_ppl": 31136.918,
-            "quant_ppl": 33420.65234375,},
+            "quant_ppl": 31310.459,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "act_calibration": False,
@@ -880,7 +880,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation_orphan_sink": True,
             "rotation_mode": "had",
             "float_ppl": 31136.918,
-            "quant_ppl": 33290.48046875,},
+            "quant_ppl": 31038.398,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "act_calibration": False,
@@ -891,7 +891,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation_orphan_sink": False,
             "rotation_mode": "had",
             "float_ppl": 31136.918,
-            "quant_ppl": 33204.80859375,},
+            "quant_ppl": 31182.68,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "act_calibration": False,
@@ -900,7 +900,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "replace_rmsnorm": True,
             "rotation": "layerwise",
             "float_ppl": 31136.918,
-            "quant_ppl": 33446.734375,},
+            "quant_ppl": 31161.514,},
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "act_calibration": False,
@@ -912,7 +912,7 @@ def test_small_models_learned_round_ppl(caplog, learned_round_ppl_args_and_ppl):
             "rotation_mode": "had",
             "rotation_layers_to_expand": ["down_proj"],
             "float_ppl": 31136.918,
-            "quant_ppl": 33216.3671875,},])
+            "quant_ppl": 31155.57,},])
 def rotation_ppl_args_and_ppl(default_run_args, request):
     args = default_run_args
     run_dict = request.param
@@ -966,7 +966,7 @@ def test_small_models_rotation_ppl(caplog, rotation_ppl_args_and_ppl):
                 "--gradient_accumulation_steps",
                 "1"],
             "float_ppl": 31136.918,
-            "quant_ppl": 33239.33984375,
+            "quant_ppl": 31236.613,
             "exp_layer_types_count": {
                 "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 4,
                 "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -994,7 +994,7 @@ def test_small_models_rotation_ppl(caplog, rotation_ppl_args_and_ppl):
                 "--gradient_accumulation_steps",
                 "1"],
             "float_ppl": 31136.918,
-            "quant_ppl": 33423.0390625,
+            "quant_ppl": 31310.459,
             "exp_layer_types_count": {
                 "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 0,
                 "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -1022,7 +1022,7 @@ def test_small_models_rotation_ppl(caplog, rotation_ppl_args_and_ppl):
                 "--gradient_accumulation_steps",
                 "1"],
             "float_ppl": 31136.918,
-            "quant_ppl": 33286.98828125,
+            "quant_ppl": 31176.02,
             "exp_layer_types_count": {
                 "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 4,
                 "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -1050,7 +1050,7 @@ def test_small_models_rotation_ppl(caplog, rotation_ppl_args_and_ppl):
                 "--gradient_accumulation_steps",
                 "1"],
             "float_ppl": 31136.918,
-            "quant_ppl": 33175.3046875,
+            "quant_ppl": 31046.008,
             "exp_layer_types_count": {
                 "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 0,
                 "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,


### PR DESCRIPTION
## Reason for this PR
Follow up to #1229 

## Changes Made in this PR

The final results of the discussion is to add the possibility to pre-prepocess the calibration datasets, adding BOS token whenever needed, before fusing and splitting the datasets into chunks of seqlength length.

We also preserve the possibility to not do this, and thus have a single BOS token at the beginning of the entire calibration set, which doesn't make a whole lot of sense logically but it's a widespread setup

## Testing Summary

Check issue above for results


## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
