### PR TITLE
Fix (test/ste_ops): fix mock tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -103,12 +103,7 @@ def tests_brevitas_cpu(session, pytorch, jit_status):
         # run graph tests separately
         session.run('pytest', 'tests/brevitas/graph', '-n', 'logical', '-v')
         session.env['BREVITAS_NATIVE_STE_BACKEND'] = '1'
-        session.run(
-            'pytest',
-            '-n',
-            'logical',
-            'tests/brevitas/function/test_ops_ste.py',
-            '-v')
+        session.run('pytest', '-n', 'logical', 'tests/brevitas/function/test_ops_ste.py', '-v')
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -102,6 +102,13 @@ def tests_brevitas_cpu(session, pytorch, jit_status):
             'tests/brevitas/nn/test_nn_quantizers.py')
         # run graph tests separately
         session.run('pytest', 'tests/brevitas/graph', '-n', 'logical', '-v')
+        session.env['BREVITAS_NATIVE_STE_BACKEND'] = '1'
+        session.run(
+            'pytest',
+            '-n',
+            'logical',
+            'tests/brevitas/function/test_ops_ste.py',
+            '-v')
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/tests/brevitas/function/hyp_helper.py
+++ b/tests/brevitas/function/hyp_helper.py
@@ -37,6 +37,20 @@ def tensor_clamp_ste_test_st():
 
 
 @st.composite
+def scalar_clamp_ste_test_st(draw):
+    """
+    Generate min_val and max_val floats, val and val_grad tensors.
+    The val and val_grad tensors has the same random shape
+    """
+    shape = draw(random_tensor_shape_st())
+    min_val = draw(float_st())
+    max_val = draw(float_st())
+    val = draw(float_tensor_st(shape))
+    val_grad = draw(float_tensor_nz_st(shape))
+    return min_val, max_val, val, val_grad
+
+
+@st.composite
 def tensor_clamp_random_shape_test_st(draw):
     """
     Generate min_val, max_val and val tensors all of the same random shape.

--- a/tests/brevitas/function/test_ops_ste.py
+++ b/tests/brevitas/function/test_ops_ste.py
@@ -41,7 +41,7 @@ def prefix_and_status_impl(jit, native_ste):
         if not jit and not config.JIT_ENABLED:
             return NATIVE_PREFIX, True
     if not native_ste and not brevitas.NATIVE_STE_BACKEND_LOADED:
-        if jit == config.JIT_ENABLED:
+        if jit == bool(config.JIT_ENABLED):
             return AUTOGRAD_OPS_PREFIX, True
     return None, None
 

--- a/tests/brevitas/function/test_ops_ste.py
+++ b/tests/brevitas/function/test_ops_ste.py
@@ -109,7 +109,7 @@ def test_scalar_clamp_min_ste_backend(prefix: str, x):
     """
     backend_name = 'scalar_clamp_min_ste_impl'
     with mock.patch(prefix + backend_name) as python_backend:
-        inp, min_val, mocked_return_val = x
+        min_val, inp, mocked_return_val = x
         python_backend.return_value = mocked_return_val
         return_val = scalar_clamp_min_ste(inp, min_val)
         # check that the wrapped function is called with the correct argument

--- a/tests/brevitas/function/test_ops_ste.py
+++ b/tests/brevitas/function/test_ops_ste.py
@@ -11,6 +11,7 @@ from brevitas import config
 from brevitas.function import ops_ste
 from brevitas.function.ops_ste import *
 from tests.brevitas.function.hyp_helper import scalar_clamp_min_ste_test_st
+from tests.brevitas.function.hyp_helper import scalar_clamp_ste_test_st
 from tests.brevitas.function.hyp_helper import tensor_clamp_ste_test_st
 from tests.brevitas.hyp_helper import two_float_tensor_random_shape_st
 
@@ -90,7 +91,7 @@ def test_tensor_clamp_ste_backend(prefix: str, x):
         assert return_val is mocked_return_val
 
 
-@given(x=tensor_clamp_ste_test_st())
+@given(x=scalar_clamp_ste_test_st())
 def test_scalar_clamp_ste_backend(prefix: str, x):
     """
     Test that scalar_clamp_ste is wrapping the backend implementation correctly.

--- a/tests/brevitas/function/test_ops_ste.py
+++ b/tests/brevitas/function/test_ops_ste.py
@@ -1,12 +1,13 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from typing import Tuple
+
 from hypothesis import given
 import mock
 import pytest
 import pytest_cases
 import torch
-from typing import Tuple
 
 import brevitas
 from brevitas import config

--- a/tests/brevitas/function/test_ops_ste.py
+++ b/tests/brevitas/function/test_ops_ste.py
@@ -60,9 +60,9 @@ def gen_case_id(jit_and_native_ste):
 
 @pytest_cases.fixture()
 @pytest_cases.parametrize(
-"jit, native_ste",
-[(j, s) for j in BOOLS for s in BOOLS],
-ids=gen_case_id,
+    "jit, native_ste",
+    [(j, s) for j in BOOLS for s in BOOLS],
+    ids=gen_case_id,
 )
 def prefix_and_status(jit, native_ste) -> Tuple[str, bool]:
     """

--- a/tests/brevitas/function/test_ops_ste.py
+++ b/tests/brevitas/function/test_ops_ste.py
@@ -43,14 +43,18 @@ def test_jit_annotations(prefix: str):
     """
     Test that the annotations to enable/disable the jit are being set correctly
     """
-    if prefix == NATIVE_PREFIX:
+    if brevitas.NATIVE_STE_BACKEND_LOADED:
+        assert prefix == NATIVE_PREFIX
         assert ops_ste.fn_prefix == torch
         assert ops_ste.script_flag == brevitas.jit.script
-        assert config.JIT_ENABLED
     else:
         assert prefix == AUTOGRAD_OPS_PREFIX
         assert ops_ste.fn_prefix == brevitas
         assert ops_ste.script_flag == torch.jit.ignore
+    if config.JIT_ENABLED:
+        assert brevitas.jit.script == torch.jit.script
+    else:
+        assert brevitas.jit.script == brevitas.jit._disabled
 
 
 @given(x=two_float_tensor_random_shape_st())


### PR DESCRIPTION
Address issue identified in #1241. The issue was much deeper than expected, so I will go into detail about the issue and the proposed solution here. The TL;DR is that there was an issue with the way the tests were written and how they were being executed on GitHub actions, but that there was no underlying issue in the Brevitas library.

## The Issue

After consulting with @Giuseppe5, my best guess is that prior to #1241 being reported, that the images on GitHub actions did not contain a valid configuration for `ninja` for any platforms. This caused the following downstream issues:
 - when `BREVITAS_JIT=1` and native STE backend could not be compiled
 - this caused `brevitas.NATIVE_STE_BACKEND_LOADED=False`
 - the compiled c++ backend was never tested by GitHub actions

After #1241, the GitHub action images for _did_ contain a valid configuration for `ninja` on the Ubuntu, MacOSX platforms, meaning:
 - when `BREVITAS_JIT=1` and native STE backend _could_ be compiled
 - when `BREVITAS_JIT=1`, `brevitas.NATIVE_STE_BACKEND_LOADED=True`
 - the compiled c++ backend _was_ tested by GitHub actions when `BREVITAS_JIT=1` on Ubuntu, MacOSX
 - these tests were written incorrectly and all failed when `BREVITAS_JIT=1`, `brevitas.NATIVE_STE_BACKEND_LOADED=True`

In general, the tests contained `tests/brevitas/function/test_ops_ste.py` check some brevitas configuration and check that the correct brevitas functions are called. However, when `config.JIT_ENABLED=True` and `config.NATIVE_STE_BACKEND_LOADED=True`, we won't see that the correct function is called, because the full compute graph is compiled down to c++, so all of these tests failed.

A few tests (`test_scalar_clamp_ste_backend`, `test_scalar_clamp_min_ste_backend`) also required some other fixes to work when `config.JIT_ENABLED=False` and `config.NATIVE_STE_BACKEND_LOADED=True`.

## The Proposed Solution

In order to fix the tests, I propose the following:
 - [x] fix minor issues with `test_scalar_clamp_ste_backend`, `test_scalar_clamp_min_ste_backend` to fix them when `brevitas.NATIVE_STE_BACKEND_LOADED=True`;
 - [x] otherwise, the test behaviour should remain the same under all configurations except when `BREVITAS_JIT=1`, `brevitas.NATIVE_STE_BACKEND_LOADED=True`;
 - [x] since the entire compute graph is compiled away, when `BREVITAS_JIT=1`, `brevitas.NATIVE_STE_BACKEND_LOADED=True` we should check that neither function is called, e.g., neither `brevitas.ops.autograd_ste_ops.scalar_clamp_min_ste_impl` nor `torch.ops.autograd_ste_ops.scalar_clamp_min_ste_impl` (the latter being the compiled c++ backend); and
 - [x] GitHub actions should test all possible values for `config.JIT_ENABLED=<False|True>` and `config.NATIVE_STE_BACKEND_LOADED=<False|True>`

In order to test all possible values for `config.JIT_ENABLED` and `config.NATIVE_STE_BACKEND_LOADED`, we need to understand how these flags are determined in Brevitas. Each flag is determined by the following conditions:
 - `config.JIT_ENABLED=False` and `config.NATIVE_STE_BACKEND_LOADED=False`, i.e., `BREVITAS_JIT=0`;
 - `config.JIT_ENABLED=False` and `config.NATIVE_STE_BACKEND_LOADED=True`, i.e., `BREVITAS_JIT=0`, `BREVITAS_NATIVE_STE_BACKEND=1` _and_ a valid configuration for `ninja` can be found;
 - `config.JIT_ENABLED=True` and `config.NATIVE_STE_BACKEND_LOADED=False`, i.e., `BREVITAS_JIT=1`, _and_ a valid configuration for `ninja` can _not_ be found; and
 - `config.JIT_ENABLED=True` and `config.NATIVE_STE_BACKEND_LOADED=True`, i.e., `BREVITAS_JIT=1`, _and_ a valid configuration for `ninja` can be found

Unfortunately, the last two configurations are only determined by whether or not a valid version of `ninja` can be found. Currently, the windows image on GitHub actions doesn't include a valid version of `ninja`, so our in order to test all configurations, we need to:
 - [x] add a test when `BREVITAS_JIT=0`, `BREVITAS_NATIVE_STE_BACKEND=1`; and
 - [x] have tests for both Ubuntu/MacOSX and Windows (which we already do)

### Issues with Proposed Solution

The main issue with the proposed solution is that it is relying on a valid `ninja` configuration to be available on some platforms (for the `config.JIT_ENABLED=True` and `config.NATIVE_STE_BACKEND_LOADED=True` tests) and it being not available on others (for the `config.JIT_ENABLED=True` and `config.NATIVE_STE_BACKEND_LOADED=False` tests). As such, it's not always clear which tests are being run. To address this, we have created custom `ids` which denote the different configurations. Passing tests across all configurations means that every mode has been tested and that it passes.

Explicitly, the id `prefix=<brevitas|torch>-called=<0|1>-jit=<0|1>-native_ste=<0|1>` denotes the testing configuration. Specifically:
 - `jit = config.JIT_ENABLED`;
 - `native_ste = config.NATIVE_STE_BACKEND_LOADED`;
 - `prefix=<brevitas|torch>` the current function prefix is under test; and
 - `called=<0|1>`, whether or not we expect the prefix to be called or not respectively.
 
An example the full space of tests running is shown below:
 
Firstly, on a system with a valid `ninja` configuration.
 
 ```bash
$ BREVITAS_JIT=0 BREVITAS_NATIVE_STE_BACKEND=0 pytest "tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend" | grep PASSED
tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend[prefix=brevitas-called=1-jit=0-native_ste=0] PASSED [100%]
 ```
 
 ```bash
$ BREVITAS_JIT=0 BREVITAS_NATIVE_STE_BACKEND=1 pytest "tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend" | grep PASSED
tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend[prefix=torch-called=1-jit=0-native_ste=1] PASSED [ 75%]
 ```
 
 ```bash
$ BREVITAS_JIT=1 pytest "tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend" | grep PASSED  
tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend[prefix=torch-called=0-jit=1-native_ste=1] PASSED [ 25%]
tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend[prefix=brevitas-called=0-jit=1-native_ste=1] PASSED [ 75%]
 ```

Finally, on a system without a valid `ninja` configuration.

 ```bash
$ BREVITAS_JIT=1 pytest "tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend" | grep PASSED
tests/brevitas/function/test_ops_ste.py::test_scalar_clamp_min_ste_backend[prefix=brevitas-called=1-jit=1-native_ste=0] PASSED [ 50%]
 ```

To ensure that these are running on the CI, we can inspect whether all configurations appear across three separate runs: any test with the [JIT disabled](https://github.com/Xilinx/brevitas/actions/runs/14249102372/job/39937352207?pr=1242), a test with the [JIT enabled and a valid `ninja` configuration](https://github.com/Xilinx/brevitas/actions/runs/14249102372/job/39937355365?pr=1242) and a test with the [JIT enabled but without a valid `ninja` configuration](https://github.com/Xilinx/brevitas/actions/runs/14249102372/job/39937338728?pr=1242). The log files of each can be downloaded, and the outputs confirmed manually by checking that all entries above exist as follows:

```bash
cat job-logs*.log | grep PASSED.*test_scalar_clamp_min_ste_backend
```