### PR TITLE
Feat (data): separating sequence and sentence BOS preprocessing

### DIFF
--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -375,9 +375,11 @@ def create_llm_args_parser():
         action="store_true",
         help='Whether to do zero or few shot eval. Default %(default)s)')
     parser.add_argument(
-        '--no-bos-preprocessing',
-        action="store_true",
-        help='Do not add BOS token during pre-processing. Default %(default)s)')
+        '--bos-preprocessing',
+        type=str,
+        default=None,
+        choices=['sentence', 'sequence'],
+        help='Type of BOS token pre-processing for training and evaluation datasets. Default %(default)s)')
     parser.add_argument(
         '--few-shot-limit', type=int, default=None, help='Few shot limit. Default %(default)s)')
     parser.add_argument(
@@ -409,6 +411,8 @@ def validate(args, extra_args: Optional[List[str]] = None):
     elif args.rotation == 'fused_no_fx':
         assert not args.convert_layernorm_to_rmsnorm, 'LayerNorm is automatically replaced with RMSNorm when running with --rotation=fused_no_fx. Remove the flag --convert-layernorm-to-rmsnorm'
         assert args.replace_rmsnorm, 'Graph rotation requires to replace HF RMSNorm with PyTorch ones (torch 2.4+ require)'
+    if args.bos_preprocessing is not None:
+        assert args.bos_preprocessing in ['sentence', 'sequence'], f"bos_preprocessing should be either 'sentence' or 'sequence' but found {args.bos_preprocessing}"
     if not args.no_quantize:
         if args.gptq and args.gpfq:
             warn("Both GPTQ and GPFQ are enabled.")

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -379,7 +379,9 @@ def create_llm_args_parser():
         type=str,
         default=None,
         choices=['sentence', 'sequence'],
-        help='Type of BOS token pre-processing for training and evaluation datasets. Default %(default)s)')
+        help=
+        'Type of BOS token pre-processing for training and evaluation datasets. Default %(default)s)'
+    )
     parser.add_argument(
         '--few-shot-limit', type=int, default=None, help='Few shot limit. Default %(default)s)')
     parser.add_argument(

--- a/src/brevitas_examples/llm/llm_quant/data.py
+++ b/src/brevitas_examples/llm/llm_quant/data.py
@@ -194,7 +194,7 @@ def get_wikitext2(
         seed: int = 42):
     random.seed(seed)
     data = _load_dataset('wikitext2', split, seed)
-    # sentence-level BOS pre-process adds a BOS token to every sentence before 
+    # sentence-level BOS pre-process adds a BOS token to every sentence before
     # concatenating and splitting it in equal-length sequences
     if bos_preprocessing == "sentence":
         return get_dataset_clm(data, tokenizer, nsamples, seqlen)

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -191,7 +191,7 @@ def quantize_llm(args, extra_args=None):
     # Load the data for calibration and evaluation.
     calibration_loader = get_dataset_for_model(
         args.model,
-        bos_preprocessing=not args.no_bos_preprocessing,
+        bos_preprocessing=args.bos_preprocessing,
         dataset_name=args.dataset,
         tokenizer=tokenizer,
         nsamples=args.nsamples,
@@ -203,7 +203,7 @@ def quantize_llm(args, extra_args=None):
 
     validation_loader = get_dataset_for_model(
         args.model,
-        bos_preprocessing=not args.no_bos_preprocessing,
+        bos_preprocessing=args.bos_preprocessing,
         dataset_name=args.dataset,
         tokenizer=tokenizer,
         nsamples=args.nsamples,
@@ -219,6 +219,7 @@ def quantize_llm(args, extra_args=None):
         # Load the data for rotation optimization
         rot_calibration_loader = get_dataset_for_model(
             args.model,
+            bos_preprocessing=args.bos_preprocessing,
             dataset_name=args.dataset,
             tokenizer=tokenizer,
             nsamples=args.nsamples_rot_calibration,


### PR DESCRIPTION
## Reason for this PR

See #1229 for detailed discussion on reason.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

- Separately considering sentence and sequence BOS pre-processing
- Repurposing `no_bos_preprocessing` argument to `bos_preprocessing`
- Making sure training and testing datasets are processed the same way

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
