### PR TITLE
Fix (ci): Don't update PyTorch version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,6 +19,7 @@ from gen_github_actions import TORCHVISION_VERSION_DICT
 IS_OSX = system() == 'Darwin'
 PYTORCH_STABLE_WHEEL_SRC = 'https://download.pytorch.org/whl/cpu'
 PYTORCH_STABLE_WHEEL_SRC_LEGACY = 'https://download.pytorch.org/whl/torch_stable.html'
+PIP_URL = 'https://pypi.org/simple'
 PYTORCH_IDS = tuple([f'pytorch_{i}' for i in PYTORCH_VERSIONS])
 EXAMPLES_LLM_PYTEST_PYTORCH_IDS = tuple([
     f'pytorch_{i}' for i in EXAMPLES_LLM_PYTEST_PYTORCH_VERSIONS])
@@ -32,7 +33,7 @@ def install_pytorch_cmd(pytorch):
         if parse(pytorch) < parse('2.4.0'):
             cmd = [f'torch=={pytorch}+cpu', '-f', PYTORCH_STABLE_WHEEL_SRC_LEGACY]
         else:
-            cmd = [f'torch=={pytorch}', '--index-url', PYTORCH_STABLE_WHEEL_SRC]
+            cmd = [f'torch=={pytorch}', '--index-url', PYTORCH_STABLE_WHEEL_SRC, '--extra-index-url', PIP_URL]
 
     else:
         cmd = [f'torch=={pytorch}']
@@ -51,7 +52,8 @@ def install_torchvision_cmd(pytorch):
             cmd = [
                 f'torchvision=={torchvision}',
                 '--index-url',
-                PYTORCH_STABLE_WHEEL_SRC]
+                PYTORCH_STABLE_WHEEL_SRC,
+                '--extra-index-url', PIP_URL]
     else:
         cmd = [f'torchvision=={torchvision}']
     return cmd

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,7 +66,7 @@ def tests_brevitas_cpu(session, pytorch, jit_status):
     session.env['BREVITAS_JIT'] = '{}'.format(int(jit_status == 'jit_enabled'))
     install_pytorch(pytorch, session)
     install_torchvision(pytorch, session)
-    session.install('--upgrade', '.[test, export]')
+    session.install('-e', '.[test, export]')
     if jit_status == 'jit_enabled':
         session.run('pytest', '-k', 'not _full', 'tests/brevitas/nn/test_nn_quantizers.py', '-v')
         session.run(
@@ -113,7 +113,7 @@ def tests_brevitas_examples_cpu(session, pytorch, jit_status):
     session.env['BREVITAS_JIT'] = '{}'.format(int(jit_status == 'jit_enabled'))
     install_pytorch(pytorch, session)
     install_torchvision(pytorch, session)  # For CV eval scripts
-    session.install('--upgrade', '.[test, tts, stt, vision]')
+    session.install('-e', '.[test, tts, stt, vision]')
     session.run(
         'pytest',
         '-n',
@@ -140,7 +140,7 @@ def tests_brevitas_examples_llm(session, pytorch, jit_status):
 def tests_brevitas_install_dev(session, pytorch):
     install_pytorch(pytorch, session)
     install_torchvision(pytorch, session)
-    session.install('--upgrade', '-e', '.[test]')
+    session.install('-e', '.[test]')
     session.env['BREVITAS_VERBOSE'] = '1'
     session.run('pytest', '-n', 'logical', '-v', 'tests/brevitas/test_brevitas_import.py')
 
@@ -150,7 +150,7 @@ def tests_brevitas_install_dev(session, pytorch):
 def tests_brevitas_examples_install_dev(session, pytorch):
     install_pytorch(pytorch, session)
     install_torchvision(pytorch, session)
-    session.install('--upgrade', '-e', '.[test, tts, stt]')
+    session.install('-e', '.[test, tts, stt]')
     session.run('pytest', '-n', 'logical', '-v', 'tests/brevitas_examples/test_examples_import.py')
 
 
@@ -159,7 +159,7 @@ def tests_brevitas_examples_install_dev(session, pytorch):
 def tests_brevitas_finn_integration(session, pytorch):
     install_pytorch(pytorch, session)
     install_torchvision(pytorch, session)
-    session.install('--upgrade', '-e', '.[test, stt, finn_integration]')
+    session.install('-e', '.[test, stt, finn_integration]')
     env = {'FINN_INST_NAME': 'finn'}
     session.run('pytest', '-v', 'tests/brevitas_finn', env=env)
 
@@ -169,7 +169,7 @@ def tests_brevitas_finn_integration(session, pytorch):
 def tests_brevitas_ort_integration(session, pytorch):
     install_pytorch(pytorch, session)
     install_torchvision(pytorch, session)
-    session.install('--upgrade', '-e', '.[test, ort_integration]')
+    session.install('-e', '.[test, ort_integration]')
     session.run('pytest', '-n', 'logical', '-v', 'tests/brevitas_ort')
 
 
@@ -178,7 +178,7 @@ def tests_brevitas_ort_integration(session, pytorch):
 def tests_brevitas_notebook(session, pytorch):
     install_pytorch(pytorch, session)
     install_torchvision(pytorch, session)
-    session.install('--upgrade', '-e', '.[test, ort_integration, notebook]')
+    session.install('-e', '.[test, ort_integration, notebook]')
     session.run(
         'pytest',
         '-n',
@@ -196,5 +196,5 @@ def tests_brevitas_notebook(session, pytorch):
 def tests_brevitas_end_to_end(session, pytorch):
     install_pytorch(pytorch, session)
     install_torchvision(pytorch, session)
-    session.install('--upgrade', '-e', '.[test, ort_integration]')
+    session.install('-e', '.[test, ort_integration]')
     session.run('pytest', '-n', 'logical', '-v', 'tests/brevitas_end_to_end')

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,12 @@ def install_pytorch_cmd(pytorch):
         if parse(pytorch) < parse('2.4.0'):
             cmd = [f'torch=={pytorch}+cpu', '-f', PYTORCH_STABLE_WHEEL_SRC_LEGACY]
         else:
-            cmd = [f'torch=={pytorch}', '--index-url', PYTORCH_STABLE_WHEEL_SRC, '--extra-index-url', PIP_URL]
+            cmd = [
+                f'torch=={pytorch}',
+                '--index-url',
+                PYTORCH_STABLE_WHEEL_SRC,
+                '--extra-index-url',
+                PIP_URL]
 
     else:
         cmd = [f'torch=={pytorch}']
@@ -44,16 +49,14 @@ def install_torchvision_cmd(pytorch):
     torchvision = PARSED_TORCHVISION_VERSION_DICT[version.parse(pytorch)]
     if not IS_OSX:
         if parse(pytorch) < parse('2.4.0'):
-            cmd = [
-                f'torchvision=={torchvision}+cpu',
-                '-f',
-                PYTORCH_STABLE_WHEEL_SRC_LEGACY]
+            cmd = [f'torchvision=={torchvision}+cpu', '-f', PYTORCH_STABLE_WHEEL_SRC_LEGACY]
         else:
             cmd = [
                 f'torchvision=={torchvision}',
                 '--index-url',
                 PYTORCH_STABLE_WHEEL_SRC,
-                '--extra-index-url', PIP_URL]
+                '--extra-index-url',
+                PIP_URL]
     else:
         cmd = [f'torchvision=={torchvision}']
     return cmd

--- a/tests/brevitas/core/test_float_to_int.py
+++ b/tests/brevitas/core/test_float_to_int.py
@@ -46,9 +46,7 @@ class TestLearnedRound():
     # closer to sys.maxsize for a given machine.
     @pytest_cases.parametrize('impl', LEARNEDROUND_IMPL)
     @pytest_cases.parametrize('training', [True, False])
-    @given(
-        weights_value=two_float_tensor_random_shape_st(
-            min_val=-9.223372036854776e+18, max_val=9.223372036854776e+18))
+    @given(weights_value=two_float_tensor_random_shape_st(min_val=-(2 ** 8), max_val=2 ** 8))
     def test_learnedround(self, impl, training, weights_value):
         # Unpack tuple of hypothesis generated tensors
         weights, value = weights_value


### PR DESCRIPTION
Issue: For some tests, `pip` was updating / reinstalling PyTorch during the environmental setup, resulting in the latest version of PyTorch being installed.

The solution is to always use a single `pip` command to install all dependencies. This solution is not fully robust, we might need to consider an alternative way to avoid updating PyTorch during CI, but it works for now.

Note, the adjustments to the environment setup exposed an issue / edge case in the learned round tests, which have also been fixed.