### PR TITLE
Feat (ex/llm): "auto" dtype

### DIFF
--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -25,8 +25,8 @@ def create_llm_args_parser():
     parser.add_argument(
         '--dtype',
         type=str,
-        default="float16",
-        choices=["float32", "float16", "bfloat16"],
+        default="auto",
+        choices=["auto", "float32", "float16", "bfloat16"],
         help='Data type for model. Default: %(default)s')
     parser.add_argument(
         '--seed', type=int, default=0, help='Seed for sampling the calibration data. Default: 0.')

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -165,12 +165,10 @@ def quantize_llm(args, extra_args=None):
     if args.export_prefix is None:
         args.export_prefix = f"{args.model.replace('/', '--')}"
 
-    dtype = getattr(torch, args.dtype)
-
     # Whether to quantize SDPA with FX
     quant_sdpa_fx = args.quant_sdpa and not args.replace_mha
 
-    kwargs = {"torch_dtype": dtype}
+    kwargs = {"torch_dtype": args.dtype}
     if quant_sdpa_fx:
         kwargs["attn_implementation"] = "sdpa"
 
@@ -179,6 +177,7 @@ def quantize_llm(args, extra_args=None):
 
     print("Model loading...")
     model = AutoModelForCausalLM.from_pretrained(args.model, **kwargs)
+    dtype = next(model.parameters()).dtype
     print("Model loaded.")
     model.eval()
     tokenizer = AutoTokenizer.from_pretrained(args.model)


### PR DESCRIPTION
Enable the "auto" option for the LLM entrypoint, so that the original dtype of the HF model is used.