### PR TITLE
Setup: temporary pin pytest

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,7 +1,7 @@
 hypothesis
 mock
 psutil
-pytest==8.3.5
+pytest<8.4
 pytest-mock
 pytest-xdist
 pytest_cases

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,7 +1,7 @@
 hypothesis
 mock
 psutil
-pytest
+pytest==8.3.5
 pytest-mock
 pytest-xdist
 pytest_cases


### PR DESCRIPTION
## Reason for this PR

It seems to be an incompatibility between the 8.4 version of pytest and pytest_cases.
Pinning on pytest 8.3.5 until this is fixed.

https://github.com/smarie/python-pytest-cases/issues/364

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
