### PR TITLE
Fix (ex/imagenet): add forward pass in imagenet ptq example

### DIFF
--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -245,6 +245,13 @@ class GPxQ(ABC):
 
     def get_quant_weights(self, i, i1, permutation_list, with_quant_history=False):
 
+        # If the weight quantizer has not been initialized, raise an error
+        for m in self.layer.weight_quant.modules():
+            if hasattr(m, 'init_done') and not m.init_done:
+                raise RuntimeError(
+                    "Weight quantizer not initialized. Run a forward pass after quantization and try again."
+                )
+
         # We need to recompute quant weights at runtime since our float weights are being updated
         # Add offset in case of blockwise computation
         i = i1 + i

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -490,6 +490,17 @@ def main():
         act_scale_computation_type=args.act_scale_computation_type,
         uint_sym_act_for_unsigned_values=args.uint_sym_act_for_unsigned_values)
 
+    # Run a forward pass to set the scales
+    model.eval()
+    dtype = next(model.parameters()).dtype
+    device = next(model.parameters()).device
+    with torch.no_grad():
+        for i, (images, target) in enumerate(calib_loader):
+            images = images.to(device)
+            images = images.to(dtype)
+            model(images)
+            break
+
     if args.act_scale_computation_type == 'static':
         # Calibrate the quant_model on the calibration dataloader
         print("Starting activation calibration:")

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -490,16 +490,15 @@ def main():
         act_scale_computation_type=args.act_scale_computation_type,
         uint_sym_act_for_unsigned_values=args.uint_sym_act_for_unsigned_values)
 
-    # Run a forward pass to set the scales
+    # Some quantizer configurations require a forward pass to initialize scale factors.
+    # This forward pass ensures that so that subsequent algoritms work as intended
     model.eval()
     dtype = next(model.parameters()).dtype
     device = next(model.parameters()).device
+    images, _ = next(iter(calib_loader))
+    images = images.to(device=device, dtype=dtype)
     with torch.no_grad():
-        for i, (images, target) in enumerate(calib_loader):
-            images = images.to(device)
-            images = images.to(dtype)
-            model(images)
-            break
+        model(images)
 
     if args.act_scale_computation_type == 'static':
         # Calibrate the quant_model on the calibration dataloader

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -491,7 +491,7 @@ def main():
         uint_sym_act_for_unsigned_values=args.uint_sym_act_for_unsigned_values)
 
     # Some quantizer configurations require a forward pass to initialize scale factors.
-    # This forward pass ensures that so that subsequent algoritms work as intended
+    # This forward pass ensures that subsequent algorithms work as intended
     model.eval()
     dtype = next(model.parameters()).dtype
     device = next(model.parameters()).device


### PR DESCRIPTION

## Reason for this PR

Regression in our current imagenet/ptq examples, where GPTQ does not work as intended.
The reason is that we need to run a forward pass immediately after quantization to correctly initialize scale factors for the weights (in case they are set to `parameter_from_stats`).

This change was already applied in the LLM entrypoint a while back, and we forgot to update the imagenet entrypoint.

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
