### PR TITLE
docs (core): Typo fix in docstring

### DIFF
--- a/src/brevitas/core/function_wrapper/shape.py
+++ b/src/brevitas/core/function_wrapper/shape.py
@@ -53,7 +53,7 @@ class OverTensorView(brevitas.jit.ScriptModule):
 
 class OverOutputChannelView(brevitas.jit.ScriptModule):
     """
-    ScriptMoodule to compute the :func:`~brevitas.function.shape.over_output_channels` view of an
+    ScriptModule to compute the :func:`~brevitas.function.shape.over_output_channels` view of an
     input tensor.
 
     Examples:


### PR DESCRIPTION
`Moodule` -> `Module`