### PR TITLE
Fix (gpxq): device management of weight_orig for GPxQ

### DIFF
--- a/src/brevitas/graph/gpfq.py
+++ b/src/brevitas/graph/gpfq.py
@@ -104,6 +104,7 @@ class GPFQ(GPxQ):
         weight = self.layer.weight.data
         weight_orig = self.layer.weight_orig.data
         dev = weight.device
+        weight_orig = weight_orig.to(dev)
 
         # Store the original dtype of the weights
         # During computation, everything is converted to float32.
@@ -179,6 +180,9 @@ class GPFQ(GPxQ):
 
         if hasattr(self.layer, 'offload_params'):
             self.layer.offload_params(self.layer)
+        # offload original weights onto the CPU
+        if self.create_weight_orig:
+            self.layer.weight_orig = self.layer.weight_orig.cpu()
 
 
 class gpfq_mode(gpxq_mode):

--- a/src/brevitas/graph/gpfq.py
+++ b/src/brevitas/graph/gpfq.py
@@ -180,9 +180,6 @@ class GPFQ(GPxQ):
 
         if hasattr(self.layer, 'offload_params'):
             self.layer.offload_params(self.layer)
-        # offload original weights onto the CPU
-        if self.create_weight_orig:
-            self.layer.weight_orig = self.layer.weight_orig.cpu()
 
 
 class gpfq_mode(gpxq_mode):

--- a/src/brevitas/graph/magr.py
+++ b/src/brevitas/graph/magr.py
@@ -149,9 +149,6 @@ class MagR(GPTQ):
         del self.H  # free memory
         if hasattr(self.layer, 'offload_params'):
             self.layer.offload_params(self.layer)
-        # offload original weights onto the CPU
-        if self.create_weight_orig:
-            self.layer.weight_orig = self.layer.weight_orig.cpu()
 
 
 class magr_mode(gpxq_mode):

--- a/src/brevitas/graph/magr.py
+++ b/src/brevitas/graph/magr.py
@@ -117,6 +117,7 @@ class MagR(GPTQ):
             weight_orig = weight.detach().clone()
 
         dev = weight.device
+        weight_orig = weight_orig.to(dev)
 
         # Store the original dtype of the weights
         # During computation, everything is converted to float32.
@@ -148,6 +149,9 @@ class MagR(GPTQ):
         del self.H  # free memory
         if hasattr(self.layer, 'offload_params'):
             self.layer.offload_params(self.layer)
+        # offload original weights onto the CPU
+        if self.create_weight_orig:
+            self.layer.weight_orig = self.layer.weight_orig.cpu()
 
 
 class magr_mode(gpxq_mode):

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -93,6 +93,7 @@ class Qronos(GPFQ):
         weight: Tensor = self.layer.weight.data
         weight_orig: Tensor = self.layer.weight_orig.data
         dev = weight.device
+        weight_orig = weight_orig.to(dev)
 
         # Store the original dtype of the weights
         # During computation, everything is converted to float32.

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -252,7 +252,3 @@ class Qronos(GPFQ):
 
         if hasattr(self.layer, 'offload_params'):
             self.layer.offload_params(self.layer)
-
-        # offload original weights onto the CPU
-        if self.create_weight_orig:
-            self.layer.weight_orig = self.layer.weight_orig.cpu()


### PR DESCRIPTION
## Reason for this PR

#1325 fixed memory leak with GPTQ by registering `weight_orig` creation on CPU. This means that we need to cast `weight_orig` to the same device as `weight` in other GPxQ implementations (GPFQ, MagR, Qronos).

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

Casting `weight_orig` in GPFQ, MagR, and Qronos algorithm implementations.

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
