### PR TITLE
Feat: skipping rotation optimization with load_checkpoint

### DIFF
--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -559,7 +559,7 @@ def quantize_llm(args, extra_args=None):
                 model.load_state_dict(torch.load(args.checkpoint_name, map_location='cpu'))
             model = offload_model(model)
 
-        if args.gptq:
+        if args.gptq and not args.load_checkpoint:
             print("Applying GPTQ...")
             apply_gptq(
                 model,
@@ -572,7 +572,7 @@ def quantize_llm(args, extra_args=None):
                 max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
             print("GPTQ applied.")
 
-        if args.gpfq:
+        if args.gpfq and not args.load_checkpoint:
             print("Applying GPFQ...")
             apply_gpfq(
                 model,
@@ -583,7 +583,7 @@ def quantize_llm(args, extra_args=None):
                 max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
             print("GPFQ applied.")
 
-        if args.qronos:
+        if args.qronos and not args.load_checkpoint:
             print("Applying Qronos...")
             apply_qronos(
                 model,
@@ -593,7 +593,7 @@ def quantize_llm(args, extra_args=None):
                 block_name=args.gpxq_block_name)
             print("Qronos applied.")
 
-        if args.bias_corr:
+        if args.bias_corr and not args.load_checkpoint:
             print("Applying bias correction...")
             apply_bias_correction(model, calibration_loader)
             print("Bias correction applied.")


### PR DESCRIPTION
## Reason for this PR

Currently, we do not skip SpinQuant when loading from the checkpoint. This PR sets `max_steps=0` when `load_checkpoint=true`, which skips SpinQuant in `apply_rotation_optimization()`.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

Sets `max_steps=0` when `load_checkpoint=true`.

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
