### PR TITLE
Fix (gguf): resolving zero point permutation issue with LlamaModel

### DIFF
--- a/src/brevitas_examples/llm/gguf_export/convert.py
+++ b/src/brevitas_examples/llm/gguf_export/convert.py
@@ -416,7 +416,11 @@ class ModelBase:
 
         else:
             _, scale = self.modify_tensors(scale, name, bid)[0]
-            _, zp = self.modify_tensors(zp, name, bid)[0]
+            # If the zero point is a scalar, it is not a tensor that needs
+            # to be modified. Also, this check avoids issues with LlamaModel,
+            # where the permutation for q_proj and k_proj causes issues.
+            if zp.ndim > 0:
+                _, zp = self.modify_tensors(zp, name, bid)[0]
             data = ggml_quant(quant_data, data_qtype, scale, zp)
 
         return data, data_qtype


### PR DESCRIPTION
## Reason for this PR

Issue with exporting GGUF:Q4_0 with Llama3 due to assumptions in permutation logic in `LlamaModel.modify_tensors`

```shell
Export to gguf:q4_0
Traceback (most recent call last):
  File "/opt/conda/bin/brevitas_ptq_llm", line 33, in <module>
    sys.exit(load_entry_point('brevitas', 'console_scripts', 'brevitas_ptq_llm')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/brevitas2/src/brevitas_examples/llm/main.py", line 744, in main
    quantize_llm(args, extra_args)
  File "/home/brevitas2/src/brevitas_examples/llm/main.py", line 699, in quantize_llm
    model_export(model, tokenizer, calibration_loader[0], args, config)
  File "/home/brevitas2/src/brevitas_examples/llm/main.py", line 162, in model_export
    save_quantized_as_gguf('.', model, tokenizer, args.export_target)
  File "/home/brevitas2/src/brevitas_examples/llm/gguf_export/export.py", line 88, in save_quantized_as_gguf
    model_instance.write()
  File "/home/brevitas2/src/brevitas_examples/llm/gguf_export/convert.py", line 551, in write
    self.prepare_tensors()
  File "/home/brevitas2/src/brevitas_examples/llm/gguf_export/convert.py", line 2234, in prepare_tensors
    super().prepare_tensors()
  File "/home/brevitas2/src/brevitas_examples/llm/gguf_export/convert.py", line 498, in prepare_tensors
    data, data_qtype = self.quantize(name, data, data_qtype, old_dtype, bid)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/brevitas2/src/brevitas_examples/llm/gguf_export/convert.py", line 419, in quantize
    _, zp = self.modify_tensors(zp, name, bid)[0]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/brevitas2/src/brevitas_examples/llm/gguf_export/convert.py", line 2160, in modify_tensors
    data_torch = LlamaModel.permute(data_torch, n_head, n_head)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/brevitas2/src/brevitas_examples/llm/gguf_export/convert.py", line 2135, in permute
    weights.reshape(n_head, 2, weights.shape[0] // n_head // 2,
                               ~~~~~~~~~~~~~^^^
IndexError: tuple index out of range
```

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
