### PR TITLE
Feat (graph): Minor refactoring layerwise_layer_handler

### DIFF
--- a/src/brevitas/core/quant/float.py
+++ b/src/brevitas/core/quant/float.py
@@ -69,8 +69,7 @@ class FloatQuant(brevitas.jit.ScriptModule):
 
         # This is more friendly for compile
         # TODO: This assumes fixed mantissa bit-width
-        self.pre_compute_max_mantissa = StatelessBuffer(
-            compute_max_mantissa(self.mantissa_bit_width()))
+        self.pre_compute_max_mantissa = StatelessBuffer(compute_max_mantissa(mantissa_bit_width))
 
     @brevitas.jit.script_method
     def quantize(self, x: torch.Tensor, scale: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/src/brevitas/graph/base.py
+++ b/src/brevitas/graph/base.py
@@ -245,7 +245,7 @@ class ModuleToModule(GraphTransform, ABC):
 
         # load state dict of the old module
         if load_state_dict:
-            load_old_module_state_dict(old_module, new_module, assign=is_assign_supported)
+            load_old_module_state_dict(old_module, new_module, is_assign_supported)
         return new_module
 
 

--- a/src/brevitas/graph/base.py
+++ b/src/brevitas/graph/base.py
@@ -9,10 +9,11 @@ from typing import Any
 from typing import Dict
 from typing import Type
 
-from packaging.version import parse
 import torch
 from torch.nn import Module
 from torch.overrides import get_testing_overrides
+
+from brevitas.utils.torch_utils import pt_ge
 
 # TODO: Deprecate PyTorch 1.11
 try:
@@ -22,7 +23,6 @@ except ImportError:
     from brevitas.utils.torch_utils import is_parametrized
     register_parametrization = None
 
-from brevitas import torch_version
 from brevitas.fx import GraphModule
 from brevitas.fx import immutable_dict
 from brevitas.fx import Node
@@ -45,11 +45,6 @@ __all__ = [
     'CallableToModule']
 
 _TORCH_TESTING_DICT = get_testing_overrides()
-
-
-# TODO (pml): Remove after deprecating old PyTorch versions
-def pt_ge(pt_version: str) -> bool:
-    return torch_version >= parse(pt_version)
 
 
 class Transform(ABC):

--- a/src/brevitas/graph/base.py
+++ b/src/brevitas/graph/base.py
@@ -213,12 +213,7 @@ class ModuleToModule(GraphTransform, ABC):
         new_kwargs.update(update_dict)
         return new_kwargs
 
-    def init_new_module(
-            self,
-            old_module: Module,
-            name: str = None,
-            load_state_dict: bool = True,
-            assign: bool = True):
+    def init_new_module(self, old_module: Module, name: str = None, load_state_dict: bool = True):
         # get attributes of original module
         new_kwargs = self._module_attributes(old_module)
         # transforms attribute of original module, e.g. bias Parameter -> bool
@@ -234,13 +229,13 @@ class ModuleToModule(GraphTransform, ABC):
         # This check is needed as older PyTorch versions do not admit the `assign`
         # and `load_state_dict` would act as a no-op, thus leaving "meta" tensors
         # on new_module
-        if 'device' in new_kwargs and (pt_ge('2.1') and load_state_dict and assign):
+        if 'device' in new_module_signature_keys and pt_ge('2.1') and load_state_dict:
             new_kwargs['device'] = torch.device("meta")
         # init the new module
         new_module = self.new_module_class(**new_kwargs)
         # load state dict of the old module
         if load_state_dict:
-            load_old_module_state_dict(old_module, new_module, assign=assign)
+            load_old_module_state_dict(old_module, new_module, assign=True)
         return new_module
 
 

--- a/src/brevitas/graph/base.py
+++ b/src/brevitas/graph/base.py
@@ -235,7 +235,7 @@ class ModuleToModule(GraphTransform, ABC):
         # on new_module
 
         # Check if torch supports `assign` flag
-        is_assign_supported = 'assign' not in inspect.signature(
+        is_assign_supported = 'assign' in inspect.signature(
             old_module.load_state_dict).parameters.keys()
         if 'device' in new_module_signature_keys and is_assign_supported and load_state_dict:
             new_kwargs['device'] = torch.device("meta")

--- a/src/brevitas/graph/base.py
+++ b/src/brevitas/graph/base.py
@@ -230,10 +230,11 @@ class ModuleToModule(GraphTransform, ABC):
         new_kwargs = self._evaluate_new_kwargs(new_kwargs, old_module, name)
         # skip memory allocation if the module constructor admits 'device'
         # as keyword argument and the state_dict from the old module is loaded
-        # TODO (pml): Remove pt_ge('2.0') after deprecating older PyTorch versions
-        # This check is needed as older PyTorch versions raise errors when operating
-        # "meta" tensors with tensors in other device for certain operations.
-        if pt_ge('2.0') and load_state_dict and 'device' in new_kwargs:
+        # TODO (pml): Remove pt_ge('2.1') after deprecating older PyTorch versions
+        # This check is needed as older PyTorch versions do not admit the `assign`
+        # and `load_state_dict` would act as a no-op, thus leaving "meta" tensors
+        # on new_module
+        if 'device' in new_kwargs and (pt_ge('2.1') and load_state_dict and assign):
             new_kwargs['device'] = torch.device("meta")
         # init the new module
         new_module = self.new_module_class(**new_kwargs)

--- a/src/brevitas/graph/quantize.py
+++ b/src/brevitas/graph/quantize.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Dict
+from typing import Optional
+from typing import Tuple
+from typing import Type
 
 from packaging import version
 import torch
@@ -144,7 +147,7 @@ COMPUTE_LAYER_MAP = {
             'bias_quant': Int32Bias,
             'return_quant_tensor': True})}
 
-LAYERWISE_COMPUTE_LAYER_MAP = {
+LAYERWISE_COMPUTE_LAYER_MAP: Dict[Type[torch.nn.Module], Optional[Tuple[torch.nn.Module, Dict]]] = {
     nn.AvgPool2d:
         None,
     nn.MultiheadAttention: (

--- a/src/brevitas/graph/quantize.py
+++ b/src/brevitas/graph/quantize.py
@@ -148,92 +148,93 @@ COMPUTE_LAYER_MAP = {
             'bias_quant': Int32Bias,
             'return_quant_tensor': True})}
 
-LAYERWISE_COMPUTE_LAYER_MAP: Dict[Type[torch.nn.Module],
-                                  Optional[Tuple[Type[torch.nn.Module], Dict[str, Any]]]] = {
-                                      nn.AvgPool2d:
-                                          None,
-                                      nn.MultiheadAttention: (
-                                          qnn.QuantMultiheadAttention,
-                                          {
-                                              'in_proj_input_quant': Int8ActPerTensorFloat,
-                                              'in_proj_weight_quant': Int8WeightPerTensorFloat,
-                                              'in_proj_bias_quant': Int32Bias,
-                                              'attn_output_weights_quant': Uint8ActPerTensorFloat,
-                                              'q_scaled_quant': Int8ActPerTensorFloat,
-                                              'k_transposed_quant': Int8ActPerTensorFloat,
-                                              'v_quant': Int8ActPerTensorFloat,
-                                              'out_proj_input_quant': Int8ActPerTensorFloat,
-                                              'out_proj_weight_quant': Int8WeightPerTensorFloat,
-                                              'out_proj_bias_quant': Int32Bias,
-                                              'return_quant_tensor': False}),
-                                      nn.LSTM: (
-                                          qnn.QuantLSTM,
-                                          {
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'io_quant': Int8ActPerTensorFloat,
-                                              'gate_acc_quant': Int8ActPerTensorFloat,
-                                              'sigmoid_quant': Uint8ActPerTensorFloat,
-                                              'tanh_quant': Int8ActPerTensorFloat,
-                                              'cell_state_quant': Int8ActPerTensorFloat,
-                                              'return_quant_tensor': False}),
-                                      nn.RNN: (
-                                          qnn.QuantRNN,
-                                          {
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'io_quant': Int8ActPerTensorFloat,
-                                              'gate_acc_quant': Int8ActPerTensorFloat,
-                                              'return_quant_tensor': False}),
-                                      nn.Conv1d: (
-                                          qnn.QuantConv1d,
-                                          {
-                                              'input_quant': Int8ActPerTensorFloat,
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'return_quant_tensor': False}),
-                                      nn.Conv2d: (
-                                          qnn.QuantConv2d,
-                                          {
-                                              'input_quant': Int8ActPerTensorFloat,
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'return_quant_tensor': False}),
-                                      nn.Conv3d: (
-                                          qnn.QuantConv3d,
-                                          {
-                                              'input_quant': Int8ActPerTensorFloat,
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'return_quant_tensor': False}),
-                                      nn.ConvTranspose1d: (
-                                          qnn.QuantConvTranspose1d,
-                                          {
-                                              'input_quant': Int8ActPerTensorFloat,
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'return_quant_tensor': False}),
-                                      nn.ConvTranspose2d: (
-                                          qnn.QuantConvTranspose2d,
-                                          {
-                                              'input_quant': Int8ActPerTensorFloat,
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'return_quant_tensor': False}),
-                                      nn.ConvTranspose3d: (
-                                          qnn.QuantConvTranspose3d,
-                                          {
-                                              'input_quant': Int8ActPerTensorFloat,
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'return_quant_tensor': False}),
-                                      nn.Linear: (
-                                          qnn.QuantLinear,
-                                          {
-                                              'input_quant': Int8ActPerTensorFloat,
-                                              'weight_quant': Int8WeightPerTensorFloat,
-                                              'bias_quant': Int32Bias,
-                                              'return_quant_tensor': False})}
+LayerMapValueType = Optional[Tuple[Type[torch.nn.Module], Dict[str, Any]]]
+
+LAYERWISE_COMPUTE_LAYER_MAP: Dict[Type[torch.nn.Module], LayerMapValueType] = {
+    nn.AvgPool2d:
+        None,
+    nn.MultiheadAttention: (
+        qnn.QuantMultiheadAttention,
+        {
+            'in_proj_input_quant': Int8ActPerTensorFloat,
+            'in_proj_weight_quant': Int8WeightPerTensorFloat,
+            'in_proj_bias_quant': Int32Bias,
+            'attn_output_weights_quant': Uint8ActPerTensorFloat,
+            'q_scaled_quant': Int8ActPerTensorFloat,
+            'k_transposed_quant': Int8ActPerTensorFloat,
+            'v_quant': Int8ActPerTensorFloat,
+            'out_proj_input_quant': Int8ActPerTensorFloat,
+            'out_proj_weight_quant': Int8WeightPerTensorFloat,
+            'out_proj_bias_quant': Int32Bias,
+            'return_quant_tensor': False}),
+    nn.LSTM: (
+        qnn.QuantLSTM,
+        {
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'io_quant': Int8ActPerTensorFloat,
+            'gate_acc_quant': Int8ActPerTensorFloat,
+            'sigmoid_quant': Uint8ActPerTensorFloat,
+            'tanh_quant': Int8ActPerTensorFloat,
+            'cell_state_quant': Int8ActPerTensorFloat,
+            'return_quant_tensor': False}),
+    nn.RNN: (
+        qnn.QuantRNN,
+        {
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'io_quant': Int8ActPerTensorFloat,
+            'gate_acc_quant': Int8ActPerTensorFloat,
+            'return_quant_tensor': False}),
+    nn.Conv1d: (
+        qnn.QuantConv1d,
+        {
+            'input_quant': Int8ActPerTensorFloat,
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'return_quant_tensor': False}),
+    nn.Conv2d: (
+        qnn.QuantConv2d,
+        {
+            'input_quant': Int8ActPerTensorFloat,
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'return_quant_tensor': False}),
+    nn.Conv3d: (
+        qnn.QuantConv3d,
+        {
+            'input_quant': Int8ActPerTensorFloat,
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'return_quant_tensor': False}),
+    nn.ConvTranspose1d: (
+        qnn.QuantConvTranspose1d,
+        {
+            'input_quant': Int8ActPerTensorFloat,
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'return_quant_tensor': False}),
+    nn.ConvTranspose2d: (
+        qnn.QuantConvTranspose2d,
+        {
+            'input_quant': Int8ActPerTensorFloat,
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'return_quant_tensor': False}),
+    nn.ConvTranspose3d: (
+        qnn.QuantConvTranspose3d,
+        {
+            'input_quant': Int8ActPerTensorFloat,
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'return_quant_tensor': False}),
+    nn.Linear: (
+        qnn.QuantLinear,
+        {
+            'input_quant': Int8ActPerTensorFloat,
+            'weight_quant': Int8WeightPerTensorFloat,
+            'bias_quant': Int32Bias,
+            'return_quant_tensor': False})}
 
 UNSIGNED_ACT_TUPLE = (nn.ReLU, nn.ReLU6, nn.Sigmoid, nn.Hardsigmoid)
 

--- a/src/brevitas/graph/quantize.py
+++ b/src/brevitas/graph/quantize.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Tuple
@@ -147,91 +148,92 @@ COMPUTE_LAYER_MAP = {
             'bias_quant': Int32Bias,
             'return_quant_tensor': True})}
 
-LAYERWISE_COMPUTE_LAYER_MAP: Dict[Type[torch.nn.Module], Optional[Tuple[torch.nn.Module, Dict]]] = {
-    nn.AvgPool2d:
-        None,
-    nn.MultiheadAttention: (
-        qnn.QuantMultiheadAttention,
-        {
-            'in_proj_input_quant': Int8ActPerTensorFloat,
-            'in_proj_weight_quant': Int8WeightPerTensorFloat,
-            'in_proj_bias_quant': Int32Bias,
-            'attn_output_weights_quant': Uint8ActPerTensorFloat,
-            'q_scaled_quant': Int8ActPerTensorFloat,
-            'k_transposed_quant': Int8ActPerTensorFloat,
-            'v_quant': Int8ActPerTensorFloat,
-            'out_proj_input_quant': Int8ActPerTensorFloat,
-            'out_proj_weight_quant': Int8WeightPerTensorFloat,
-            'out_proj_bias_quant': Int32Bias,
-            'return_quant_tensor': False}),
-    nn.LSTM: (
-        qnn.QuantLSTM,
-        {
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'io_quant': Int8ActPerTensorFloat,
-            'gate_acc_quant': Int8ActPerTensorFloat,
-            'sigmoid_quant': Uint8ActPerTensorFloat,
-            'tanh_quant': Int8ActPerTensorFloat,
-            'cell_state_quant': Int8ActPerTensorFloat,
-            'return_quant_tensor': False}),
-    nn.RNN: (
-        qnn.QuantRNN,
-        {
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'io_quant': Int8ActPerTensorFloat,
-            'gate_acc_quant': Int8ActPerTensorFloat,
-            'return_quant_tensor': False}),
-    nn.Conv1d: (
-        qnn.QuantConv1d,
-        {
-            'input_quant': Int8ActPerTensorFloat,
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'return_quant_tensor': False}),
-    nn.Conv2d: (
-        qnn.QuantConv2d,
-        {
-            'input_quant': Int8ActPerTensorFloat,
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'return_quant_tensor': False}),
-    nn.Conv3d: (
-        qnn.QuantConv3d,
-        {
-            'input_quant': Int8ActPerTensorFloat,
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'return_quant_tensor': False}),
-    nn.ConvTranspose1d: (
-        qnn.QuantConvTranspose1d,
-        {
-            'input_quant': Int8ActPerTensorFloat,
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'return_quant_tensor': False}),
-    nn.ConvTranspose2d: (
-        qnn.QuantConvTranspose2d,
-        {
-            'input_quant': Int8ActPerTensorFloat,
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'return_quant_tensor': False}),
-    nn.ConvTranspose3d: (
-        qnn.QuantConvTranspose3d,
-        {
-            'input_quant': Int8ActPerTensorFloat,
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'return_quant_tensor': False}),
-    nn.Linear: (
-        qnn.QuantLinear,
-        {
-            'input_quant': Int8ActPerTensorFloat,
-            'weight_quant': Int8WeightPerTensorFloat,
-            'bias_quant': Int32Bias,
-            'return_quant_tensor': False})}
+LAYERWISE_COMPUTE_LAYER_MAP: Dict[Type[torch.nn.Module],
+                                  Optional[Tuple[Type[torch.nn.Module], Dict[str, Any]]]] = {
+                                      nn.AvgPool2d:
+                                          None,
+                                      nn.MultiheadAttention: (
+                                          qnn.QuantMultiheadAttention,
+                                          {
+                                              'in_proj_input_quant': Int8ActPerTensorFloat,
+                                              'in_proj_weight_quant': Int8WeightPerTensorFloat,
+                                              'in_proj_bias_quant': Int32Bias,
+                                              'attn_output_weights_quant': Uint8ActPerTensorFloat,
+                                              'q_scaled_quant': Int8ActPerTensorFloat,
+                                              'k_transposed_quant': Int8ActPerTensorFloat,
+                                              'v_quant': Int8ActPerTensorFloat,
+                                              'out_proj_input_quant': Int8ActPerTensorFloat,
+                                              'out_proj_weight_quant': Int8WeightPerTensorFloat,
+                                              'out_proj_bias_quant': Int32Bias,
+                                              'return_quant_tensor': False}),
+                                      nn.LSTM: (
+                                          qnn.QuantLSTM,
+                                          {
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'io_quant': Int8ActPerTensorFloat,
+                                              'gate_acc_quant': Int8ActPerTensorFloat,
+                                              'sigmoid_quant': Uint8ActPerTensorFloat,
+                                              'tanh_quant': Int8ActPerTensorFloat,
+                                              'cell_state_quant': Int8ActPerTensorFloat,
+                                              'return_quant_tensor': False}),
+                                      nn.RNN: (
+                                          qnn.QuantRNN,
+                                          {
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'io_quant': Int8ActPerTensorFloat,
+                                              'gate_acc_quant': Int8ActPerTensorFloat,
+                                              'return_quant_tensor': False}),
+                                      nn.Conv1d: (
+                                          qnn.QuantConv1d,
+                                          {
+                                              'input_quant': Int8ActPerTensorFloat,
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'return_quant_tensor': False}),
+                                      nn.Conv2d: (
+                                          qnn.QuantConv2d,
+                                          {
+                                              'input_quant': Int8ActPerTensorFloat,
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'return_quant_tensor': False}),
+                                      nn.Conv3d: (
+                                          qnn.QuantConv3d,
+                                          {
+                                              'input_quant': Int8ActPerTensorFloat,
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'return_quant_tensor': False}),
+                                      nn.ConvTranspose1d: (
+                                          qnn.QuantConvTranspose1d,
+                                          {
+                                              'input_quant': Int8ActPerTensorFloat,
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'return_quant_tensor': False}),
+                                      nn.ConvTranspose2d: (
+                                          qnn.QuantConvTranspose2d,
+                                          {
+                                              'input_quant': Int8ActPerTensorFloat,
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'return_quant_tensor': False}),
+                                      nn.ConvTranspose3d: (
+                                          qnn.QuantConvTranspose3d,
+                                          {
+                                              'input_quant': Int8ActPerTensorFloat,
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'return_quant_tensor': False}),
+                                      nn.Linear: (
+                                          qnn.QuantLinear,
+                                          {
+                                              'input_quant': Int8ActPerTensorFloat,
+                                              'weight_quant': Int8WeightPerTensorFloat,
+                                              'bias_quant': Int32Bias,
+                                              'return_quant_tensor': False})}
 
 UNSIGNED_ACT_TUPLE = (nn.ReLU, nn.ReLU6, nn.Sigmoid, nn.Hardsigmoid)
 

--- a/src/brevitas/graph/quantize_impl.py
+++ b/src/brevitas/graph/quantize_impl.py
@@ -522,12 +522,12 @@ def _layerwise_replace_modules(
     meet a top-level module that is supported. Specifically, it allows to map nn.MultiheadAttetion to its
     quantized counterpart and not its Linear submodules.
     """
-    if _module_class_name(type_before_parametrizations(module)) in layer_map.keys():
-        if layer_map[_module_class_name(type_before_parametrizations(module))] is not None:
-            quant_module_class, quant_module_kwargs = layer_map[_module_class_name(type_before_parametrizations(module))]
-            rewriter = ModuleToModuleByInstance(module, quant_module_class, **quant_module_kwargs)
-            quant_module = rewriter.init_new_module(old_module=module, name=prefix)
-            set_module(model, quant_module, prefix)
+    quant_map = layer_map.get(_module_class_name(type_before_parametrizations(module)), None)
+    if quant_map:
+        quant_module_class, quant_module_kwargs = quant_map
+        rewriter = ModuleToModuleByInstance(module, quant_module_class, **quant_module_kwargs)
+        quant_module = rewriter.init_new_module(old_module=module, name=prefix)
+        set_module(model, quant_module, prefix)
     else:
         for name, child in module.named_children():
             full_name = prefix + '.' + name if prefix != '' else name

--- a/src/brevitas/graph/quantize_impl.py
+++ b/src/brevitas/graph/quantize_impl.py
@@ -525,9 +525,7 @@ def _layerwise_replace_modules(
     if _module_class_name(type_before_parametrizations(module)) in layer_map.keys():
         quant_module_class, quant_module_kwargs = layer_map[_module_class_name(type_before_parametrizations(module))]
         rewriter = ModuleToModuleByInstance(module, quant_module_class, **quant_module_kwargs)
-        # TODO (pml): Make _init_new_module public?
-        quant_module = rewriter._init_new_module(
-            old_module=module, name=prefix, load_state_dict=True, low_mem=True)
+        quant_module = rewriter.init_new_module(old_module=module, name=prefix)
         set_module(model, quant_module, prefix)
     else:
         for name, child in module.named_children():

--- a/src/brevitas/graph/quantize_impl.py
+++ b/src/brevitas/graph/quantize_impl.py
@@ -523,10 +523,11 @@ def _layerwise_replace_modules(
     quantized counterpart and not its Linear submodules.
     """
     if _module_class_name(type_before_parametrizations(module)) in layer_map.keys():
-        quant_module_class, quant_module_kwargs = layer_map[_module_class_name(type_before_parametrizations(module))]
-        rewriter = ModuleToModuleByInstance(module, quant_module_class, **quant_module_kwargs)
-        quant_module = rewriter.init_new_module(old_module=module, name=prefix)
-        set_module(model, quant_module, prefix)
+        if layer_map[_module_class_name(type_before_parametrizations(module))] is not None:
+            quant_module_class, quant_module_kwargs = layer_map[_module_class_name(type_before_parametrizations(module))]
+            rewriter = ModuleToModuleByInstance(module, quant_module_class, **quant_module_kwargs)
+            quant_module = rewriter.init_new_module(old_module=module, name=prefix)
+            set_module(model, quant_module, prefix)
     else:
         for name, child in module.named_children():
             full_name = prefix + '.' + name if prefix != '' else name

--- a/src/brevitas/graph/quantize_impl.py
+++ b/src/brevitas/graph/quantize_impl.py
@@ -18,8 +18,9 @@ except ImportError:
 from brevitas.graph.base import InsertModuleCallAfter
 from brevitas.graph.base import ModuleInstanceToModuleInstance
 from brevitas.graph.base import ModuleToModuleByInstance
-from brevitas.graph.utils import del_module, set_module
+from brevitas.graph.utils import del_module
 from brevitas.graph.utils import get_module
+from brevitas.graph.utils import set_module
 from brevitas.utils.logging import setup_logger
 
 logging = setup_logger(__name__)
@@ -526,7 +527,8 @@ def find_module(
         quant_module_class, quant_module_kwargs = layer_map[_module_class_name(type_before_parametrizations(module))]
         rewriter = ModuleToModuleByInstance(module, quant_module_class, **quant_module_kwargs)
         # TODO (pml): Make _init_new_module public?
-        quant_module = rewriter._init_new_module(old_module=module, name=prefix, load_state_dict=True)
+        quant_module = rewriter._init_new_module(
+            old_module=module, name=prefix, load_state_dict=True, low_mem=True)
         set_module(model, quant_module, prefix)
     else:
         for name, child in module.named_children():

--- a/src/brevitas/graph/utils.py
+++ b/src/brevitas/graph/utils.py
@@ -99,13 +99,13 @@ def get_module_name_and_parent(model, fully_qualified_module_name):
     prefix_list = prefix_list[:-1]  # exclude module name
     for prefix in prefix_list:
         if prefix:  # exclude empty prefix
-            supermodule = supermodule._modules[prefix]
+            supermodule = getattr(supermodule, prefix)
     return module_name, supermodule
 
 
 def set_module(model, module, fully_qualified_module_name):
     module_name, supermodule = get_module_name_and_parent(model, fully_qualified_module_name)
-    supermodule._modules[module_name] = module
+    setattr(supermodule, module_name, module)
 
 
 def get_module(model, fully_qualified_module_name):

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -2,17 +2,18 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy
-from dataclasses import dataclass
 from functools import wraps
 from typing import List
 from typing import Optional
 from typing import Tuple
 
+from packaging.version import parse
 import torch
 import torch.distributed as dist
 from torch.nn import Sequential
 
 import brevitas
+from brevitas import torch_version
 import brevitas.compiler as brevitas_compiler
 from brevitas.function.ops_ste import floor_ste
 
@@ -208,3 +209,8 @@ def init_process_group(backend: str = "nccl") -> None:
     if dist.is_torchelastic_launched():
         # If that is the case, initialize the default process group
         dist.init_process_group(backend=backend)
+
+
+# TODO (pml): Potentially remove after deprecating old PyTorch versions
+def pt_ge(pt_version: str) -> bool:
+    return torch_version >= parse(pt_version)

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -3,17 +3,14 @@
 
 import copy
 from functools import wraps
-from typing import List
 from typing import Optional
 from typing import Tuple
 
-from packaging.version import parse
 import torch
 import torch.distributed as dist
 from torch.nn import Sequential
 
 import brevitas
-from brevitas import torch_version
 import brevitas.compiler as brevitas_compiler
 from brevitas.function.ops_ste import floor_ste
 

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -209,8 +209,3 @@ def init_process_group(backend: str = "nccl") -> None:
     if dist.is_torchelastic_launched():
         # If that is the case, initialize the default process group
         dist.init_process_group(backend=backend)
-
-
-# TODO (pml): Potentially remove after deprecating old PyTorch versions
-def pt_ge(pt_version: str) -> bool:
-    return torch_version >= parse(pt_version)

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -432,24 +432,8 @@ def quantize_llm(args, extra_args=None):
             else:
                 name_blacklist += ["lm_head", "embed_out"]
 
-        # TODO (pml): Remove
-        import cProfile
-        import io
-        import pstats
-
-        profiler = cProfile.Profile()
-        profiler.enable()
-
         model = layerwise_quantize(
             model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
-
-        # TODO (pml): Remove
-        profiler.disable()
-        s = io.StringIO()
-        sortby = pstats.SortKey.CUMULATIVE  # Sort by cumulative time
-        ps = pstats.Stats(profiler, stream=s).sort_stats(sortby)
-        ps.print_stats()
-        print(s.getvalue())
 
         # Just to be sure
         model.eval()

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -432,17 +432,17 @@ def quantize_llm(args, extra_args=None):
             else:
                 name_blacklist += ["lm_head", "embed_out"]
 
-        # TODO (pml): Remove       
+        # TODO (pml): Remove
         import cProfile
-        import pstats
         import io
+        import pstats
 
         profiler = cProfile.Profile()
         profiler.enable()
 
         model = layerwise_quantize(
             model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
-        
+
         # TODO (pml): Remove
         profiler.disable()
         s = io.StringIO()

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -431,8 +431,26 @@ def quantize_llm(args, extra_args=None):
                 last_layer_kwargs['input_quant'] = input_quant
             else:
                 name_blacklist += ["lm_head", "embed_out"]
+
+        # TODO (pml): Remove       
+        import cProfile
+        import pstats
+        import io
+
+        profiler = cProfile.Profile()
+        profiler.enable()
+
         model = layerwise_quantize(
             model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
+        
+        # TODO (pml): Remove
+        profiler.disable()
+        s = io.StringIO()
+        sortby = pstats.SortKey.CUMULATIVE  # Sort by cumulative time
+        ps = pstats.Stats(profiler, stream=s).sort_stats(sortby)
+        ps.print_stats()
+        print(s.getvalue())
+
         # Just to be sure
         model.eval()
         model = model.to(dtype)

--- a/src/brevitas_examples/stable_diffusion/main.py
+++ b/src/brevitas_examples/stable_diffusion/main.py
@@ -917,7 +917,7 @@ def quantize_sd(args: Namespace, extra_args: Optional[List[str]] = None):
 
             float_images_values = load_images_from_folder(os.path.join(output_dir, 'float'))
             quant_images_values = load_images_from_folder(os.path.join(output_dir, 'quant'))
-            fid = FrechetInceptionDistance(normalize=False).to(args.device)
+            fid = FrechetInceptionDistance(normalize=False, antialias=False).to(args.device)
             for float_image in tqdm(float_images_values):
                 fid.update(float_image.unsqueeze(0).to(args.device), real=True)
             for quant_image in tqdm(quant_images_values):

--- a/tests/brevitas/graph/test_quantize.py
+++ b/tests/brevitas/graph/test_quantize.py
@@ -6,6 +6,8 @@ import inspect
 from itertools import chain
 import platform
 import random
+from typing import get_origin
+from typing import Union
 
 import pytest
 import pytest_cases
@@ -83,12 +85,13 @@ class QuantLayerCases:
             # Retrieve the required parameters of the __init__ method
             layer_kwargs = {}
             for name, parameter in inspect.signature(torch_layer_cls.__init__).parameters.items():
+                breakpoint()
                 # Check if the parameter is required
                 if name != 'self' and parameter.default is inspect.Parameter.empty and parameter.kind in (
                         inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):
                     # If so, check the type
                     if parameter.annotation == int or (
-                            parameter.annotation.__name__ == 'Union' and
+                            get_origin(parameter.annotation) == Union and
                             any([arg == int for arg in parameter.annotation.__args__])):
                         layer_kwargs[name] = random.randint(a=MIN_INT, b=MAX_INT)
                     else:

--- a/tests/brevitas/graph/test_quantize.py
+++ b/tests/brevitas/graph/test_quantize.py
@@ -85,7 +85,6 @@ class QuantLayerCases:
             # Retrieve the required parameters of the __init__ method
             layer_kwargs = {}
             for name, parameter in inspect.signature(torch_layer_cls.__init__).parameters.items():
-                breakpoint()
                 # Check if the parameter is required
                 if name != 'self' and parameter.default is inspect.Parameter.empty and parameter.kind in (
                         inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):

--- a/tests/brevitas/graph/test_quantize.py
+++ b/tests/brevitas/graph/test_quantize.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import copy
 import inspect
 from itertools import chain

--- a/tests/brevitas/graph/test_quantize.py
+++ b/tests/brevitas/graph/test_quantize.py
@@ -76,6 +76,9 @@ class QuantLayerCases:
 
         if quant_layer_cls_kwargs is None:
             pytest.skip(f'There is no quant layer defined for {torch_layer_cls.__name__}')
+        # TODO (pml): Investigate this issue
+        elif torch_layer_cls in (torch.nn.LSTM, torch.nn.RNN):
+            pytest.skip(f'state_dict is not correctly loaded for {torch_layer_cls.__name__}')
 
         if torch_layer_cls in (torch.nn.LSTM, torch.nn.RNN):
             layer_kwargs = {'input_size': RNN_INPUT_SIZE, 'hidden_size': RNN_HIDDEN_SIZE}
@@ -134,10 +137,6 @@ def test_layerwise_quantize_quant_model(
     assert all([
         param.device != torch.device("meta")
         for param in chain(qmodel.parameters(), qmodel.buffers())])
-    # Verify that the common parameters of the torch and quant modules share the same storage position
-    assert all([
-        param.storage().data_ptr() == recurse_getattr(qmodel, name).storage().data_ptr() for name,
-        param in chain(qmodel.named_parameters(), qmodel.named_buffers())])
 
 
 @pytest_cases.parametrize(

--- a/tests/brevitas/graph/test_utils.py
+++ b/tests/brevitas/graph/test_utils.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+from torch import nn
+
+from brevitas.graph.utils import get_module_name_and_parent
+from brevitas.graph.utils import set_module
+from tests.conftest import SEED
+
+IN_FEATURES = 2
+OUT_FEATURES = 2
+
+torch.manual_seed(SEED)
+
+
+class SubModel(nn.Module):
+
+    def __init__(self):
+        super(SubModel, self).__init__()
+        self.linear = nn.Linear(IN_FEATURES, OUT_FEATURES)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class Model(nn.Module):
+
+    def __init__(self):
+        super(Model, self).__init__()
+        self.sub_model = SubModel()
+
+    def forward(self, x):
+        return self.sub_model(x)
+
+
+def test_get_module_name_and_parent():
+    model = Model()
+    module_name, supermodule = get_module_name_and_parent(model, "sub_model.linear")
+    assert module_name == "linear"
+    assert supermodule is model.sub_model
+
+
+def test_set_module():
+    model = Model()
+    new_module = nn.Linear(IN_FEATURES, OUT_FEATURES)
+    set_module(model, new_module, "sub_model.linear")
+    assert model.sub_model.linear is new_module

--- a/tests/brevitas_examples/test_quantize_model.py
+++ b/tests/brevitas_examples/test_quantize_model.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 from copy import deepcopy
 
 import pytest


### PR DESCRIPTION
`layerwise_layer_handler` involved numerous loops through the model's modules,  as demonstrated by the number of calls to `named_modules` shown in this profile:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  600/354    0.138    0.000   75.835    0.214 /lib/python3.12/queue.py:154(get)
      608    0.392    0.001   53.289    0.088 /lib/python3.12/threading.py:323(wait)
    73/72    0.614    0.008   31.345    0.435 /brevitas/src/brevitas/graph/base.py:397(apply)
      253    0.114    0.000   29.812    0.118 /lib/python3.12/threading.py:637(wait)
2867904/246720   28.980    0.000   29.267    0.000 brevitas_env/lib/python3.12/site-packages/torch/nn/modules/module.py:2395(named_modules)
       72    0.006    0.000   15.472    0.215/brevitas/src/brevitas/graph/base.py:193(_replace_old_module)
       72    0.002    0.000   11.329    0.157 /brevitas/src/brevitas/graph/utils.py:133(replace_module)
       72    0.543    0.008    9.150    0.127 /brevitas/src/brevitas/graph/utils.py:126(name_from_module)
```

This PR simplifies the code structure to prevent unnecessary looping. After these changes, most of the time is spent in the initialization of the quantized module, which seems arguably more sensible. See the following profile:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      2/1    0.000    0.000    5.854    5.854/brevitas/src/brevitas/graph/quantize.py:391(layerwise_quantize)
      2/1    0.000    0.000    5.682    5.682 /brevitas/src/brevitas/graph/quantize_impl.py:539(layerwise_layer_handler)
    141/1    0.038    0.000    5.682    5.682 brevitas/src/brevitas/graph/quantize_impl.py:512(find_module)
       72    0.005    0.000    5.498    0.076 /brevitas/src/brevitas/graph/base.py:203(_init_new_module)
      288    0.007    0.000    3.504    0.012 /brevitas/src/brevitas/proxy/parameter_quant.py:68(init_tensor_quant)
       72    0.002    0.000    3.475    0.048 /brevitas/src/brevitas/nn/quant_linear.py:28(__init__)
      288    0.008    0.000    3.319    0.012 /brevitas/src/brevitas/proxy/quant_proxy.py:97(init_tensor_quant)
```

Also, the parameters of the quantized modules are created in the "meta" device and then reassigned when loading the state_dict to those of the original module, thus preventing any extra memory consumption.

PR Todo List:
 - [ ] Address TODOs.
 - [ ] Add tests.
 - [ ]  Verify that memory from old modules can be freed as soon as each rewriter is applied.