### PR TITLE
Fix (eq/rotation): find value if passed as kwarg

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1835,7 +1835,7 @@ class GraphRotationEqualization(RotationEqualization):
             if sdpa_node.kwargs.get('value', False):
                 value_input = sdpa_node.kwargs['value']  # value passed as kwarg
             else:
-                value_input = sdpa_node.args[-1]  # value passed as last arg
+                value_input = sdpa_node.args[2]  # value passed as 3rd arg
 
             value_node = find_src(value_input)
             output_node = find_sink(value_input)

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1832,7 +1832,10 @@ class GraphRotationEqualization(RotationEqualization):
                 return output_node
 
         for sdpa_node in sdpa_nodes:
-            value_input = sdpa_node.args[-1]
+            if sdpa_node.kwargs.get('value', False):
+                value_input = sdpa_node.kwargs['value']  # value passed as kwarg
+            else:
+                value_input = sdpa_node.args[-1]  # value passed as last arg
 
             value_node = find_src(value_input)
             output_node = find_sink(value_input)


### PR DESCRIPTION
During rotation equalization, `value` is checked as the last passed `arg`, but if is not found if `value` is passed as a `kwarg`. Minor correction which fixes that.