### PR TITLE
Fix (core/scaling): handle edge cases with signed scale

### DIFF
--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from abc import ABCMeta
 import math
 from typing import Optional
 from typing import Tuple
@@ -22,6 +23,20 @@ from brevitas.utils.torch_utils import kthvalue
 from .stats_wrapper import SCALAR_SHAPE
 
 DEFAULT_STD_DEV_EPSILON = 1e-8
+
+
+class UnsignedScaleStat(ABCMeta):
+
+    @classmethod
+    def is_scale_unsigned(cls):
+        True
+
+
+class SignedScaleStats(ABCMeta):
+
+    @classmethod
+    def is_scale_unsigned(cls):
+        False
 
 
 class NegativeMinOrZero(brevitas.jit.ScriptModule):
@@ -48,7 +63,7 @@ class NegativeMinOrZero(brevitas.jit.ScriptModule):
         return min_val
 
 
-class AbsPercentile(brevitas.jit.ScriptModule):
+class AbsPercentile(brevitas.jit.ScriptModule, UnsignedScaleStat):
     __constants__ = ['q', 'stats_reduce_dim', 'keepdim']
 
     def __init__(
@@ -116,7 +131,7 @@ class NegativePercentileOrZero(brevitas.jit.ScriptModule):
         return result
 
 
-class PercentileInterval(brevitas.jit.ScriptModule):
+class PercentileInterval(brevitas.jit.ScriptModule, UnsignedScaleStat):
     __constants__ = ['stats_reduce_dim', 'low_q', 'high_q', 'keepdim']
 
     def __init__(
@@ -159,7 +174,7 @@ class PercentileInterval(brevitas.jit.ScriptModule):
         return abs_interval
 
 
-class AbsMax(brevitas.jit.ScriptModule):
+class AbsMax(brevitas.jit.ScriptModule, UnsignedScaleStat):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: Optional[int] = None, keepdim: bool = False) -> None:
@@ -175,7 +190,7 @@ class AbsMax(brevitas.jit.ScriptModule):
             return torch.max(torch.abs(x), dim=self.stats_reduce_dim, keepdim=self.keepdim)[0]
 
 
-class AbsMinMax(brevitas.jit.ScriptModule):
+class AbsMinMax(brevitas.jit.ScriptModule, UnsignedScaleStat):
     __constants__ = ['stats_reduce_dim', 'keepdim']
 
     def __init__(
@@ -202,7 +217,7 @@ class AbsMinMax(brevitas.jit.ScriptModule):
         return torch.abs(max_val - min_val)
 
 
-class AbsMaxAve(brevitas.jit.ScriptModule):
+class AbsMaxAve(brevitas.jit.ScriptModule, UnsignedScaleStat):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: int) -> None:
@@ -214,7 +229,7 @@ class AbsMaxAve(brevitas.jit.ScriptModule):
         return torch.mean(torch.max(torch.abs(x), dim=self.stats_reduce_dim)[0])
 
 
-class AbsMaxL2(brevitas.jit.ScriptModule):
+class AbsMaxL2(brevitas.jit.ScriptModule, UnsignedScaleStat):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: int) -> None:
@@ -229,7 +244,7 @@ class AbsMaxL2(brevitas.jit.ScriptModule):
         return out
 
 
-class AbsAve(brevitas.jit.ScriptModule):
+class AbsAve(brevitas.jit.ScriptModule, UnsignedScaleStat):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: Optional[int] = None) -> None:
@@ -244,7 +259,7 @@ class AbsAve(brevitas.jit.ScriptModule):
             return torch.mean(torch.abs(x), dim=self.stats_reduce_dim)
 
 
-class MeanSigmaStd(brevitas.jit.ScriptModule):
+class MeanSigmaStd(brevitas.jit.ScriptModule, UnsignedScaleStat):
 
     def __init__(
             self,
@@ -289,7 +304,7 @@ class _MeanSigmaStdImpl(brevitas.jit.ScriptModule):
         return mean_val + sigma * std_val
 
 
-class MeanLearnedSigmaStd(brevitas.jit.ScriptModule):
+class MeanLearnedSigmaStd(brevitas.jit.ScriptModule, UnsignedScaleStat):
 
     def __init__(
             self,


### PR DESCRIPTION
## Reason for this PR

We currently do not handle signed scale in the following scenarios:
- Log restriction (either po2 or log)
- Learned scale, when the scale can start positive and then become negative. In this case, the user might want to force the scale to stay positive for the entire QAT process


## Changes Made in this PR

At dep inj time, we verify if the scale must be signed or unsigned.
It must be unsigned if:
- The user uses Log restriction
- The user forces through a specific dep-inj flag
- The user picks an unsigned stats op (all current available stats)

It can be signed if:
- The user does not use any log restriction for the scale
- The user picks a signed stats op  (not yet implemented)



## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
