### PR TITLE
Fix (ex/llm/benchmark): import error

### DIFF
--- a/src/brevitas_examples/llm/benchmark/llm_benchmark.py
+++ b/src/brevitas_examples/llm/benchmark/llm_benchmark.py
@@ -13,7 +13,7 @@ from typing import Tuple
 
 from brevitas_examples.common.benchmark.utils import benchmark
 from brevitas_examples.common.benchmark.utils import BenchmarkUtils
-from brevitas_examples.llm.llm_args import create_llm_args_parser
+from brevitas_examples.llm.llm_args import create_args_parser as create_llm_args_parser
 from brevitas_examples.llm.llm_args import validate as validate_llm_args
 
 


### PR DESCRIPTION
Benchmark currently broken. Typo must've slipped in with #1339.