### PR TITLE
Fix(core/stochastic_round): adjust stochastic round device

### DIFF
--- a/src/brevitas/core/function_wrapper/stochastic_round.py
+++ b/src/brevitas/core/function_wrapper/stochastic_round.py
@@ -41,6 +41,8 @@ class StochasticRoundSte(torch.nn.Module):
 
     @torch.jit.ignore
     def forward(self, x):
+        if x.device != self.generator.device:
+            self.device = torch.Generator(device=x.device)
         if self.deterministic_inference and not self.training:
             return self.inference_fn(x)
         return self.round_fn(x)

--- a/src/brevitas/core/function_wrapper/stochastic_round.py
+++ b/src/brevitas/core/function_wrapper/stochastic_round.py
@@ -30,7 +30,8 @@ class StochasticRoundSte(torch.nn.Module):
     def __init__(self, deterministic_inference=True, seed=None, device=None) -> None:
         super().__init__()
         self.generator = torch.Generator(device=device)
-        if seed is not None:
+        self.seed = seed
+        if self.seed is not None:
             self.generator.manual_seed(seed)
         self.round_fn = stochastic_round_ste_fn(self.generator)
         self.deterministic_inference = deterministic_inference
@@ -42,7 +43,10 @@ class StochasticRoundSte(torch.nn.Module):
     @torch.jit.ignore
     def forward(self, x):
         if x.device != self.generator.device:
-            self.device = torch.Generator(device=x.device)
+            self.generator = torch.Generator(device=x.device)
+            if self.seed is not None:
+                self.generator.manual_seed(self.seed)
+            self.round_fn = stochastic_round_ste_fn(self.generator)
         if self.deterministic_inference and not self.training:
             return self.inference_fn(x)
         return self.round_fn(x)


### PR DESCRIPTION
## Reason for this PR

Fix for #1294 

## Changes Made in this PR

There is no way to update the device of a generator once it was created, so the only solution is to check and re-create generator and Autograd Function at runtime.

This is not a jit module so we can be a bit more free with how we handle these things, but I'm not 100% happy with this solution.

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
