### PR TITLE
Setup: temporarily pin diffusers version

### DIFF
--- a/requirements/requirements-diffusion.txt
+++ b/requirements/requirements-diffusion.txt
@@ -1,5 +1,5 @@
 accelerate<1.10
-diffusers
+diffusers<=0.34
 pandas
 torchmetrics[image]
 tqdm


### PR DESCRIPTION
## Reason for this PR

New diffusers version requires torch 2.4+ because of `custom_op` in `torch.library`

## Changes Made in this PR

Currently pinning to diffusers <= 0.34

Maybe in the future we want to remove the pin and adjust the tests to run only on torch 2.4+


## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
