### PR TITLE
Feat (proxy): runtime flag for QuantTensor creation

### DIFF
--- a/src/brevitas/export/inference/handler.py
+++ b/src/brevitas/export/inference/handler.py
@@ -140,9 +140,8 @@ class GroupwiseIntInferenceHandler(IntInferencetHandler):
         inp_shape = x.shape
         x, scale, zero_point, *other = self.module_forward(x)
 
-        # If we skip quant tensor, we return the flattened version of the groupwise tensor
-        if self.skip_create_quant_tensor:
-            x = groupwise_dequant_expand(x, scale, zero_point, self.group_dim, inp_shape)[0]
+        # When we skip quant tensor, we return the flattened version of the groupwise tensor
+        x = groupwise_dequant_expand(x, scale, zero_point, self.group_dim, inp_shape)[0]
         output_args = tuple([x, scale, zero_point] + list(other))
         return output_args
 

--- a/src/brevitas/nn/mixin/parameter.py
+++ b/src/brevitas/nn/mixin/parameter.py
@@ -74,10 +74,10 @@ class QuantWeightMixin(QuantProxyMixin):
             out = self.weight_quant(
                 weights_to_quantize[weight_slice_tuple],
                 quant_input,
-                create_quant_tensor=return_quant_tensor)
+                return_quant_tensor=return_quant_tensor)
         else:
             out = self.weight_quant(
-                weights_to_quantize[weight_slice_tuple], create_quant_tensor=return_quant_tensor)
+                weights_to_quantize[weight_slice_tuple], return_quant_tensor=return_quant_tensor)
         if subtensor_slice_list is not None:
             # Restore the quantizer behaviour to full tensor quantization
             # The modules to slice should have been cached already at this point

--- a/src/brevitas/nn/mixin/parameter.py
+++ b/src/brevitas/nn/mixin/parameter.py
@@ -45,7 +45,8 @@ class QuantWeightMixin(QuantProxyMixin):
     def quant_weight(
             self,
             quant_input: Optional[QuantTensor] = None,
-            subtensor_slice_list: List[Optional[Tuple[int, int]]] = None):
+            subtensor_slice_list: List[Optional[Tuple[int, int]]] = None,
+            return_quant_tensor: bool = True):
         weights_to_quantize = self.weight
         if not self.weight_quant.is_quant_enabled and hasattr(self, 'weight_orig'):
             weights_to_quantize = self.weight_orig.to(self.weight.device)
@@ -70,9 +71,13 @@ class QuantWeightMixin(QuantProxyMixin):
         else:
             weight_slice_tuple = slice(None)
         if self.weight_quant.requires_quant_input:
-            out = self.weight_quant(weights_to_quantize[weight_slice_tuple], quant_input)
+            out = self.weight_quant(
+                weights_to_quantize[weight_slice_tuple],
+                quant_input,
+                create_quant_tensor=return_quant_tensor)
         else:
-            out = self.weight_quant(weights_to_quantize[weight_slice_tuple])
+            out = self.weight_quant(
+                weights_to_quantize[weight_slice_tuple], create_quant_tensor=return_quant_tensor)
         if subtensor_slice_list is not None:
             # Restore the quantizer behaviour to full tensor quantization
             # The modules to slice should have been cached already at this point

--- a/src/brevitas/nn/quant_accumulator.py
+++ b/src/brevitas/nn/quant_accumulator.py
@@ -37,7 +37,7 @@ class TruncQuantAccumulator(TruncMixin, QuantLayerMixin, Module):
 
     def forward(self, input: QuantTensor):
         x = self.unpack_input(input)
-        x = self.trunc_quant(x)
+        x = self.trunc_quant(x, return_quant_tensor=self.return_quant_tensor)
         return self.pack_output(x)
 
 
@@ -61,5 +61,5 @@ class ClampQuantAccumulator(QuantClampMixin, QuantLayerMixin, Module):
 
     def forward(self, input: QuantTensor):
         x = self.unpack_input(input)
-        x = self.clamp_quant(x)
+        x = self.clamp_quant(x, return_quant_tensor=self.return_quant_tensor)
         return self.pack_output(x)

--- a/src/brevitas/nn/quant_avg_pool.py
+++ b/src/brevitas/nn/quant_avg_pool.py
@@ -83,7 +83,7 @@ class TruncAvgPool2d(TruncMixin, QuantLayerMixin, AvgPool2d):
             if not isinstance(x, QuantTensor):
                 x = self.cache_class.quant_tensor.set(value=x)
             y = AvgPool2d.forward(self, x)
-            y = self.trunc_quant(y)
+            y = self.trunc_quant(y, return_quant_tensor=self.return_quant_tensor)
         else:
             y = AvgPool2d.forward(self, _unpack_quant_tensor(x))
 
@@ -149,7 +149,7 @@ class TruncAdaptiveAvgPool2d(TruncMixin, QuantLayerMixin, AdaptiveAvgPool2d):
             if not isinstance(x, QuantTensor):
                 x = self.cache_class.quant_tensor.set(value=x)
             y = AdaptiveAvgPool2d.forward(self, x)
-            y = self.trunc_quant(y)
+            y = self.trunc_quant(y, return_quant_tensor=self.return_quant_tensor)
         else:
             y = AdaptiveAvgPool2d.forward(self, _unpack_quant_tensor(x))
 

--- a/src/brevitas/nn/quant_embedding.py
+++ b/src/brevitas/nn/quant_embedding.py
@@ -60,7 +60,7 @@ class QuantEmbedding(QuantWeightMixin, Embedding):
         return self.num_embeddings
 
     def forward(self, inp):
-        quant_weight = self.quant_weight()
+        quant_weight = self.quant_weight(return_quant_tensor=self.return_quant_tensor)
         out = embedding(
             inp,
             quant_weight,

--- a/src/brevitas/nn/quant_layer.py
+++ b/src/brevitas/nn/quant_layer.py
@@ -45,12 +45,12 @@ class QuantNonLinearActLayer(QuantNonLinearActMixin, QuantInputMixin, QuantLayer
 
     def forward(self, input: Union[Tensor, QuantTensor]):
         input = self.unpack_input(input)
-        quant_input = self.input_quant(input)
+        quant_input = self.input_quant(input, return_quant_tensor=self.return_quant_tensor)
         # shortcut execution through the export impl during export
         if self.export_mode:
             out = self.export_handler(quant_input)
             return out
-        out = self.act_quant(quant_input)
+        out = self.act_quant(quant_input, return_quant_tensor=self.return_quant_tensor)
         out = self.pack_output(out)
         return out
 
@@ -142,8 +142,8 @@ class QuantWeightBiasInputOutputLayer(QuantBiasMixin, QuantWeightMixin, QuantInp
             out = self.export_handler(inp)
             return out
 
-        quant_input = self.input_quant(inp)
-        quant_weight = self.quant_weight(quant_input)
+        quant_input = self.input_quant(inp, return_quant_tensor=self.return_quant_tensor)
+        quant_weight = self.quant_weight(quant_input, return_quant_tensor=self.return_quant_tensor)
 
         compute_output_quant_tensor = isinstance(quant_input, QuantTensor) and isinstance(
             quant_weight, QuantTensor)
@@ -152,12 +152,14 @@ class QuantWeightBiasInputOutputLayer(QuantBiasMixin, QuantWeightMixin, QuantInp
             raise RuntimeError("QuantLayer is not correctly configured")
 
         if self.bias is not None:
-            quant_bias = self.bias_quant(self.bias, quant_input, quant_weight)
+            quant_bias = self.bias_quant(
+                self.bias, quant_input, quant_weight, return_quant_tensor=self.return_quant_tensor)
         else:
             quant_bias = None
         output_tensor = self.inner_forward_impl(quant_input, quant_weight, quant_bias)
 
-        quant_output = self.output_quant(output_tensor)
+        quant_output = self.output_quant(
+            output_tensor, return_quant_tensor=self.return_quant_tensor)
         return self.pack_output(quant_output)
 
     def _load_from_state_dict(

--- a/src/brevitas/nn/quant_rnn.py
+++ b/src/brevitas/nn/quant_rnn.py
@@ -20,6 +20,7 @@ from brevitas.nn import QuantSigmoid
 from brevitas.nn import QuantTanh
 from brevitas.nn.mixin import QuantBiasMixin
 from brevitas.nn.mixin import QuantWeightMixin
+from brevitas.nn.mixin.base import QuantLayerMixin
 from brevitas.nn.mixin.base import QuantRecurrentLayerMixin
 from brevitas.quant import Int8ActPerTensorFloat
 from brevitas.quant import Int8WeightPerTensorFloat
@@ -38,13 +39,22 @@ QuantTupleLongDisabled = List[Tuple[Tensor,
                                     Optional[Tensor]]]
 
 
-class GateWeight(QuantWeightMixin, nn.Module):
+class GateWeight(QuantWeightMixin, QuantLayerMixin, nn.Module):
 
-    def __init__(self, input_features, output_features, weight_quant, dtype, device, **kwargs):
+    def __init__(
+            self,
+            input_features,
+            output_features,
+            weight_quant,
+            return_quant_tensor,
+            dtype,
+            device,
+            **kwargs):
         nn.Module.__init__(self)
         self.weight = nn.Parameter(
             torch.randn(output_features, input_features, dtype=dtype, device=device))
         QuantWeightMixin.__init__(self, weight_quant=weight_quant, **kwargs)
+        QuantLayerMixin.__init__(self, return_quant_tensor=return_quant_tensor)
 
     @property
     def output_channel_dim(self):
@@ -55,7 +65,7 @@ class GateWeight(QuantWeightMixin, nn.Module):
         return self.weight.size(self.output_channel_dim)
 
     def forward(self):
-        return self.weight_quant(self.weight)
+        return self.weight_quant(self.weight, return_quant_tensor=self.return_quant_tensor)
 
 
 class GateParams(QuantBiasMixin, nn.Module):
@@ -68,6 +78,7 @@ class GateParams(QuantBiasMixin, nn.Module):
             weight_quant,
             bias_quant,
             input_weight,
+            return_quant_tensor,
             dtype,
             device,
             **kwargs):
@@ -82,6 +93,7 @@ class GateParams(QuantBiasMixin, nn.Module):
                 input_size,
                 hidden_size,
                 weight_quant=weight_quant,
+                return_quant_tensor=return_quant_tensor,
                 dtype=dtype,
                 device=device,
                 **kwargs)
@@ -91,6 +103,7 @@ class GateParams(QuantBiasMixin, nn.Module):
             hidden_size,
             hidden_size,
             weight_quant=input_weight.weight_quant,
+            return_quant_tensor=return_quant_tensor,
             dtype=dtype,
             device=device)
 
@@ -120,7 +133,7 @@ class _QuantStatesInit(nn.Module):
         return quant_states
 
 
-class _QuantRNNCell(nn.Module):
+class _QuantRNNCell(QuantLayerMixin, nn.Module):
     __constants__ = ['reverse_input', 'batch_first']
 
     def __init__(
@@ -131,8 +144,11 @@ class _QuantRNNCell(nn.Module):
             reverse_input: bool,
             batch_first: bool,
             output_quant_enabled: bool,
-            fast_impl: bool):
-        super(_QuantRNNCell, self).__init__()
+            fast_impl: bool,
+            return_quant_tensor: bool):
+        nn.Module.__init__(self)
+        QuantLayerMixin.__init__(self, return_quant_tensor=return_quant_tensor)
+
         self.act_fn = act_fn
         self.gate_acc_quant = gate_acc_quant
         self.output_quant = output_quant
@@ -143,9 +159,11 @@ class _QuantRNNCell(nn.Module):
     def forward_iter(self, quant_input, quant_state, quant_weight_ih, quant_weight_hh, quant_bias):
         quant_gate_ih = F.linear(quant_input, quant_weight_ih)
         quant_gate_hh = F.linear(quant_state, quant_weight_hh)
-        quant_gate = self.gate_acc_quant(quant_gate_ih + quant_gate_hh + quant_bias)[0]
+        quant_gate = self.gate_acc_quant(
+            quant_gate_ih + quant_gate_hh + quant_bias, return_quant_tensor=False)
         quant_gate = self.act_fn(quant_gate)
-        quant_state_tuple = self.output_quant(quant_gate)
+        quant_state_tuple = self.output_quant(
+            quant_gate, return_quant_tensor=self.return_quant_tensor)
         return quant_state_tuple
 
     def forward(
@@ -176,7 +194,7 @@ class _QuantRNNCell(nn.Module):
         return quant_outputs
 
 
-class _QuantLSTMCell(nn.Module):
+class _QuantLSTMCell(QuantLayerMixin, nn.Module):
     __constants__ = ['reverse_input', 'batch_first', 'cifg']
 
     def __init__(
@@ -197,8 +215,12 @@ class _QuantLSTMCell(nn.Module):
             cifg: bool,
             output_quant_enabled: bool,
             cell_state_quant_enabled: bool,
-            fast_impl: bool):
-        super(_QuantLSTMCell, self).__init__()
+            fast_impl: bool,
+            return_quant_tensor: bool):
+
+        nn.Module.__init__(self)
+        QuantLayerMixin.__init__(self, return_quant_tensor=return_quant_tensor)
+
         self.output_quant = output_quant
         self.cell_state_quant = cell_state_quant
         self.input_acc_quant = input_acc_quant
@@ -236,35 +258,45 @@ class _QuantLSTMCell(nn.Module):
         # Input gate
         quant_ii_gate = F.linear(quant_input, quant_weight_ii)
         quant_hi_gate = F.linear(quant_hidden_state, quant_weight_hi)
-        quant_input_gate = self.input_acc_quant(quant_ii_gate + quant_hi_gate + quant_bias_input)[0]
-        quant_input_gate = self.input_sigmoid_quant(quant_input_gate)[0]
+        quant_input_gate = self.input_acc_quant(
+            quant_ii_gate + quant_hi_gate + quant_bias_input, return_quant_tensor=False)
+        quant_input_gate = self.input_sigmoid_quant(quant_input_gate, return_quant_tensor=False)
         # Forget gate
         if self.cifg:
-            quant_ones = self.input_sigmoid_quant.tensor_quant(torch.ones_like(quant_input_gate))[0]
+            quant_ones = self.input_sigmoid_quant.tensor_quant(
+                torch.ones_like(quant_input_gate), return_quant_tensor=False)
             # CIFG is defined as 1 - input_gate, in line with ONNXRuntime
             quant_forget_gate = quant_ones - quant_input_gate
         else:
             quant_if_gate = F.linear(quant_input, quant_weight_if)
             quant_hf_gate = F.linear(quant_hidden_state, quant_weight_hf)
             quant_forget_gate = self.forget_acc_quant(
-                quant_if_gate + quant_hf_gate + quant_bias_forget)[0]
-            quant_forget_gate = self.forget_sigmoid_quant(quant_forget_gate)[0]
+                quant_if_gate + quant_hf_gate + quant_bias_forget, return_quant_tensor=False)
+            quant_forget_gate = self.forget_sigmoid_quant(
+                quant_forget_gate, return_quant_tensor=False)
         # Cell gate
         quant_ic_gate = F.linear(quant_input, quant_weight_ic)
         quant_hc_gate = F.linear(quant_hidden_state, quant_weight_hc)
-        quant_cell_gate = self.cell_acc_quant(quant_ic_gate + quant_hc_gate + quant_bias_cell)[0]
-        quant_cell_gate = self.cell_tanh_quant(quant_cell_gate)[0]
+        quant_cell_gate = self.cell_acc_quant(
+            quant_ic_gate + quant_hc_gate + quant_bias_cell, return_quant_tensor=False)
+        quant_cell_gate = self.cell_tanh_quant(quant_cell_gate, return_quant_tensor=False)
         # Output gate
         quant_io_gate = F.linear(quant_input, quant_weight_io)
         quant_ho_gate = F.linear(quant_hidden_state, quant_weight_ho)
-        quant_out_gate = self.output_acc_quant(quant_io_gate + quant_ho_gate + quant_bias_output)[0]
-        quant_out_gate = self.output_sigmoid_quant(quant_out_gate)[0]
-        quant_forget_cell = self.cell_state_quant(quant_forget_gate * quant_cell_state)[0]
-        quant_inp_cell = self.cell_state_quant(quant_input_gate * quant_cell_gate)[0]
-        quant_cell_state_tuple = self.cell_state_quant(quant_forget_cell + quant_inp_cell)
-        quant_hidden_state_tanh = self.hidden_state_tanh_quant(quant_cell_state_tuple[0])[0]
+        quant_out_gate = self.output_acc_quant(
+            quant_io_gate + quant_ho_gate + quant_bias_output, return_quant_tensor=False)
+        quant_out_gate = self.output_sigmoid_quant(quant_out_gate, return_quant_tensor=False)
+        quant_forget_cell = self.cell_state_quant(
+            quant_forget_gate * quant_cell_state, return_quant_tensor=False)
+        quant_inp_cell = self.cell_state_quant(
+            quant_input_gate * quant_cell_gate, return_quant_tensor=False)
+        quant_cell_state_tuple = self.cell_state_quant(
+            quant_forget_cell + quant_inp_cell, return_quant_tensor=False)
+        quant_hidden_state_tanh = self.hidden_state_tanh_quant(
+            quant_cell_state_tuple, return_quant_tensor=False)
         quant_hidden_state = quant_out_gate * quant_hidden_state_tanh
-        quant_hidden_state_tuple = self.output_quant(quant_hidden_state)
+        quant_hidden_state_tuple = self.output_quant(
+            quant_hidden_state, return_quant_tensor=self.return_quant_tensor)
         return quant_hidden_state_tuple, quant_cell_state_tuple
 
     def forward(
@@ -361,7 +393,8 @@ class _QuantRNNLayer(QuantRecurrentLayerMixin, nn.Module):
             reverse_input,
             batch_first,
             io_quant.act_quant.is_quant_enabled,
-            fast_impl=False)
+            fast_impl=False,
+            return_quant_tensor=return_quant_tensor)
         QuantRecurrentLayerMixin.__init__(
             self,
             cell=cell,
@@ -379,6 +412,7 @@ class _QuantRNNLayer(QuantRecurrentLayerMixin, nn.Module):
             weight_quant,
             bias_quant,
             input_weight,
+            return_quant_tensor=return_quant_tensor,
             dtype=dtype,
             device=device,
             **kwargs)
@@ -410,7 +444,8 @@ class _QuantRNNLayer(QuantRecurrentLayerMixin, nn.Module):
                 self.cell.reverse_input,
                 self.cell.batch_first,
                 self.cell.output_quant.is_quant_enabled,
-                fast_impl=True)
+                fast_impl=True,
+                return_quant_tensor=self.return_quant_tensor)
             if brevitas.config.JIT_ENABLED:
                 self._fast_cell = torch.jit.script(self._fast_cell)
             return self._fast_cell
@@ -555,7 +590,8 @@ class _QuantLSTMLayer(QuantRecurrentLayerMixin, nn.Module):
             cifg=cifg,
             output_quant_enabled=io_quant.act_quant.is_quant_enabled,
             cell_state_quant_enabled=cell_state_quant.act_quant.is_quant_enabled,
-            fast_impl=False)
+            fast_impl=False,
+            return_quant_tensor=return_quant_tensor)
         QuantRecurrentLayerMixin.__init__(
             self,
             cell=cell,
@@ -574,6 +610,7 @@ class _QuantLSTMLayer(QuantRecurrentLayerMixin, nn.Module):
             weight_quant,
             bias_quant,
             input_forget_weight,
+            return_quant_tensor=return_quant_tensor,
             dtype=dtype,
             device=device,
             **kwargs)
@@ -590,6 +627,7 @@ class _QuantLSTMLayer(QuantRecurrentLayerMixin, nn.Module):
                 weight_quant,
                 bias_quant,
                 input_input_weight,
+                return_quant_tensor=return_quant_tensor,
                 dtype=dtype,
                 device=device,
                 **kwargs)
@@ -600,6 +638,7 @@ class _QuantLSTMLayer(QuantRecurrentLayerMixin, nn.Module):
             weight_quant,
             bias_quant,
             input_cell_weight,
+            return_quant_tensor=return_quant_tensor,
             dtype=dtype,
             device=device,
             **kwargs)
@@ -610,6 +649,7 @@ class _QuantLSTMLayer(QuantRecurrentLayerMixin, nn.Module):
             weight_quant,
             bias_quant,
             input_output_weight,
+            return_quant_tensor=return_quant_tensor,
             dtype=dtype,
             device=device,
             **kwargs)
@@ -663,7 +703,8 @@ class _QuantLSTMLayer(QuantRecurrentLayerMixin, nn.Module):
                 cifg=self.cell.cifg,
                 output_quant_enabled=self.cell.output_quant.is_quant_enabled,
                 cell_state_quant_enabled=self.cell.cell_state_quant.is_quant_enabled,
-                fast_impl=True)
+                fast_impl=True,
+                return_quant_tensor=self.return_quant_tensor)
             if brevitas.config.JIT_ENABLED:
                 self._fast_cell = torch.jit.script(self._fast_cell)
             return self._fast_cell

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -98,7 +98,6 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
         self.cache_inference_quant_weight_metadata_only = False
         self.cache_class = None  # To be redefined by each class
         self.quant_tensor_class = None  # To be redefined by each class
-        self.skip_create_quant_tensor = False
 
     def compile_quant(self, compile_export=False):
         if compile_export and hasattr(self, 'export_handler') and self.export_handler is not None:
@@ -147,23 +146,25 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
     def create_quant_tensor(self, qt_args: Tuple[Any]) -> Union[Tensor, QuantTensor]:
         raise NotImplementedError
 
-    def forward(self, x: torch.Tensor) -> Union[Tensor, QuantTensor]:
+    def forward(self,
+                x: torch.Tensor,
+                return_quant_tensor: bool = True) -> Union[Tensor, QuantTensor]:
         if self.is_quant_enabled:
             # If quant is enabled the priority is:
             # - export mode
             # - quantization flow
             if self.export_mode:
                 out = self.export_handler(x)
-                if self.skip_create_quant_tensor:
-                    out = out[0]
-                else:
+                if return_quant_tensor:
                     out = self.create_quant_tensor(out)
+                else:
+                    out = out[0]
             else:
                 out = self.tensor_quant(x)
-                if self.skip_create_quant_tensor:
-                    out = out[0]
-                else:
+                if return_quant_tensor:
                     out = self.create_quant_tensor(out)
+                else:
+                    out = out[0]
                     if not self.training and self.cache_inference_quant_weight and self._cached_weight is None:
                         self._cached_weight = self.cache_class(
                             out.detach(),
@@ -181,7 +182,6 @@ class BiasQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector, BiasQuantP
         self.cache_inference_quant_bias = False
         self.cache_inference_quant_bias_metadata_only = False
         self.requires_input_scale = self.quant_injector.requires_input_scale
-        self.skip_create_quant_tensor = False
 
     @property
     def tracked_parameter_list(self):
@@ -267,10 +267,10 @@ class DecoupledWeightQuantWithInputProxyFromInjector(DecoupledWeightQuantProxyFr
         raise NotImplementedError
 
     def forward(
-        self,
-        x: torch.Tensor,
-        quant_input: Optional[Union[Tensor,
-                                    IntQuantTensor]] = None) -> Union[Tensor, IntQuantTensor]:
+            self,
+            x: torch.Tensor,
+            quant_input: Optional[Union[Tensor, IntQuantTensor]] = None,
+            create_quant_tensor: bool = True) -> Union[Tensor, IntQuantTensor]:
         if isinstance(quant_input,
                       IntQuantTensor) and not self.training and self.cache_inference_quant_act:
             cached_inp = _CachedIO(quant_input.detach(), self.cache_quant_io_metadata_only)
@@ -288,7 +288,7 @@ class DecoupledWeightQuantWithInputProxyFromInjector(DecoupledWeightQuantProxyFr
 
             impl = self.export_handler if self.export_mode else self.tensor_quant
             out, scale, zero_point, bit_width, pre_scale, pre_zero_point = impl(x, input_bit_width, input_is_signed)
-            if self.skip_create_quant_tensor:
+            if create_quant_tensor:
                 return out
             return IntQuantTensor(out, scale, zero_point, bit_width, self.is_signed, self.training)
         else:  # quantization disabled
@@ -355,8 +355,8 @@ class BiasQuantProxyFromInjector(BiasQuantProxyFromInjectorBase):
             self,
             x: Tensor,
             input: Optional[Union[Tensor, IntQuantTensor]] = None,
-            weight: Optional[Union[Tensor,
-                                   IntQuantTensor]] = None) -> Union[Tensor, IntQuantTensor]:
+            weight: Optional[Union[Tensor, IntQuantTensor]] = None,
+            create_quant_tensor: bool = True) -> Union[Tensor, IntQuantTensor]:
         out = x
         if self.is_quant_enabled:
             input_scale = self.compute_bias_scale(input, weight)
@@ -372,7 +372,7 @@ class BiasQuantProxyFromInjector(BiasQuantProxyFromInjectorBase):
                 out, out_scale, out_zp, out_bit_width = impl(x, input_scale)
             else:
                 out, out_scale, out_zp, out_bit_width = impl(x)
-            if not self.skip_create_quant_tensor:
+            if create_quant_tensor:
                 out = IntQuantTensor(
                     out, out_scale, out_zp, out_bit_width, self.is_signed, self.training)
                 if not self.training and self.cache_inference_quant_bias:

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -101,7 +101,6 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         self.cache_inference_quant_act = False
         self.cache_quant_io_metadata_only = True
         self.cache_class = None
-        self.skip_create_quant_tensor = False
 
     def compile_quant(self, compile_export=False):
         fullgraph = not self.is_groupwise
@@ -177,7 +176,9 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         # In both cases, the output is a QuantTensor
         raise NotImplementedError
 
-    def forward(self, x: Union[Tensor, QuantTensor]) -> Union[Tensor, QuantTensor]:
+    def forward(self,
+                x: Union[Tensor, QuantTensor],
+                return_quant_tensor: bool = True) -> Union[Tensor, QuantTensor]:
         # If fused activation quant proxy is not enabled, return the input
         if self.fused_activation_quant_proxy is None:
             return x
@@ -199,9 +200,7 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         # If y is an empty QuantTensor, we need to check if this is a passthrough proxy,
         # otherwise return a simple Tensor
 
-        if self.skip_create_quant_tensor:
-            out = y[0]
-        else:
+        if return_quant_tensor:
             # If the second value (i.e., scale) is None, then quant is disabled
             if y[1] is not None:
                 out = self.create_quant_tensor(y, x=x)
@@ -211,6 +210,8 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
                 out = self.create_quant_tensor(y, x=x)
             else:
                 out = y[0]
+        else:
+            out = y[0]
 
         if not self.training and self.cache_inference_quant_act and isinstance(out, QuantTensor):
             cached_out = self.cache_class(out.detach(), self.cache_quant_io_metadata_only)
@@ -257,16 +258,19 @@ class ClampQuantProxyFromInjector(QuantProxyFromInjector, AccQuantProxyProtocol)
 
     def __init__(self):
         super().__init__()
-        self.skip_create_quant_tensor = False
 
-    def forward(self, x: IntQuantTensor) -> Union[Tensor, IntQuantTensor]:
+    def forward(self,
+                x: IntQuantTensor,
+                return_quant_tensor: bool = True) -> Union[Tensor, IntQuantTensor]:
         if self.is_quant_enabled:
             out_tuple = self.tensor_quant(x.value, x.scale, x.bit_width)
             out_value, out_scale, out_zp, out_bit_width = out_tuple
-            if self.skip_create_quant_tensor:
-                return out_value
-            return IntQuantTensor(
-                out_value, out_scale, out_zp, out_bit_width, self.is_signed, self.training)
+            if return_quant_tensor:
+                out = IntQuantTensor(
+                    out_value, out_scale, out_zp, out_bit_width, self.is_signed, self.training)
+            else:
+                out = out_value
+            return out
         return x
 
 
@@ -278,7 +282,6 @@ class TruncQuantProxyFromInjector(QuantProxyFromInjector, AccQuantProxyProtocol)
         self.cache_inference_quant_act = True
         self.cache_quant_io_metadata_only = True
         self.cache_class = _CachedIO
-        self.skip_create_quant_tensor = False
 
     def retrieve_attribute(self, attribute):
         if self._cached_act is not None:
@@ -300,7 +303,9 @@ class TruncQuantProxyFromInjector(QuantProxyFromInjector, AccQuantProxyProtocol)
     def bit_width(self):
         return self.retrieve_attribute('bit_width')
 
-    def forward(self, x: IntQuantTensor) -> Union[Tensor, IntQuantTensor]:
+    def forward(self,
+                x: IntQuantTensor,
+                return_quant_tensor: bool = True) -> Union[Tensor, IntQuantTensor]:
         if self.is_quant_enabled:
             if self.export_mode:
                 out_tuple = self.export_handler(
@@ -308,7 +313,7 @@ class TruncQuantProxyFromInjector(QuantProxyFromInjector, AccQuantProxyProtocol)
             else:
                 out_tuple = self.tensor_quant(x.value, x.scale, x.zero_point, x.bit_width, x.signed)
             out_value, out_scale, out_zp, out_bit_width = out_tuple
-            if self.skip_create_quant_tensor:
+            if not return_quant_tensor:
                 return out_value
             out = IntQuantTensor(
                 out_value, out_scale, out_zp, out_bit_width, x.signed, self.training)

--- a/src/brevitas/quant_tensor/int_torch_handler.py
+++ b/src/brevitas/quant_tensor/int_torch_handler.py
@@ -173,7 +173,7 @@ def quant_layer(fn, quant_input, quant_weight, bias, *args, **kwargs):
             *args,
             **kwargs)
 
-    if isinstance(quant_input, IntQuantTensor) and isinstance(quant_weight, IntQuantTensor):
+    if compute_output_quant_tensor:
         output_bit_width = max_acc_bit_width(
             quant_input.bit_width,
             quant_weight.bit_width,


### PR DESCRIPTION
## Reason for this PR

Currently our proxies will always return a QuantTensor, even when this is subsequently discarded.

This causes some slowdown, especially when a lot of compute time is used to compute a new QuantTensor as output of a linear/conv, just to be discarded immediately afterwards.

## Changes Made in this PR

This PR introduces a runtime argument for the forward pass of all the proxies, so that if the main layer has `return_quant_tensor=False`, then no QuantTensor is created at the proxy level.

This has the implicit effect of skipping the custom `__torch_function__` calls to specialized forwards for conv/linear/etc. since all tensors will be plain tensors and not quant tensors.

Some layers have been extended to inherit from QuantLayerMixin (they were properly quant layers anyway) to support the return_quant_tensor flag.

This has cleaned up also the `[0]` in the quant_rnn file, where we discarded the quant tensor metadata anyway immediately.

## Testing Summary

Plenty existing.

The default behaviour has been preserved to return_quant_tensor=True, in case I missed something.
This is retrocompatible.

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
