### PR TITLE
Fix (setup.py): Update author and contact in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     long_description=read(PROJECT_ROOT, 'README.md'),
     long_description_content_type="text/markdown",
     author="AMD Research and Advanced Development",
+    author_email="brevitas-external@amd.com",
     url="https://github.com/Xilinx/brevitas",
     python_requires=">=3.8",
     install_requires=read_requirements('requirements.txt'),


### PR DESCRIPTION
Update from Ale -> RAD. Note, `author_email` does not seem to be a [required field](https://packaging.python.org/en/latest/specifications/core-metadata/), so ~I suggest removing it for now~. Instead we've switched to an alias.