### PR TITLE
Feat (core/scaling): Add option to restrict the output of (scale / threshold)

### DIFF
--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -31,9 +31,11 @@ class StatsFromParameterScaling(brevitas.jit.ScriptModule):
             scaling_stats_input_concat_dim: int,
             tracked_parameter_list: List[torch.nn.Parameter],
             scaling_shape: Tuple[int, ...],
+            is_scale_unsigned: bool = True,
             force_parameter: bool = False,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
+            restrict_scale_threshold_impl: Optional[Module] = None,
             scaling_affine_rescaling_init: Optional[float] = None,
             scaling_affine_shifting_init: Optional[float] = None,
             scaling_min_val: Optional[float] = None,
@@ -53,14 +55,16 @@ class StatsFromParameterScaling(brevitas.jit.ScriptModule):
             tracked_parameter_list,
             force_parameter)
         self.stats_scaling_impl = _StatsScaling(
-            restrict_scaling_impl,
-            restrict_threshold_impl,
-            scaling_min_val,
-            scaling_shape,
-            scaling_affine_rescaling_init,
-            scaling_affine_shifting_init,
-            dtype,
-            device)
+            restrict_scaling_impl=restrict_scaling_impl,
+            restrict_threshold_impl=restrict_threshold_impl,
+            restrict_scale_threshold_impl=restrict_scale_threshold_impl,
+            scaling_min_val=scaling_min_val,
+            scaling_shape=scaling_shape,
+            scaling_affine_rescaling_init=scaling_affine_rescaling_init,
+            scaling_affine_shifting_init=scaling_affine_shifting_init,
+            dtype=dtype,
+            device=device,
+            is_scale_unsigned=is_scale_unsigned)
 
     @brevitas.jit.script_method
     def forward(
@@ -85,6 +89,7 @@ class _StatsScaling(brevitas.jit.ScriptModule):
             scaling_affine_shifting_init: Optional[float],
             dtype: Optional[torch.dtype],
             device: Optional[torch.device],
+            restrict_scale_threshold_impl: Optional[Module] = None,
             is_scale_unsigned: bool = True) -> None:
         super(_StatsScaling, self).__init__()
         _affine_rescaling = scaling_affine_rescaling_init is not None
@@ -105,6 +110,8 @@ class _StatsScaling(brevitas.jit.ScriptModule):
             scaling_min_val, restrict_scaling_impl, is_scale_unsigned)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
+        self.restrict_clamp_scale_threshold = _RestrictClampValue(
+            restrict_scale_threshold_impl, is_scale_unsigned)
         self.restrict_scaling_pre = restrict_scaling_impl.restrict_init_module()
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
         self.clamp_scaling = _ClampValue(scaling_min_val)
@@ -121,7 +128,7 @@ class _StatsScaling(brevitas.jit.ScriptModule):
         stats = self.restrict_scaling_pre(stats)
         stats = self.affine_rescaling(stats)
         stats = self.restrict_clamp_scaling(stats)
-        stats = stats / threshold
+        stats = self.restrict_clamp_scale_threshold(stats / threshold)
         return stats
 
 
@@ -132,10 +139,12 @@ class RuntimeStatsScaling(brevitas.jit.ScriptModule):
             scaling_stats_impl: Module,
             scaling_stats_input_view_shape_impl: Module,
             scaling_shape: Tuple[int, ...],
+            is_scale_unsigned: bool = True,
             scaling_affine_rescaling_init: Optional[float] = None,
             scaling_affine_shifting_init: Optional[float] = None,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
+            restrict_scale_threshold_impl: Optional[Module] = None,
             scaling_stats_momentum: float = DEFAULT_MOMENTUM,
             scaling_min_val: Optional[float] = None,
             dtype: Optional[torch.dtype] = None,
@@ -154,14 +163,16 @@ class RuntimeStatsScaling(brevitas.jit.ScriptModule):
             dtype,
             device)
         self.stats_scaling_impl = _StatsScaling(
-            restrict_scaling_impl,
-            restrict_threshold_impl,
-            scaling_min_val,
-            scaling_shape,
-            scaling_affine_rescaling_init,
-            scaling_affine_shifting_init,
-            dtype,
-            device)
+            restrict_scaling_impl=restrict_scaling_impl,
+            restrict_threshold_impl=restrict_threshold_impl,
+            restrict_scale_threshold_impl=restrict_scale_threshold_impl,
+            scaling_min_val=scaling_min_val,
+            scaling_shape=scaling_shape,
+            scaling_affine_rescaling_init=scaling_affine_rescaling_init,
+            scaling_affine_shifting_init=scaling_affine_shifting_init,
+            dtype=dtype,
+            device=device,
+            is_scale_unsigned=is_scale_unsigned)
 
     @brevitas.jit.script_method
     def forward(self, x: torch.Tensor, threshold: Optional[torch.Tensor] = None) -> torch.Tensor:
@@ -215,7 +226,9 @@ class RuntimeDynamicGroupStatsScaling(brevitas.jit.ScriptModule):
             scaling_stats_impl: Module,
             scaling_min_val: Optional[float],
             restrict_scaling_impl: Module = FloatRestrictValue(),
-            restrict_threshold_impl: Optional[Module] = None) -> None:
+            restrict_threshold_impl: Optional[Module] = None,
+            restrict_scale_threshold_impl: Optional[Module] = None,
+            is_scale_unsigned: bool = True) -> None:
         super(RuntimeDynamicGroupStatsScaling, self).__init__()
 
         # Ensure retro-compatibility with shared threshold/scaling restrict
@@ -227,9 +240,12 @@ class RuntimeDynamicGroupStatsScaling(brevitas.jit.ScriptModule):
         self.scaling_stats_impl = scaling_stats_impl
         self.scaling_min_val = scaling_min_val
         self.input_view_impl = input_view_impl
-        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
+        self.restrict_clamp_scaling = _RestrictClampValue(
+            scaling_min_val, restrict_scaling_impl, is_scale_signed)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
+        self.restrict_clamp_scale_threshold = _RestrictClampValue(
+            restrict_scale_threshold_impl, is_scale_unsigned)
         self.restrict_scaling_pre = self.restrict_clamp_scaling.restrict_value_impl.restrict_init_module(
         )
         self.restrict_threshold_pre = self.restrict_clamp_threshold.restrict_value_impl.restrict_init_module(
@@ -252,4 +268,5 @@ class RuntimeDynamicGroupStatsScaling(brevitas.jit.ScriptModule):
         out = self.restrict_scaling_pre(out)
         # Apply restrict_value and clamping
         out = self.restrict_clamp_scaling(out) / threshold
+        out = self.restrict_clamp_scale_threshold(out)
         return out

--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -37,8 +37,10 @@ class ConstScaling(brevitas.jit.ScriptModule):
 
     Args:
         scaling_init (Union[float, Tensor]): value to initialize the constant scale factor.
+        is_scale_unsigned (bool): Whether the scale is unsigned. Default: True.
         restrict_scaling_impl (Module): restrict the scale factor according to some criteria. Default: FloatRestrictValue().
         restrict_threshold_impl (Optional[Module]): restrict the threshold according to some criteria. Default: None.
+        restrict_scale_threshold_impl (Optional[Module]): restrict value of scale / threshold according to some criteria. Default: None.
         scaling_min_val (Optional[float]): force a lower-bound on the scale factor. Default: None.
         dtype (Optional[torch.dtype]): data type of the scale factor. Default: None.
         device (Optional[torch.device]): device of the scale factor. Default: None.
@@ -68,8 +70,10 @@ class ConstScaling(brevitas.jit.ScriptModule):
     def __init__(
             self,
             scaling_init: Union[float, Tensor],
+            is_scale_unsigned: bool = True,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
+            restrict_scale_threshold_impl: Optional[Module] = None,
             scaling_min_val: Optional[float] = None,
             dtype: Optional[torch.dtype] = None,
             device: Optional[torch.device] = None) -> None:
@@ -79,9 +83,12 @@ class ConstScaling(brevitas.jit.ScriptModule):
         if restrict_threshold_impl is None:
             restrict_threshold_impl = restrict_scaling_impl
 
-        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
+        self.restrict_clamp_scaling = _RestrictClampValue(
+            scaling_min_val, restrict_scaling_impl, is_scale_unsigned)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
+        self.restrict_clamp_scale_threshold = _RestrictClampValue(
+            restrict_scale_threshold_impl, is_scale_unsigned)
         if isinstance(scaling_init, Tensor):
             scaling_init = scaling_init.to(device=device, dtype=dtype)
             scaling_init = restrict_scaling_impl.restrict_init_tensor(scaling_init)
@@ -99,7 +106,7 @@ class ConstScaling(brevitas.jit.ScriptModule):
         # For IntQuant, this is no-op, retrocompatible.
         threshold = self.restrict_clamp_threshold(self.restrict_threshold_pre(threshold))
         restricted_value = self.restrict_clamp_scaling(self.value())
-        restricted_value = restricted_value / threshold
+        restricted_value = self.restrict_clamp_scale_threshold(restricted_value / threshold)
         return restricted_value
 
 
@@ -113,6 +120,7 @@ class ParameterScaling(brevitas.jit.ScriptModule):
         scaling_shape (Optional[Tuple[int, ...]]): Shape of the learned scale factor. Default: None.
         restrict_scaling_impl (Module): Restrict the scale factor according to some criteria. Default: FloatRestrictValue().
         restrict_threshold_impl (Optional[Module]): Restrict the threshold according to some criteria. Default: None.
+        restrict_scale_threshold_impl (Optional[Module]): restrict value of scale / threshold according to some criteria. Default: None.
         scaling_min_val (Optional[float]): Force a lower-bound on the scale factor. Default: None.
         dtype (Optional[torch.dtype]): Data type of the scale factor. Default: None.
         device (Optional[torch.device]): Device of the scale factor. Default: None.
@@ -154,6 +162,7 @@ class ParameterScaling(brevitas.jit.ScriptModule):
             scaling_shape: Optional[Tuple[int, ...]] = None,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
+            restrict_scale_threshold_impl: Optional[Module] = None,
             scaling_min_val: Optional[float] = None,
             dtype: Optional[torch.dtype] = None,
             device: Optional[torch.device] = None) -> None:
@@ -183,6 +192,8 @@ class ParameterScaling(brevitas.jit.ScriptModule):
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
+        self.restrict_clamp_scale_threshold = _RestrictClampValue(
+            restrict_scale_threshold_impl, is_scale_unsigned)
 
     @brevitas.jit.script_method
     def forward(self, placeholder: Tensor, threshold: Optional[Tensor] = None) -> Tensor:
@@ -193,7 +204,8 @@ class ParameterScaling(brevitas.jit.ScriptModule):
         threshold = self.restrict_clamp_threshold(self.restrict_threshold_pre(threshold))
         # We can clamp after restrict val since the learned parameter is already in log-domain
         value = self.restrict_clamp_scaling(self.value)
-        return value / threshold
+        value = self.restrict_clamp_scale_threshold(value / threshold)
+        return value
 
     def _load_from_state_dict(
             self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
@@ -222,6 +234,7 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
         force_parameter (bool): If True, always use a tracked_parameter_list for statistics, even if only one is tracked. Default: False.
         restrict_scaling_impl (Module): Restrict the scale factor according to some criteria. Default: FloatRestrictValue().
         restrict_threshold_impl (Optional[Module]): Restrict the threshold according to some criteria. Default: None.
+        restrict_scale_threshold_impl (Optional[Module]): restrict value of scale / threshold according to some criteria. Default: None.
         scaling_affine_rescaling_init (Optional[float]): Initial value for affine rescaling. Default: None.
         scaling_affine_shifting_init (Optional[float]): Initial value for affine shifting. Default: None.
         scaling_min_val (Optional[float]): Force a lower-bound on the scale factor. Default: None.
@@ -262,6 +275,7 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
             force_parameter: bool = False,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
+            restrict_scale_threshold_impl: Optional[Module] = None,
             scaling_affine_rescaling_init: Optional[float] = None,
             scaling_affine_shifting_init: Optional[float] = None,
             scaling_min_val: Optional[float] = None,
@@ -281,14 +295,15 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
             restrict_threshold_impl = restrict_scaling_impl
 
         self.stats_scaling_impl = _StatsScaling(
-            restrict_scaling_impl,
-            restrict_threshold_impl,
-            scaling_min_val,
-            scaling_shape,
-            scaling_affine_rescaling_init,
-            scaling_affine_shifting_init,
-            dtype,
-            device,
+            restrict_scaling_impl=restrict_scaling_impl,
+            restrict_threshold_impl=restrict_threshold_impl,
+            restrict_scale_threshold_impl=restrict_scale_threshold_impl,
+            scaling_min_val=scaling_min_val,
+            scaling_shape=scaling_shape,
+            scaling_affine_rescaling_init=scaling_affine_rescaling_init,
+            scaling_affine_shifting_init=scaling_affine_shifting_init,
+            dtype=dtype,
+            device=device,
             is_scale_unsigned=is_scale_unsigned)
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
         self.restrict_inplace_scaling_pre = restrict_scaling_impl.restrict_init_inplace_module()
@@ -307,7 +322,7 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
             threshold = self.stats_scaling_impl.restrict_clamp_threshold(
                 self.restrict_threshold_pre(threshold))
             value = self.stats_scaling_impl.restrict_clamp_scaling(self.value)
-            value = value / threshold
+            value = self.stats_scaling_impl.restrict_clamp_scale_threshold(value / threshold)
             return value
         else:
             stats = self.parameter_list_stats(x)
@@ -324,7 +339,7 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
                 self.restrict_threshold_pre(threshold))
             inplace_tensor_mul(self.value.detach(), stats)
             value = self.stats_scaling_impl.restrict_clamp_scaling(self.value)
-            value = value / threshold
+            value = self.stats_scaling_impl.restrict_clamp_scale_threshold(value / threshold)
             self.init_done = True
             return value
 
@@ -368,6 +383,7 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
         scaling_shape (Tuple[int, ...], optional): Shape of the torch.nn.Parameter used in the second phase. Default: SCALAR_SHAPE.
         restrict_scaling_impl (Module, optional): Restrict the learned scale factor according to some criteria. Default: FloatRestrictValue().
         restrict_threshold_impl (Optional[Module], optional): Restrict the threshold according to some criteria. Default: None.
+        restrict_scale_threshold_impl (Optional[Module]): restrict value of scale / threshold according to some criteria. Default: None.
         scaling_stats_momentum (Optional[float], optional): Momentum for the statistics moving average. Default: DEFAULT_MOMENTUM.
         scaling_min_val (Optional[float], optional): Force a lower-bound on the learned scale factor. Default: None.
         dtype (Optional[torch.dtype], optional): Data type of the scale factor. Default: None.
@@ -409,6 +425,7 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
             scaling_shape: Tuple[int, ...] = SCALAR_SHAPE,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
+            restrict_scale_threshold_impl: Optional[Module] = None,
             scaling_stats_momentum: Optional[float] = DEFAULT_MOMENTUM,
             scaling_min_val: Optional[float] = None,
             dtype: Optional[torch.dtype] = None,
@@ -429,8 +446,10 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
         self.register_buffer('buffer', torch.full(scaling_shape, 1.0, dtype=dtype, device=device))
         self.value = Parameter(torch.full(scaling_shape, 1.0, dtype=dtype, device=device))
         self.abs_value = _AbsValue(is_unsigned=is_scale_unsigned)
-        self.restrict_scaling = _RestrictValue(restrict_scaling_impl)
+        self.restrict_scaling = _RestrictValue(restrict_scaling_impl, is_scale_unsigned)
         self.restrict_threshold = _RestrictValue(restrict_threshold_impl)
+        self.restrict_clamp_scale_threshold = _RestrictClampValue(
+            restrict_scale_threshold_impl, is_scale_unsigned)
         self.clamp_scaling = _ClampValue(scaling_min_val)
         self.local_loss_mode: bool = brevitas.jit.Attribute(
             False, bool)  # required to support MSE eval or variants
@@ -468,12 +487,12 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
             self.init_scale()
             value = self.clamp_scaling(self.restrict_scaling(self.value))
             threshold = self.restrict_threshold(self.restrict_threshold_pre(threshold))
-            value = value / threshold
+            value = self.restrict_clamp_scale_threshold(value / threshold)
             return value
         else:
             threshold = self.restrict_threshold(self.restrict_threshold_pre(threshold))
             value = self.clamp_scaling(self.restrict_scaling(self.value))
-            value = value / threshold
+            value = self.restrict_clamp_scale_threshold(value / threshold)
             return value
 
     @brevitas.jit.script_method
@@ -493,7 +512,7 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
             threshold = self.restrict_threshold(self.restrict_threshold_pre(threshold))
             out = self.restrict_scaling(out)
             out = self.abs_value(out)
-            out = out / threshold
+            out = self.restrict_clamp_scale_threshold(out / threshold)
             # We can clamp after restrict val since the learned parameter is already in log-domain
             out = self.clamp_scaling(out)
         return out


### PR DESCRIPTION
Added a module to all user-facing scaling classes to allow the output of `(scale / threshold)` to be restricted with some type of restriction module.

Also, took the opportunity to allow signed scaling in activation scaling implementations.