### PR TITLE
deps (ex) update accelerate version

### DIFF
--- a/requirements/requirements-diffusion.txt
+++ b/requirements/requirements-diffusion.txt
@@ -1,4 +1,4 @@
-accelerate<1.10
+accelerate
 diffusers<=0.34
 pandas
 torch>=2.0

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -1,4 +1,4 @@
-accelerate<1.10
+accelerate
 datasets
 gguf==0.17.0
 lm_eval

--- a/requirements/requirements-vision.txt
+++ b/requirements/requirements-vision.txt
@@ -1,4 +1,4 @@
-accelerate<1.10
+accelerate
 torch>=1.13
 torchvision
 tqdm


### PR DESCRIPTION
No longer restrict accelerate versions, after [this fix](https://github.com/huggingface/accelerate/pull/3742).

Fixes #1351.