### PR TITLE
Test (graph): restore skipped tests

### DIFF
--- a/requirements/requirements-diffusion.txt
+++ b/requirements/requirements-diffusion.txt
@@ -4,4 +4,4 @@ pandas
 torch>=2.2
 torchmetrics[image]
 tqdm
-transformers==4.50.0
+transformers

--- a/requirements/requirements-diffusion.txt
+++ b/requirements/requirements-diffusion.txt
@@ -4,4 +4,4 @@ pandas
 torch>=2.2
 torchmetrics[image]
 tqdm
-transformers
+transformers==4.50.0

--- a/src/brevitas/nn/mixin/parameter.py
+++ b/src/brevitas/nn/mixin/parameter.py
@@ -85,7 +85,6 @@ class QuantWeightMixin(QuantProxyMixin):
         super(QuantWeightMixin, self).register_parameter(name, value)
         if hasattr(self, 'weight_quant') and name == 'weight':
             self.weight_quant.init_tensor_quant()
-            self.weight_quant.to(self.weight.device)
 
 
 class QuantBiasMixin(QuantProxyMixin):

--- a/tests/brevitas/graph/test_quantize.py
+++ b/tests/brevitas/graph/test_quantize.py
@@ -76,9 +76,6 @@ class QuantLayerCases:
 
         if quant_layer_cls_kwargs is None:
             pytest.skip(f'There is no quant layer defined for {torch_layer_cls.__name__}')
-        # TODO (pml): Investigate this issue
-        elif torch_layer_cls in (torch.nn.LSTM, torch.nn.RNN):
-            pytest.skip(f'state_dict is not correctly loaded for {torch_layer_cls.__name__}')
 
         if torch_layer_cls in (torch.nn.LSTM, torch.nn.RNN):
             layer_kwargs = {'input_size': RNN_INPUT_SIZE, 'hidden_size': RNN_HIDDEN_SIZE}


### PR DESCRIPTION
## Reason for this PR

When there are shared quantizers, moving the quantizer to another device will cause an error, because of the reference to the original weight tensor that might still be on 'meta' device.

Since we have a better way to solve for dtype and device for weights, we can safely remove that line.

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
