### PR TITLE
Fix (ex/llm): Fix integration with Lighteval Python API

### DIFF
--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
 gguf==0.17.0
-lighteval; python_version >= "3.10"
+lighteval[math]; python_version >= "3.10"
 lm_eval
 numexpr<2.14.0
 onnx

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
 gguf==0.17.0
-lighteval
+lighteval; python_version >= "3.10"
 lm_eval
 numexpr<2.14.0
 onnx

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
 gguf==0.17.0
-lighteval[math]; python_version >= "3.10"
+lighteval[math]
 lm_eval
 numexpr<2.14.0
 onnx

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -8,6 +8,7 @@ onnx
 onnxruntime<1.21
 optimum[onnxruntime]
 pandas
+pydantic
 torch>=2.4
 tqdm
 transformers[sentencepiece]==4.50.0

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -1,6 +1,7 @@
 accelerate
 datasets
 gguf==0.17.0
+lighteval
 lm_eval
 numexpr<2.14.0
 onnx

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -8,6 +8,9 @@ onnx
 onnxruntime<1.21
 optimum[onnxruntime]
 pandas
+# TODO (pml): Remove when unpinning `transformers`, as `lighteval>=0.10.0`
+# requires this dependency explicitely.
+# See https://github.com/huggingface/lighteval/commit/2651750480d9a23ab0153f8ed3ef1d3331a2ea88.
 pydantic
 torch>=2.4
 tqdm

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -9,4 +9,4 @@ optimum[onnxruntime]
 pandas
 torch>=2.4
 tqdm
-transformers[sentencepiece]
+transformers[sentencepiece]==4.50.0

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -9,4 +9,4 @@ optimum[onnxruntime]
 pandas
 torch>=2.4
 tqdm
-transformers[sentencepiece]==4.50.0
+transformers[sentencepiece]

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -25,6 +25,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import override
+
+from lighteval.logging.evaluation_tracker import EvaluationTracker
+from lighteval.models.abstract_model import LightevalModel
+from lighteval.models.model_loader import TransformersModel
+from lighteval.models.transformers.transformers_model import TransformersModelConfig
+from lighteval.pipeline import ParallelismManager
+from lighteval.pipeline import Pipeline
+from lighteval.pipeline import PipelineParameters
 from torch import nn
 
 
@@ -41,6 +50,27 @@ def filter_results(results, tasks):
     return eval_results
 
 
+# TODO (pml): Deprecate after upgrading to transformers>=4.54.0 in Brevitas,
+# as this version is required for lighteval>=4.54.0, which features the override
+# of _init_model.
+class BrevitasPipeline(Pipeline):
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    @override
+    def _init_model(self, model_config, model):
+        # Verify that both the model and model_config are passed
+        assert model is not None and model_config is not None, "Provide both a model and a model config."
+        assert not isinstance(model, LightevalModel), "A LigthevalModel and a model config cannot be provided simultaneously."
+
+        return TransformersModel.from_model(
+            model=model,
+            config=model_config,
+            accelerator=self.accelerator,
+        )
+
+
 def run_lighteval(
     model_name: str,
     model: nn.Module,
@@ -55,35 +85,6 @@ def run_lighteval(
     Returns:
         results (dict): Evaluation results containing metrics and scores for all tasks.
     """
-    # TODO (pml): Deprecate after upgrading to transformers>=4.54.0 in Brevitas,
-    # as this version is required for lighteval>=4.54.0, which features the override
-    # of _init_model.
-    from typing import override
-
-    from lighteval.logging.evaluation_tracker import EvaluationTracker
-    from lighteval.models.abstract_model import LightevalModel
-    from lighteval.models.model_loader import TransformersModel
-    from lighteval.models.transformers.transformers_model import TransformersModelConfig
-    from lighteval.pipeline import ParallelismManager
-    from lighteval.pipeline import Pipeline
-    from lighteval.pipeline import PipelineParameters
-
-    class BrevitasPipeline(Pipeline):
-
-        def __init__(self, *args, **kwargs) -> None:
-            super().__init__(*args, **kwargs)
-
-        @override
-        def _init_model(self, model_config, model):
-            # Verify that both the model and model_config are passed
-            assert model is not None and model_config is not None, "Provide both a model and a model config."
-            assert not isinstance(model, LightevalModel), "A LigthevalModel and a model config cannot be provided simultaneously."
-
-            return TransformersModel.from_model(
-                model=model,
-                config=model_config,
-                accelerator=self.accelerator,
-            )
 
     evaluation_tracker = EvaluationTracker(output_dir=output_dir, save_details=True)
 

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#Adapted from https://github.com/huggingface/lighteval, released under the following LICENSE:
+
+# MIT License
+
+# Copyright (c) 2024 The HuggingFace Team
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from torch import nn
+
+def filter_results(results, tasks):
+    # filter out what we actually want to track
+    eval_results = dict()
+    for task_name in tasks:
+        # log all result metrics we have for this task
+        for key, val in results["results"][task_name].items():
+            if not isinstance(val, str):
+                # for mmlu, we don't log results per subtask, but simply overall results
+                name = f"{task_name}_{key}"
+                eval_results[name] = val
+    return eval_results
+
+def run_lighteval(
+    model_name: str,
+    model: nn.Module,
+    tasks: list[str],
+    output_dir: str = "./results",
+    dtype: str | None = None,
+    batch_size: int | None = None,
+    max_samples: int | None = None,
+):
+    """Evaluate model using HuggingFace Lighteval with accelerate as backend.
+
+    Returns:
+        results (dict): Evaluation results containing metrics and scores for all tasks.
+    """
+    from lighteval.logging.evaluation_tracker import EvaluationTracker
+    from lighteval.models.transformers.transformers_model import TransformersModelConfig
+    from lighteval.pipeline import ParallelismManager
+    from lighteval.pipeline import Pipeline
+    from lighteval.pipeline import PipelineParameters
+
+    evaluation_tracker = EvaluationTracker(
+        output_dir=output_dir, 
+        save_details=True
+    )
+
+    pipeline_params = PipelineParameters(
+        launcher_type=ParallelismManager.ACCELERATE,
+        max_samples=max_samples,
+    )
+
+    model_config = TransformersModelConfig(
+        model_name=model_name,
+        dtype=dtype,
+        batch_size=batch_size,
+        model_parallel=True
+    )
+
+    # Pipeline expects a comma-separated list of tasks
+    tasks = ",".join(tasks)
+
+    pipeline = Pipeline(
+        tasks=tasks,
+        pipeline_parameters=pipeline_params,
+        evaluation_tracker=evaluation_tracker,
+        model=model,
+        model_config=model_config,
+    )
+
+    pipeline.evaluate()
+
+    results = pipeline.get_results()
+    results = filter_results(results, list(results["results"].keys()))
+
+    return results

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -55,19 +55,18 @@ def run_lighteval(
     Returns:
         results (dict): Evaluation results containing metrics and scores for all tasks.
     """
-    from lighteval.logging.evaluation_tracker import EvaluationTracker
-    from lighteval.models.transformers.transformers_model import TransformersModelConfig
-    from lighteval.pipeline import ParallelismManager
-    from lighteval.pipeline import Pipeline
-    from lighteval.pipeline import PipelineParameters
-
     # TODO (pml): Deprecate after upgrading to transformers>=4.54.0 in Brevitas,
     # as this version is required for lighteval>=4.54.0, which features the override
     # of _init_model.
     from typing import override
 
+    from lighteval.logging.evaluation_tracker import EvaluationTracker
     from lighteval.models.abstract_model import LightevalModel
     from lighteval.models.model_loader import TransformersModel
+    from lighteval.models.transformers.transformers_model import TransformersModelConfig
+    from lighteval.pipeline import ParallelismManager
+    from lighteval.pipeline import Pipeline
+    from lighteval.pipeline import PipelineParameters
 
     class BrevitasPipeline(Pipeline):
 

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -61,6 +61,31 @@ def run_lighteval(
     from lighteval.pipeline import Pipeline
     from lighteval.pipeline import PipelineParameters
 
+    # TODO (pml): Deprecate after upgrading to transformers>=4.54.0 in Brevitas,
+    # as this version is required for lighteval>=4.54.0, which features the override
+    # of _init_model.
+    from typing import override
+
+    from lighteval.models.abstract_model import LightevalModel
+    from lighteval.models.model_loader import TransformersModel
+
+    class BrevitasPipeline(Pipeline):
+
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+
+        @override
+        def _init_model(self, model_config, model):
+            # Verify that both the model and model_config are passed
+            assert model is not None and model_config is not None, "Provide both a model and a model config."
+            assert not isinstance(model, LightevalModel), "A LigthevalModel and a model config cannot be provided simultaneously."
+
+            return TransformersModel.from_model(
+                model=model,
+                config=model_config,
+                accelerator=self.accelerator,
+            )
+
     evaluation_tracker = EvaluationTracker(output_dir=output_dir, save_details=True)
 
     pipeline_params = PipelineParameters(
@@ -74,7 +99,7 @@ def run_lighteval(
     # Pipeline expects a comma-separated list of tasks
     tasks = ",".join(tasks)
 
-    pipeline = Pipeline(
+    pipeline = BrevitasPipeline(
         tasks=tasks,
         pipeline_parameters=pipeline_params,
         evaluation_tracker=evaluation_tracker,

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -27,6 +27,7 @@
 
 from torch import nn
 
+
 def filter_results(results, tasks):
     # filter out what we actually want to track
     eval_results = dict()
@@ -38,6 +39,7 @@ def filter_results(results, tasks):
                 name = f"{task_name}_{key}"
                 eval_results[name] = val
     return eval_results
+
 
 def run_lighteval(
     model_name: str,
@@ -59,10 +61,7 @@ def run_lighteval(
     from lighteval.pipeline import Pipeline
     from lighteval.pipeline import PipelineParameters
 
-    evaluation_tracker = EvaluationTracker(
-        output_dir=output_dir, 
-        save_details=True
-    )
+    evaluation_tracker = EvaluationTracker(output_dir=output_dir, save_details=True)
 
     pipeline_params = PipelineParameters(
         launcher_type=ParallelismManager.ACCELERATE,
@@ -70,11 +69,7 @@ def run_lighteval(
     )
 
     model_config = TransformersModelConfig(
-        model_name=model_name,
-        dtype=dtype,
-        batch_size=batch_size,
-        model_parallel=True
-    )
+        model_name=model_name, dtype=dtype, batch_size=batch_size, model_parallel=True)
 
     # Pipeline expects a comma-separated list of tasks
     tasks = ",".join(tasks)

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -50,9 +50,12 @@ def filter_results(results, tasks):
     return eval_results
 
 
-# TODO (pml): Deprecate after upgrading to transformers>=4.54.0 in Brevitas,
-# as this version is required for lighteval>=4.54.0, which features the override
-# of _init_model.
+# TODO (pml): The implementation of `_init_model` in `BrevitasPipeline` mimics that
+# of `Pipeline` in `lighteval>=0.11.0`. However, `lighteval>=0.11.0` requires
+# `transformers>=4.54.0`, which clashes with the pin `transformers[sentencepiece]==4.50.0`
+# in `requirements-llm.txt`. Therefore, `BrevitasPipeline` can only be removed once the
+# `transformers` requirement is upgraded to `transformers>=4.54.0`. The following
+# provides extra context on the changes to _init_model: https://github.com/huggingface/lighteval/pull/921.
 class BrevitasPipeline(Pipeline):
 
     def __init__(self, *args, **kwargs) -> None:

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -25,8 +25,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import override
-
 from lighteval.logging.evaluation_tracker import EvaluationTracker
 from lighteval.models.abstract_model import LightevalModel
 from lighteval.models.model_loader import TransformersModel
@@ -61,7 +59,6 @@ class BrevitasPipeline(Pipeline):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    @override
     def _init_model(self, model_config, model):
         # Verify that both the model and model_config are passed
         assert model is not None and model_config is not None, "Provide both a model and a model config."

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -667,31 +667,26 @@ def quantize_llm(args, extra_args=None):
             from lighteval.pipeline import ParallelismManager
             from lighteval.pipeline import Pipeline
             from lighteval.pipeline import PipelineParameters
-            from lighteval.utils.utils import EnvConfig
 
             with torch.no_grad(), quant_inference_mode(model, compile=args.compile_eval):
                 model(**calibration_loader[0])
                 remove_hooks(model)
                 # expects a list
                 few_shot_tasks = ",".join(args.few_shot_tasks)
-                accelerator = Accelerator(
-                    kwargs_handlers=[InitProcessGroupKwargs(timeout=timedelta(seconds=3000))])
                 evaluation_tracker = EvaluationTracker(output_dir="./results", save_details=True)
                 pipeline_params = PipelineParameters(
-                    launcher_type=ParallelismManager.ACCELERATE,
-                    env_config=EnvConfig(cache_dir=constants.HF_HUB_CACHE),
-                    override_batch_size=args.few_shot_override_batch_size)
+                    launcher_type=ParallelismManager.ACCELERATE)
                 model_config = TransformersModelConfig(
-                    pretrained=args.model,
-                    dtype=dtype,
-                    model_parallel=True,
-                    accelerator=accelerator)
+                    model_name=args.model,
+                    dtype=args.dtype,
+                    batch_size=args.few_shot_override_batch_size,
+                    model_parallel=True)
                 pipeline = Pipeline(
                     tasks=few_shot_tasks,
                     pipeline_parameters=pipeline_params,
                     evaluation_tracker=evaluation_tracker,
                     model=model,
-                    config=model_config)
+                    model_config=model_config)
                 pipeline.evaluate()
             few_shot_eval_results = pipeline.get_results()
             few_shot_eval_results = filter_results(

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -662,7 +662,7 @@ def quantize_llm(args, extra_args=None):
             with torch.no_grad(), quant_inference_mode(model, compile=args.compile_eval):
                 model(**calibration_loader[0])
                 remove_hooks(model)
-                # expects a list
+                
                 from brevitas_examples.llm.eval_lighteval import run_lighteval
                 few_shot_eval_results = run_lighteval(
                     model_name=args.model,

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -662,7 +662,7 @@ def quantize_llm(args, extra_args=None):
             with torch.no_grad(), quant_inference_mode(model, compile=args.compile_eval):
                 model(**calibration_loader[0])
                 remove_hooks(model)
-                
+
                 from brevitas_examples.llm.eval_lighteval import run_lighteval
                 few_shot_eval_results = run_lighteval(
                     model_name=args.model,

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -3,7 +3,6 @@
 
 from contextlib import nullcontext
 from copy import deepcopy
-from datetime import timedelta
 import functools
 import os
 import pprint
@@ -659,38 +658,20 @@ def quantize_llm(args, extra_args=None):
             print("Few shot eval results")
             pprint.pprint(few_shot_eval_results)
         elif args.few_shot_eval == 'lighteval':
-            from accelerate import Accelerator
-            from accelerate import InitProcessGroupKwargs
-            from huggingface_hub import constants
-            from lighteval.logging.evaluation_tracker import EvaluationTracker
-            from lighteval.models.transformers.transformers_model import TransformersModelConfig
-            from lighteval.pipeline import ParallelismManager
-            from lighteval.pipeline import Pipeline
-            from lighteval.pipeline import PipelineParameters
 
             with torch.no_grad(), quant_inference_mode(model, compile=args.compile_eval):
                 model(**calibration_loader[0])
                 remove_hooks(model)
                 # expects a list
-                few_shot_tasks = ",".join(args.few_shot_tasks)
-                evaluation_tracker = EvaluationTracker(output_dir="./results", save_details=True)
-                pipeline_params = PipelineParameters(
-                    launcher_type=ParallelismManager.ACCELERATE)
-                model_config = TransformersModelConfig(
+                from brevitas_examples.llm.eval_lighteval import run_lighteval
+                few_shot_eval_results = run_lighteval(
                     model_name=args.model,
+                    model=model,
+                    tasks=args.few_shot_tasks,
                     dtype=args.dtype,
                     batch_size=args.few_shot_override_batch_size,
-                    model_parallel=True)
-                pipeline = Pipeline(
-                    tasks=few_shot_tasks,
-                    pipeline_parameters=pipeline_params,
-                    evaluation_tracker=evaluation_tracker,
-                    model=model,
-                    model_config=model_config)
-                pipeline.evaluate()
-            few_shot_eval_results = pipeline.get_results()
-            few_shot_eval_results = filter_results(
-                few_shot_eval_results, list(few_shot_eval_results["results"].keys()))
+                )
+            # Print nicely formatted results
             pprint.pprint(few_shot_eval_results)
         remove_hooks(model)
         if args.checkpoint_name is not None and not args.load_checkpoint:

--- a/tests/brevitas_examples/common.py
+++ b/tests/brevitas_examples/common.py
@@ -70,13 +70,20 @@ def allclose(x, y, rtol, atol) -> bool:
 
 
 def assert_metrics(
-        results: Dict[str, float], exp_metrics: Dict[str, float], atol: float, rtol: float) -> None:
+        results: Dict[str, float],
+        exp_metrics: Dict[str, float],
+        atol: float,
+        rtol: float,
+        strict: bool = True) -> None:
     # Evalute quality metrics
     for metric, value in results.items():
-        if isinstance(value, torch.Tensor):
-            value = value.detach().cpu().numpy()
-        exp_value = exp_metrics[metric]
-        assert allclose(exp_value, value, rtol=rtol, atol=atol), f"Expected {metric} {exp_value}, measured {value}"
+        # If `strict=True`, all metrics in `results` are checked, so an error is raised
+        # whenever there is a `metric` in `results` that is not registered `exp_metrics`
+        if strict or metric in exp_metrics:
+            if isinstance(value, torch.Tensor):
+                value = value.detach().cpu().numpy()
+            exp_value = exp_metrics[metric]
+            assert allclose(exp_value, value, rtol=rtol, atol=atol), f"Expected {metric} {exp_value}, measured {value}"
 
 
 def assert_layer_types(model: Module, exp_layer_types: Dict[str, str]) -> None:

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -385,8 +385,7 @@ def test_parse_yaml_trainer_arguments(caplog, kwargs):
                 "leaderboard|arc:challenge|0|0",
                 "leaderboard|winogrande|0|0",
                 "lighteval|arc:easy|0|0",
-                "leaderboard|hellaswag|0|0",
-                "lighteval|piqa|0|0",],
+                "leaderboard|hellaswag|0|0",],
             "few_shot_zeroshot": True,
             "imports": ["lighteval"],
             "all_acc": 0.375,},])

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -3,6 +3,7 @@
 
 from argparse import ArgumentParser
 from argparse import Namespace
+from contextlib import ExitStack
 import logging
 import os
 import platform
@@ -45,6 +46,9 @@ from tests.marker import requires_pt_ge
 
 ATOL_PPL = 1e+01
 RTOL_PPL = 1e-04
+
+ATOL_ACC = 5e-1
+RTOL_ACC = 1e-5
 
 
 def mock_load_raw_dataset(dataset_name: str, split: str, seed: int = 42) -> Dataset:
@@ -366,3 +370,59 @@ def test_parse_yaml_trainer_arguments(caplog, kwargs):
     with patch("brevitas_examples.llm.main.quantize_llm", quantize_llm_assert_args):
         with patch("brevitas_examples.llm.main.sys.argv", ["main.py", "--config", yaml_file_path]):
             llm_main()
+
+
+@pytest_cases.fixture(
+    ids=["lighteval"],
+    params=[
+        {
+            "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
+            "no_quantize": True,
+            "eval": False,
+            "few_shot_eval": "lighteval",
+            "few_shot_override_batch_size": 16,
+            "few_shot_tasks": [
+                "leaderboard|arc:challenge|0|0",
+                "leaderboard|winogrande|0|0",
+                "lighteval|arc:easy|0|0",
+                "leaderboard|hellaswag|0|0",
+                "lighteval|piqa|0|0",],
+            "few_shot_zeroshot": True,
+            "imports": ["lighteval"],
+            "all_acc": 0.375,},])
+def few_shot_eval_args(default_run_args, request):
+    # Skip cases for which the LM evaluation library has not been installed
+    for lib in request.param["imports"]:
+        pytest.importorskip(lib, reason=f"`{lib}` needs to be installed.")
+    del request.param["imports"]
+
+    yield process_args_and_metrics(
+        default_run_args, request.param, extra_keys=["imports", "all_acc"])
+
+
+@pytest.mark.llm
+def test_few_shot_eval(caplog, few_shot_eval_args, main):
+    caplog.set_level(logging.INFO)
+    args, _, exp_metrics = few_shot_eval_args
+
+    with ExitStack() as ctx_stack:
+        # Patch LM eval calls when needed
+        if args.few_shot_eval == "lighteval":
+            from brevitas_examples.llm.eval_lighteval import run_lighteval
+            max_samples = args.few_shot_override_batch_size
+
+            def mock_run_lighteval(*args, **kwargs):
+                kwargs["max_samples"] = max_samples
+                return run_lighteval(*args, **kwargs)
+
+            # Patch the call to `run_lighteval`
+            ctx_stack.enter_context(
+                patch(
+                    'brevitas_examples.llm.eval_lighteval.run_lighteval',
+                    side_effect=mock_run_lighteval))
+
+        results, _ = main(args)
+
+    # Verify that LM eval metrics match. `strict` is set to False, as
+    # only a subset of metrics are checked.
+    assert_metrics(results, exp_metrics, atol=ATOL_ACC, rtol=RTOL_ACC, strict=False)


### PR DESCRIPTION
## Reason for this PR

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

Refactored integration with `lighteval` Python API to not avoid relying on the custom [fork](https://github.com/Giuseppe5/lighteval) (see https://github.com/huggingface/lighteval/issues/489 for extra context).

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

Refactored the `lighteval` evaluation code out of the LLM entrypoint, using a similar structure to https://github.com/huggingface/lighteval/blob/main/src/lighteval/main_accelerate.py.

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

Added a new end-to-end test in `test_llm` (`test_few_shot_eval`) to evaluate a quantized model in `lighteval`.

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [x] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [x] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [x] 1+ reviews given, and any review issues addressed and approved.
- [x] Post-review full CI/CD passing.
