### PR TITLE
Fix (paper/expand): Avoid skipping baseline experiment

### DIFF
--- a/src/brevitas_examples/papers/expansion/benchmark.py
+++ b/src/brevitas_examples/papers/expansion/benchmark.py
@@ -10,7 +10,7 @@ class ExpansionBenchmark(LLMBenchmarkUtils):
     def validate(args, extra_args=None):
         super(LLMBenchmarkUtils, ExpansionBenchmark).validate(args, extra_args)
         if len(args.rotation_layers_to_expand) == 0:
-            assert args.expansion_step == 1
+            assert args.expansion_step == 7
 
 
 if __name__ == "__main__":

--- a/src/brevitas_examples/papers/expansion/benchmark.py
+++ b/src/brevitas_examples/papers/expansion/benchmark.py
@@ -10,7 +10,9 @@ class ExpansionBenchmark(LLMBenchmarkUtils):
     def validate(args, extra_args=None):
         super(LLMBenchmarkUtils, ExpansionBenchmark).validate(args, extra_args)
         if len(args.rotation_layers_to_expand) == 0:
-            assert args.expansion_step == 7
+            assert args.expansion_step == 0
+        else:
+            assert args.expansion_step != 0
 
 
 if __name__ == "__main__":

--- a/src/brevitas_examples/papers/expansion/double_quarot_star.yaml
+++ b/src/brevitas_examples/papers/expansion/double_quarot_star.yaml
@@ -115,6 +115,7 @@ rotation_layers_to_expand:
 - - 'down_proj'
   - 'o_proj'
 expansion_step:
+- 0
 - 7
 scale_rounding_func_type:
 - null

--- a/src/brevitas_examples/papers/expansion/double_spinquant_star.yaml
+++ b/src/brevitas_examples/papers/expansion/double_spinquant_star.yaml
@@ -129,6 +129,7 @@ rotation_layers_to_expand:
 - - 'down_proj'
   - 'o_proj'
 expansion_step:
+- 0
 - 7
 save_safetensors:
 - false

--- a/src/brevitas_examples/papers/expansion/quarot_star.yaml
+++ b/src/brevitas_examples/papers/expansion/quarot_star.yaml
@@ -114,6 +114,7 @@ rotation_layers_to_expand:
 - []
 - ['down_proj']
 expansion_step:
+- 0
 - 1
 - 3
 - 5

--- a/src/brevitas_examples/papers/expansion/quarot_star_mxfp4.yaml
+++ b/src/brevitas_examples/papers/expansion/quarot_star_mxfp4.yaml
@@ -115,6 +115,7 @@ rotation_layers_to_expand:
 - - 'down_proj'
   - 'o_proj'
 expansion_step:
+- 0
 - 7
 scale_rounding_func_type:
 - null

--- a/src/brevitas_examples/papers/expansion/spinquant_star.yaml
+++ b/src/brevitas_examples/papers/expansion/spinquant_star.yaml
@@ -128,6 +128,7 @@ rotation_layers_to_expand:
 - []
 - ['down_proj']
 expansion_step:
+- 0
 - 1
 - 3
 - 5

--- a/src/brevitas_examples/papers/expansion/spinquant_star_mxfp4.yaml
+++ b/src/brevitas_examples/papers/expansion/spinquant_star_mxfp4.yaml
@@ -129,6 +129,7 @@ rotation_layers_to_expand:
 - - 'down_proj'
   - 'o_proj'
 expansion_step:
+- 0
 - 7
 save_safetensors:
 - false


### PR DESCRIPTION
Minor bugfix. Some configs only contain the `7` option for expansion steps, meaning the baseline experiment is skipped.

Switched to include a `0` option, which runs the baseline only, while the others do the expansion.