### PR TITLE
Fix (nn/bias): propagate runtime_shape from QuantScaleBias

### DIFF
--- a/src/brevitas/nn/quant_scale_bias.py
+++ b/src/brevitas/nn/quant_scale_bias.py
@@ -26,7 +26,8 @@ __all__ = ['ScaleBias', 'QuantScaleBias']
 
 class ScaleBias(Module):
 
-    def __init__(self, num_features: int, bias: bool, runtime_shape: Tuple[int] = (1, -1, 1, 1)):
+    def __init__(
+        self, num_features: int, bias: bool, runtime_shape: Tuple[int, ...] = (1, -1, 1, 1)):
         super(ScaleBias, self).__init__()
         self.num_features = num_features
         self.weight = Parameter(torch.ones(num_features))
@@ -50,7 +51,7 @@ class QuantScaleBias(QuantWBIOL, ScaleBias):
             bias_quant: Optional[BiasQuantType] = None,
             input_quant: Optional[ActQuantType] = None,
             output_quant: Optional[ActQuantType] = None,
-            runtime_shape: Tuple[int] = (1, -1, 1, 1),
+            runtime_shape: Tuple[int, ...] = (1, -1, 1, 1),
             return_quant_tensor: bool = False,
             **kwargs) -> None:
         ScaleBias.__init__(self, num_features, bias, runtime_shape)

--- a/src/brevitas/nn/quant_scale_bias.py
+++ b/src/brevitas/nn/quant_scale_bias.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Optional
+from typing import Tuple
 from typing import Type
 from typing import Union
 
@@ -25,7 +26,7 @@ __all__ = ['ScaleBias', 'QuantScaleBias']
 
 class ScaleBias(Module):
 
-    def __init__(self, num_features: int, bias: bool, runtime_shape=(1, -1, 1, 1)):
+    def __init__(self, num_features: int, bias: bool, runtime_shape: Tuple[int] = (1, -1, 1, 1)):
         super(ScaleBias, self).__init__()
         self.num_features = num_features
         self.weight = Parameter(torch.ones(num_features))
@@ -49,9 +50,10 @@ class QuantScaleBias(QuantWBIOL, ScaleBias):
             bias_quant: Optional[BiasQuantType] = None,
             input_quant: Optional[ActQuantType] = None,
             output_quant: Optional[ActQuantType] = None,
+            runtime_shape: Tuple[int] = (1, -1, 1, 1),
             return_quant_tensor: bool = False,
             **kwargs) -> None:
-        ScaleBias.__init__(self, num_features, bias)
+        ScaleBias.__init__(self, num_features, bias, runtime_shape)
         QuantWBIOL.__init__(
             self,
             weight_quant=weight_quant,

--- a/tests/brevitas/nn/test_wbiol.py
+++ b/tests/brevitas/nn/test_wbiol.py
@@ -12,7 +12,6 @@ from brevitas.nn import QuantConvTranspose1d
 from brevitas.nn import QuantConvTranspose2d
 from brevitas.nn import QuantConvTranspose3d
 from brevitas.nn import QuantLinear
-from brevitas.nn import QuantScaleBias
 from brevitas.nn.quant_layer import QuantWeightBiasInputOutputLayer as QuantWBIOL
 from brevitas.proxy import ActQuantProxyFromInjector
 from brevitas.proxy import BiasQuantProxyFromInjector


### PR DESCRIPTION
## Reason for this PR

Fix for #1384 

## Changes Made in this PR

Propagate runtime_shape from QuantScaleBias to ScaleBias at init time.

## Testing Summary

NA

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
