### PR TITLE
Setup: fix requirements for HF packages

### DIFF
--- a/.github/workflows/examples_llm_pytest.yml
+++ b/.github/workflows/examples_llm_pytest.yml
@@ -16,7 +16,7 @@ jobs:
 
       matrix:
         python_version: ['3.9', '3.10']
-        pytorch_version: ['2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        pytorch_version: ['2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled', 'jit_enabled']
 

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -84,7 +84,7 @@ END_TO_END_EXCLUDE_LIST = generate_exclusion_list([[['platform', [
 MATRIX = od([('python_version', list(PYTHON_VERSIONS)), ('pytorch_version', list(PYTORCH_VERSIONS)),
              ('platform', PLATFORM_LIST)])
 
-EXAMPLES_LLM_PYTEST_PYTORCH_VERSIONS = ('2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1')
+EXAMPLES_LLM_PYTEST_PYTORCH_VERSIONS = ('2.4.1', '2.5.1', '2.6.0', '2.7.1')
 EXAMPLES_LLM_PYTEST_MATRIX = od([('python_version', list(PYTHON_VERSIONS)),
                                  ('pytorch_version', list(EXAMPLES_LLM_PYTEST_PYTORCH_VERSIONS)),
                                  ('platform', PLATFORM_LIST)])

--- a/requirements/requirements-diffusion.txt
+++ b/requirements/requirements-diffusion.txt
@@ -4,4 +4,4 @@ pandas
 torch>=2.2
 torchmetrics[image]
 tqdm
-transformers
+transformers<4.57.0

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -6,6 +6,6 @@ onnx
 onnxruntime<1.21
 optimum[onnxruntime]
 pandas
-torch>=2.3
+torch>=2.4
 tqdm
 transformers[sentencepiece]==4.50.0

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -4,7 +4,7 @@ gguf==0.17.0
 lm_eval
 onnx
 onnxruntime<1.21
-optimum
+optimum[onnxruntime]
 pandas
 torch>=2.3
 tqdm

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -46,11 +46,6 @@ from tests.marker import requires_pt_ge
 ATOL_PPL = 1e+01
 RTOL_PPL = 1e-04
 
-MODEL_PT_VERSION_REQUIREMENTS = {
-    "hf-internal-testing/tiny-random-LlamaForCausalLM": "2.0",
-    "hf-internal-testing/tiny-random-MistralForCausalLM": "2.0",
-    "hf-internal-testing/tiny-random-OPTForCausalLM": "2.4",}
-
 
 def mock_load_raw_dataset(dataset_name: str, split: str, seed: int = 42) -> Dataset:
     assert dataset_name == "c4", f"Expected dataset_name to be c4 but got {dataset_name} instead"
@@ -72,9 +67,6 @@ def validate_args(parser: ArgumentParser, args: Namespace) -> None:
     a, da = parse_args_and_defaults(args, parser)
     for k in a.keys():
         assert k in da.keys(), f"Key {k} does not seem to be a valid argument for `quantize_llm`"
-    req_pt = MODEL_PT_VERSION_REQUIREMENTS[args.model]
-    if torch_version < version.parse(req_pt):
-        pytest.skip(f"{args.model} requires PyTorch version {req_pt}")
     if args.replace_rmsnorm:
         if torch_version < version.parse('2.4'):
             pytest.skip("Replacing RMSNorm requires torch 2.4+ or greater")

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -4,12 +4,10 @@
 import pytest_cases
 
 from tests.brevitas_examples.common import process_args_and_metrics
-from tests.marker import requires_pt_ge
 
 
 class LLMRunCases:
 
-    @requires_pt_ge('2.3')
     @pytest_cases.parametrize(
         "run_dict",
         [
@@ -161,7 +159,6 @@ class LLMPerplexityCases:
     def case_small_models_learned_round_ppl(self, run_dict, default_run_args, request):
         yield process_args_and_metrics(default_run_args, run_dict, extra_keys=LLMPerplexityCases.METRICS)
 
-    @requires_pt_ge('2.4')
     @pytest_cases.parametrize(
         "run_dict",
         [
@@ -526,7 +523,6 @@ class LLMQuantLayerCountCases:
 
 class LLMRotationOptimizationCases:
 
-    @requires_pt_ge('2.4')
     @pytest_cases.parametrize(
         "run_dict",
             [


### PR DESCRIPTION
## Reason for this PR

Our pinned version of diffusers does not work with transformers 4.57 and above, as explained in the following PR:  https://github.com/huggingface/diffusers/pull/12438.

New version of accelerate requires explicit installation of onnxruntime packages.

New version of optimum requires torch 2.4+. See: https://github.com/huggingface/transformers/pull/33177.

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
