### PR TITLE
Fix (requirements): pin `numexpr`

### DIFF
--- a/requirements/requirements-diffusion.txt
+++ b/requirements/requirements-diffusion.txt
@@ -1,5 +1,6 @@
 accelerate
 diffusers<=0.34
+numexpr<2.14.0
 pandas
 torch>=2.2
 torchmetrics[image]

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -2,6 +2,7 @@ accelerate
 datasets
 gguf==0.17.0
 lm_eval
+numexpr<2.14.0
 onnx
 onnxruntime<1.21
 optimum[onnxruntime]

--- a/src/brevitas_examples/stable_diffusion/mlperf_evaluation/requirements.txt
+++ b/src/brevitas_examples/stable_diffusion/mlperf_evaluation/requirements.txt
@@ -1,5 +1,6 @@
 accelerate==1.0.1
 diffusers==0.30.3
+numexpr<2.14.0
 open-clip-torch==2.26.1
 opencv-python==4.10.0.84
 pandas==2.2.2


### PR DESCRIPTION
## Reason for this PR

The latest version of `numexpr` (2.4.0) is not compatible with `numpy < 2.0`. See the issue https://github.com/pydata/numexpr/issues/540. This was also observed in our CI pipeline: https://github.com/Xilinx/brevitas/actions/runs/18463399125/job/52599726328?pr=1379.

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

Set `numexpr<2.4.0` in the examples requirements.