### PR TITLE
Setup: deprecate old python and torch versions

### DIFF
--- a/.github/workflows/develop_install.yml
+++ b/.github/workflows/develop_install.yml
@@ -15,8 +15,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
-        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        python_version: ['3.10', '3.11']
+        pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -15,8 +15,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
-        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        python_version: ['3.10', '3.11']
+        pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 

--- a/.github/workflows/examples_diffusion_pytest.yml
+++ b/.github/workflows/examples_diffusion_pytest.yml
@@ -15,7 +15,7 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
+        python_version: ['3.10', '3.11']
         pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled', 'jit_enabled']

--- a/.github/workflows/examples_llm_pytest.yml
+++ b/.github/workflows/examples_llm_pytest.yml
@@ -15,7 +15,7 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
+        python_version: ['3.10', '3.11']
         pytorch_version: ['2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled', 'jit_enabled']

--- a/.github/workflows/examples_pytest.yml
+++ b/.github/workflows/examples_pytest.yml
@@ -15,8 +15,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
-        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        python_version: ['3.10', '3.11']
+        pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled', 'jit_enabled']
 

--- a/.github/workflows/examples_vision_pytest.yml
+++ b/.github/workflows/examples_vision_pytest.yml
@@ -15,8 +15,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
-        pytorch_version: ['2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        python_version: ['3.10', '3.11']
+        pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled', 'jit_enabled']
 

--- a/.github/workflows/finn_integration.yml
+++ b/.github/workflows/finn_integration.yml
@@ -15,8 +15,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
-        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        python_version: ['3.10', '3.11']
+        pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest']
 
 

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -29,9 +29,9 @@ NOTEBOOK_YML = 'notebook.yml'
 ENDTOEND_YML = 'end_to_end.yml'
 
 # Reduced Test for PRs, except when a review is requested
-PYTHON_VERSIONS_REDUCED = ('3.9',)
+PYTHON_VERSIONS_REDUCED = ('3.10',)
 
-PYTORCH_LIST_REDUCED = ["1.13.1", "2.4.1", "2.7.1"]
+PYTORCH_LIST_REDUCED = ['2.2.2', '2.4.1', '2.7.1']
 
 PLATFORM_LIST_REDUCED = ['ubuntu-latest']
 
@@ -59,10 +59,9 @@ PYTEST_MATRIX_EXTRA_REDUCED = od([('jit_status', [
     'jit_disabled',])])
 
 # Data shared betwen Nox sessions and Github Actions, formatted as tuples
-PYTHON_VERSIONS = ('3.9', '3.10')
+PYTHON_VERSIONS = ('3.10', '3.11')
 
-PYTORCH_VERSIONS = (
-    '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1')
+PYTORCH_VERSIONS = ('2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1')
 JIT_STATUSES = ('jit_disabled', 'jit_enabled')
 
 # Data used only by Github Actions, formatted as lists or lists of ordered dicts
@@ -95,8 +94,7 @@ EXAMPLES_DIFFUSION_PYTEST_MATRIX = od([
     ('pytorch_version', list(EXAMPLES_DIFFUSION_PYTEST_PYTORCH_VERSIONS)),
     ('platform', PLATFORM_LIST)])
 
-EXAMPLES_VISION_PYTEST_PYTORCH_VERSIONS = (
-    '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1')
+EXAMPLES_VISION_PYTEST_PYTORCH_VERSIONS = ('2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1')
 EXAMPLES_VISION_PYTEST_MATRIX = od([
     ('python_version', list(PYTHON_VERSIONS)),
     ('pytorch_version', list(EXAMPLES_VISION_PYTEST_PYTORCH_VERSIONS)),

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -15,8 +15,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
-        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        python_version: ['3.10', '3.11']
+        pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 

--- a/.github/workflows/ort_integration.yml
+++ b/.github/workflows/ort_integration.yml
@@ -15,8 +15,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
-        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        python_version: ['3.10', '3.11']
+        pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,8 +15,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10']
-        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
+        python_version: ['3.10', '3.11']
+        pytorch_version: ['2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled', 'jit_enabled']
 

--- a/.github/workflows/reduced_develop_install.yml
+++ b/.github/workflows/reduced_develop_install.yml
@@ -17,8 +17,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
-        pytorch_version: ['1.13.1', '2.4.1', '2.7.1']
+        python_version: ['3.10']
+        pytorch_version: ['2.2.2', '2.4.1', '2.7.1']
         platform: ['ubuntu-latest']
 
 

--- a/.github/workflows/reduced_end_to_end.yml
+++ b/.github/workflows/reduced_end_to_end.yml
@@ -17,8 +17,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
-        pytorch_version: ['1.13.1', '2.4.1', '2.7.1']
+        python_version: ['3.10']
+        pytorch_version: ['2.2.2', '2.4.1', '2.7.1']
         platform: ['ubuntu-latest']
 
 

--- a/.github/workflows/reduced_examples_diffusion_pytest.yml
+++ b/.github/workflows/reduced_examples_diffusion_pytest.yml
@@ -17,7 +17,7 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
+        python_version: ['3.10']
         pytorch_version: ['2.4.1']
         platform: ['ubuntu-latest']
         jit_status: ['jit_disabled']

--- a/.github/workflows/reduced_examples_llm_pytest.yml
+++ b/.github/workflows/reduced_examples_llm_pytest.yml
@@ -17,7 +17,7 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
+        python_version: ['3.10']
         pytorch_version: ['2.4.1']
         platform: ['ubuntu-latest']
         jit_status: ['jit_disabled']

--- a/.github/workflows/reduced_examples_pytest.yml
+++ b/.github/workflows/reduced_examples_pytest.yml
@@ -17,8 +17,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
-        pytorch_version: ['1.13.1', '2.4.1', '2.7.1']
+        python_version: ['3.10']
+        pytorch_version: ['2.2.2', '2.4.1', '2.7.1']
         platform: ['ubuntu-latest']
         jit_status: ['jit_disabled']
 

--- a/.github/workflows/reduced_examples_vision_pytest.yml
+++ b/.github/workflows/reduced_examples_vision_pytest.yml
@@ -17,7 +17,7 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
+        python_version: ['3.10']
         pytorch_version: ['2.4.1']
         platform: ['ubuntu-latest']
         jit_status: ['jit_disabled']

--- a/.github/workflows/reduced_finn_integration.yml
+++ b/.github/workflows/reduced_finn_integration.yml
@@ -17,8 +17,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
-        pytorch_version: ['1.13.1', '2.4.1', '2.7.1']
+        python_version: ['3.10']
+        pytorch_version: ['2.2.2', '2.4.1', '2.7.1']
         platform: ['ubuntu-latest']
 
 

--- a/.github/workflows/reduced_notebook.yml
+++ b/.github/workflows/reduced_notebook.yml
@@ -17,8 +17,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
-        pytorch_version: ['1.13.1', '2.4.1', '2.7.1']
+        python_version: ['3.10']
+        pytorch_version: ['2.2.2', '2.4.1', '2.7.1']
         platform: ['ubuntu-latest']
 
 

--- a/.github/workflows/reduced_ort_integration.yml
+++ b/.github/workflows/reduced_ort_integration.yml
@@ -17,8 +17,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
-        pytorch_version: ['1.13.1', '2.4.1', '2.7.1']
+        python_version: ['3.10']
+        pytorch_version: ['2.2.2', '2.4.1', '2.7.1']
         platform: ['ubuntu-latest']
 
 

--- a/.github/workflows/reduced_pytest.yml
+++ b/.github/workflows/reduced_pytest.yml
@@ -17,8 +17,8 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9']
-        pytorch_version: ['1.13.1', '2.4.1', '2.7.1']
+        python_version: ['3.10']
+        pytorch_version: ['2.2.2', '2.4.1', '2.7.1']
         platform: ['ubuntu-latest']
         jit_status: ['jit_disabled']
 


### PR DESCRIPTION
## Reason for this PR

Python 3.9 has reached end of life, so we will move our tests against python 3.10 and 3.11

The other goal is also to move away from torch <2.2, which will allow us to support better the latest and greatest features of torch, and deprecate some workarounds and exceptions we had to account for until now.

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
