### PR TITLE
Feat (core/stats): signed scaling stats

### DIFF
--- a/src/brevitas/core/function_wrapper/misc.py
+++ b/src/brevitas/core/function_wrapper/misc.py
@@ -118,7 +118,7 @@ class InplaceAbs(torch.nn.Module):
     Examples:
         >>> inplace_abs = InplaceAbs()
         >>> x = torch.tensor(-1.0)
-        >>> inplace_log_two(x)
+        >>> inplace_abs(x)
         >>> x
         tensor(1.)
 

--- a/src/brevitas/core/function_wrapper/misc.py
+++ b/src/brevitas/core/function_wrapper/misc.py
@@ -109,3 +109,27 @@ class InplaceLogTwo(torch.nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x.log2_()
         return x
+
+
+class InplaceAbs(torch.nn.Module):
+    """
+    Module wrapper for :func:`~torch.abs_`.
+
+    Examples:
+        >>> inplace_abs = InplaceAbs()
+        >>> x = torch.tensor(-1.0)
+        >>> inplace_log_two(x)
+        >>> x
+        tensor(1.)
+
+    Notes:
+        Inplace operations in TorchScript can be problematic, compilation is disabled.
+    """
+
+    def __init__(self) -> None:
+        super(InplaceAbs, self).__init__()
+
+    @torch.jit.ignore
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x.abs_()
+        return x

--- a/src/brevitas/core/function_wrapper/misc.py
+++ b/src/brevitas/core/function_wrapper/misc.py
@@ -29,6 +29,30 @@ class Abs(brevitas.jit.ScriptModule):
         return torch.abs(x)
 
 
+class InplaceAbs(torch.nn.Module):
+    """
+    Module wrapper for :func:`~torch.abs_`.
+
+    Examples:
+        >>> inplace_abs = InplaceAbs()
+        >>> x = torch.tensor(-1.0)
+        >>> inplace_abs(x)
+        >>> x
+        tensor(1.)
+
+    Notes:
+        Inplace operations in TorchScript can be problematic, compilation is disabled.
+    """
+
+    def __init__(self) -> None:
+        super(InplaceAbs, self).__init__()
+
+    @torch.jit.ignore
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x.abs_()
+        return x
+
+
 class Identity(brevitas.jit.ScriptModule):
     """
     Identity ScriptModule.
@@ -108,28 +132,4 @@ class InplaceLogTwo(torch.nn.Module):
     @torch.jit.ignore
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x.log2_()
-        return x
-
-
-class InplaceAbs(torch.nn.Module):
-    """
-    Module wrapper for :func:`~torch.abs_`.
-
-    Examples:
-        >>> inplace_abs = InplaceAbs()
-        >>> x = torch.tensor(-1.0)
-        >>> inplace_abs(x)
-        >>> x
-        tensor(1.)
-
-    Notes:
-        Inplace operations in TorchScript can be problematic, compilation is disabled.
-    """
-
-    def __init__(self) -> None:
-        super(InplaceAbs, self).__init__()
-
-    @torch.jit.ignore
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x.abs_()
         return x

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -103,10 +103,10 @@ class FloatRestrictValue(brevitas.jit.ScriptModule):
         return x
 
 
-class SignedRestrictValue(brevitas.jit.ScriptModule):
+class SignedFloatRestrictValue(brevitas.jit.ScriptModule):
 
     def __init__(self) -> None:
-        super(SignedRestrictValue, self).__init__()
+        super(SignedFloatRestrictValue, self).__init__()
 
     def restrict_init_float(self, x: float) -> float:
         return x

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -81,8 +81,32 @@ class _ClampValue(brevitas.jit.ScriptModule):
 
 class FloatRestrictValue(brevitas.jit.ScriptModule):
 
-    def __init__(self) -> None:
+    def __init__(self):
         super(FloatRestrictValue, self).__init__()
+        self.apply_abs: Module = Abs()
+
+    def restrict_init_float(self, x: float):
+        return math.abs(x)
+
+    def restrict_init_tensor(self, x: Tensor):
+        return torch.abs(x)
+
+    def restrict_init_module(self):
+        return Abs()
+
+    def restrict_init_inplace_module(self):
+        return InplaceAbs()
+
+    @brevitas.jit.script_method
+    def forward(self, x: Tensor):
+        x = self.apply_abs(x)
+        return x
+
+
+class SignedRestrictValue(brevitas.jit.ScriptModule):
+
+    def __init__(self) -> None:
+        super(SignedRestrictValue, self).__init__()
 
     def restrict_init_float(self, x: float) -> float:
         return x
@@ -211,27 +235,3 @@ class QuantRestrictValue(brevitas.jit.ScriptModule):
             o = o.view(self.scale_dequantized_shape)
 
         return o
-
-
-class PositiveFloatRestrictValue(brevitas.jit.ScriptModule):
-
-    def __init__(self):
-        super(PositiveFloatRestrictValue, self).__init__()
-        self.apply_abs: Module = Abs()
-
-    def restrict_init_float(self, x: float):
-        return math.abs(x)
-
-    def restrict_init_tensor(self, x: Tensor):
-        return torch.abs(x)
-
-    def restrict_init_module(self):
-        return Abs()
-
-    def restrict_init_inplace_module(self):
-        return InplaceAbs()
-
-    @brevitas.jit.script_method
-    def forward(self, x: Tensor):
-        x = self.apply_abs(x)
-        return x

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -2,17 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math
-from typing import Callable
 from typing import Optional
 from typing import Tuple
-from typing import Union
 
 import torch
 from torch import Tensor
 from torch.nn import Module
 
 import brevitas
-from brevitas.core.function_wrapper import Abs
 from brevitas.core.function_wrapper import Identity
 from brevitas.core.function_wrapper import InplaceLogTwo
 from brevitas.core.function_wrapper import LogTwo
@@ -31,8 +28,7 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
     def __init__(
             self,
             scaling_min_val: Optional[float] = None,
-            restrict_value_impl: Optional[Module] = None,
-            is_unsigned=True):
+            restrict_value_impl: Optional[Module] = None):
         super(_RestrictClampValue, self).__init__()
         if scaling_min_val is not None and scaling_min_val != 0:
             self.clamp_min_ste = ScalarSignedClampMinSte(scaling_min_val)
@@ -78,21 +74,6 @@ class _ClampValue(brevitas.jit.ScriptModule):
     @brevitas.jit.script_method
     def forward(self, x: Tensor):
         x = self.clamp_min_ste(x)
-        return x
-
-
-class _AbsValue(brevitas.jit.ScriptModule):
-
-    def __init__(self, is_unsigned: bool = True):
-        super(_AbsValue, self).__init__()
-        if is_unsigned:
-            self.apply_abs = Abs()
-        else:
-            self.apply_abs = Identity()
-
-    @brevitas.jit.script_method
-    def forward(self, x: Tensor):
-        x = self.apply_abs(x)
         return x
 
 

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -16,6 +16,8 @@ from brevitas.core.function_wrapper import LogTwo
 from brevitas.core.function_wrapper import PowerOfTwo
 from brevitas.core.function_wrapper import RoundSte
 from brevitas.core.function_wrapper import ScalarSignedClampMinSte
+from brevitas.core.function_wrapper.misc import Abs
+from brevitas.core.function_wrapper.misc import InplaceAbs
 from brevitas.inject.enum import FloatToIntImplType  # retrocompatibility
 from brevitas.inject.enum import RestrictValueType
 
@@ -209,3 +211,27 @@ class QuantRestrictValue(brevitas.jit.ScriptModule):
             o = o.view(self.scale_dequantized_shape)
 
         return o
+
+
+class PositiveFloatRestrictValue(brevitas.jit.ScriptModule):
+
+    def __init__(self):
+        super(PositiveFloatRestrictValue, self).__init__()
+        self.apply_abs: Module = Abs()
+
+    def restrict_init_float(self, x: float):
+        return math.abs(x)
+
+    def restrict_init_tensor(self, x: Tensor):
+        return torch.abs(x)
+
+    def restrict_init_module(self):
+        return Abs()
+
+    def restrict_init_inplace_module(self):
+        return InplaceAbs()
+
+    @brevitas.jit.script_method
+    def forward(self, x: Tensor):
+        x = self.apply_abs(x)
+        return x

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -86,7 +86,7 @@ class FloatRestrictValue(brevitas.jit.ScriptModule):
         self.apply_abs: Module = Abs()
 
     def restrict_init_float(self, x: float):
-        return math.abs(x)
+        return math.fabs(x)
 
     def restrict_init_tensor(self, x: Tensor):
         return torch.abs(x)

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -43,16 +43,10 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
         else:
             self.restrict_value_impl = Identity()
 
-        if is_unsigned:
-            self.apply_abs = Abs()
-        else:
-            self.apply_abs = Identity()
-
     @brevitas.jit.script_method
     def forward(self, x: Tensor):
         x = self.restrict_value_impl(x)
         x = self.clamp_min_ste(x)
-        x = self.apply_abs(x)
         return x
 
 

--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -22,9 +22,6 @@ from brevitas.core.utils import ParameterWrapper
 from brevitas.core.utils import StatelessBuffer
 
 
-# TODO (pml): Why is not is_scale_unsigned in __init__?
-# The dependency injector yields the following error when adding it:
-#  _dependencies.exceptions.DependencyError: 'is_scale_unsigned' is a circular dependency in the 'StatsFromParameterScaling' constructor
 class StatsFromParameterScaling(brevitas.jit.ScriptModule):
 
     def __init__(

--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -12,6 +12,7 @@ from torch.nn import Parameter
 import brevitas
 import brevitas.config as config
 from brevitas.core.function_wrapper import Identity
+from brevitas.core.restrict_val import _AbsValue
 from brevitas.core.restrict_val import _ClampValue
 from brevitas.core.restrict_val import _RestrictClampValue
 from brevitas.core.restrict_val import FloatRestrictValue
@@ -107,15 +108,15 @@ class _StatsScaling(brevitas.jit.ScriptModule):
                 device)
         else:
             self.affine_rescaling = Identity()
-        self.restrict_clamp_scaling = _RestrictClampValue(
-            scaling_min_val, restrict_scaling_impl, is_scale_unsigned)
+        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_clamp_scale_threshold = _RestrictClampValue(
-            restrict_value_impl=restrict_scale_threshold_impl, is_unsigned=is_scale_unsigned)
+            restrict_value_impl=restrict_scale_threshold_impl)
         self.restrict_scaling_pre = restrict_scaling_impl.restrict_init_module()
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
         self.clamp_scaling = _ClampValue(scaling_min_val)
+        self.apply_abs = _AbsValue(is_unsigned=is_scale_unsigned)
 
     @brevitas.jit.script_method
     def forward(
@@ -126,6 +127,7 @@ class _StatsScaling(brevitas.jit.ScriptModule):
         threshold = self.restrict_clamp_threshold(threshold)
         # Clamping avoids eventual log(0) with restrict_val
         stats = self.clamp_scaling(stats)
+        stats = self.apply_abs(stats)
         stats = self.restrict_scaling_pre(stats)
         stats = self.affine_rescaling(stats)
         stats = self.restrict_clamp_scaling(stats)

--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -12,7 +12,6 @@ from torch.nn import Parameter
 import brevitas
 import brevitas.config as config
 from brevitas.core.function_wrapper import Identity
-from brevitas.core.restrict_val import _AbsValue
 from brevitas.core.restrict_val import _ClampValue
 from brevitas.core.restrict_val import _RestrictClampValue
 from brevitas.core.restrict_val import FloatRestrictValue
@@ -91,8 +90,7 @@ class _StatsScaling(brevitas.jit.ScriptModule):
             scaling_affine_shifting_init: Optional[float],
             dtype: Optional[torch.dtype],
             device: Optional[torch.device],
-            restrict_scale_threshold_impl: Optional[Module] = None,
-            is_scale_unsigned: bool = True) -> None:
+            restrict_scale_threshold_impl: Optional[Module] = None) -> None:
         super(_StatsScaling, self).__init__()
         _affine_rescaling = scaling_affine_rescaling_init is not None
         _affine_shift_scale = scaling_affine_shifting_init is not None
@@ -116,7 +114,6 @@ class _StatsScaling(brevitas.jit.ScriptModule):
         self.restrict_scaling_pre = restrict_scaling_impl.restrict_init_module()
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
         self.clamp_scaling = _ClampValue(scaling_min_val)
-        self.apply_abs = _AbsValue(is_unsigned=is_scale_unsigned)
 
     @brevitas.jit.script_method
     def forward(
@@ -127,7 +124,6 @@ class _StatsScaling(brevitas.jit.ScriptModule):
         threshold = self.restrict_clamp_threshold(threshold)
         # Clamping avoids eventual log(0) with restrict_val
         stats = self.clamp_scaling(stats)
-        stats = self.apply_abs(stats)
         stats = self.restrict_scaling_pre(stats)
         stats = self.affine_rescaling(stats)
         stats = self.restrict_clamp_scaling(stats)
@@ -142,7 +138,6 @@ class RuntimeStatsScaling(brevitas.jit.ScriptModule):
             scaling_stats_impl: Module,
             scaling_stats_input_view_shape_impl: Module,
             scaling_shape: Tuple[int, ...],
-            is_scale_unsigned: bool = True,
             scaling_affine_rescaling_init: Optional[float] = None,
             scaling_affine_shifting_init: Optional[float] = None,
             restrict_scaling_impl: Module = FloatRestrictValue(),
@@ -174,8 +169,7 @@ class RuntimeStatsScaling(brevitas.jit.ScriptModule):
             scaling_affine_rescaling_init=scaling_affine_rescaling_init,
             scaling_affine_shifting_init=scaling_affine_shifting_init,
             dtype=dtype,
-            device=device,
-            is_scale_unsigned=is_scale_unsigned)
+            device=device)
 
     @brevitas.jit.script_method
     def forward(self, x: torch.Tensor, threshold: Optional[torch.Tensor] = None) -> torch.Tensor:
@@ -230,8 +224,7 @@ class RuntimeDynamicGroupStatsScaling(brevitas.jit.ScriptModule):
             scaling_min_val: Optional[float],
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
-            restrict_scale_threshold_impl: Optional[Module] = None,
-            is_scale_unsigned: bool = True) -> None:
+            restrict_scale_threshold_impl: Optional[Module] = None) -> None:
         super(RuntimeDynamicGroupStatsScaling, self).__init__()
 
         # Ensure retro-compatibility with shared threshold/scaling restrict
@@ -243,12 +236,11 @@ class RuntimeDynamicGroupStatsScaling(brevitas.jit.ScriptModule):
         self.scaling_stats_impl = scaling_stats_impl
         self.scaling_min_val = scaling_min_val
         self.input_view_impl = input_view_impl
-        self.restrict_clamp_scaling = _RestrictClampValue(
-            scaling_min_val, restrict_scaling_impl, is_scale_unsigned)
+        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_clamp_scale_threshold = _RestrictClampValue(
-            restrict_value_impl=restrict_scale_threshold_impl, is_unsigned=is_scale_unsigned)
+            restrict_value_impl=restrict_scale_threshold_impl)
         self.restrict_scaling_pre = self.restrict_clamp_scaling.restrict_value_impl.restrict_init_module(
         )
         self.restrict_threshold_pre = self.restrict_clamp_threshold.restrict_value_impl.restrict_init_module(

--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -22,6 +22,9 @@ from brevitas.core.utils import ParameterWrapper
 from brevitas.core.utils import StatelessBuffer
 
 
+# TODO (pml): Why is not is_scale_unsigned in __init__?
+# The dependency injector yields the following error when adding it:
+#  _dependencies.exceptions.DependencyError: 'is_scale_unsigned' is a circular dependency in the 'StatsFromParameterScaling' constructor
 class StatsFromParameterScaling(brevitas.jit.ScriptModule):
 
     def __init__(

--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -13,10 +13,8 @@ from torch.nn import Parameter
 
 import brevitas
 import brevitas.config as config
-from brevitas.core.function_wrapper import Identity
 from brevitas.core.function_wrapper import OverBatchOverTensorView
 from brevitas.core.function_wrapper import TensorClamp
-from brevitas.core.restrict_val import _AbsValue
 from brevitas.core.restrict_val import _ClampValue
 from brevitas.core.restrict_val import _RestrictClampValue
 from brevitas.core.restrict_val import _RestrictValue
@@ -37,7 +35,6 @@ class ConstScaling(brevitas.jit.ScriptModule):
 
     Args:
         scaling_init (Union[float, Tensor]): value to initialize the constant scale factor.
-        is_scale_unsigned (bool): Whether the scale is unsigned. Default: True.
         restrict_scaling_impl (Module): restrict the scale factor according to some criteria. Default: FloatRestrictValue().
         restrict_threshold_impl (Optional[Module]): restrict the threshold according to some criteria. Default: None.
         restrict_scale_threshold_impl (Optional[Module]): restrict value of scale / threshold according to some criteria. Default: None.
@@ -70,7 +67,6 @@ class ConstScaling(brevitas.jit.ScriptModule):
     def __init__(
             self,
             scaling_init: Union[float, Tensor],
-            is_scale_unsigned: bool = True,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
             restrict_scale_threshold_impl: Optional[Module] = None,
@@ -83,12 +79,11 @@ class ConstScaling(brevitas.jit.ScriptModule):
         if restrict_threshold_impl is None:
             restrict_threshold_impl = restrict_scaling_impl
 
-        self.restrict_clamp_scaling = _RestrictClampValue(
-            scaling_min_val, restrict_scaling_impl, is_scale_unsigned)
+        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_clamp_scale_threshold = _RestrictClampValue(
-            restrict_value_impl=restrict_scale_threshold_impl, is_unsigned=is_scale_unsigned)
+            restrict_value_impl=restrict_scale_threshold_impl)
         if isinstance(scaling_init, Tensor):
             scaling_init = scaling_init.to(device=device, dtype=dtype)
             scaling_init = restrict_scaling_impl.restrict_init_tensor(scaling_init)
@@ -116,7 +111,6 @@ class ParameterScaling(brevitas.jit.ScriptModule):
 
     Args:
         scaling_init (Union[float, Tensor]): Value to initialize the learned scale factor.
-        is_scale_unsigned (bool): Whether the scale is unsigned. Default: True.
         scaling_shape (Optional[Tuple[int, ...]]): Shape of the learned scale factor. Default: None.
         restrict_scaling_impl (Module): Restrict the scale factor according to some criteria. Default: FloatRestrictValue().
         restrict_threshold_impl (Optional[Module]): Restrict the threshold according to some criteria. Default: None.
@@ -158,7 +152,6 @@ class ParameterScaling(brevitas.jit.ScriptModule):
     def __init__(
             self,
             scaling_init: Union[float, Tensor],
-            is_scale_unsigned: bool = True,
             scaling_shape: Optional[Tuple[int, ...]] = None,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
@@ -187,13 +180,12 @@ class ParameterScaling(brevitas.jit.ScriptModule):
         if scaling_init.shape == SCALAR_SHAPE and scaling_shape is not None:
             scaling_init = torch.full(scaling_shape, scaling_init, dtype=dtype, device=device)
         self.value = Parameter(scaling_init)
-        self.restrict_clamp_scaling = _RestrictClampValue(
-            scaling_min_val, restrict_scaling_impl, is_scale_unsigned)
+        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
         self.restrict_clamp_scale_threshold = _RestrictClampValue(
-            restrict_value_impl=restrict_scale_threshold_impl, is_unsigned=is_scale_unsigned)
+            restrict_value_impl=restrict_scale_threshold_impl)
 
     @brevitas.jit.script_method
     def forward(self, placeholder: Tensor, threshold: Optional[Tensor] = None) -> Tensor:
@@ -230,7 +222,6 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
         scaling_stats_input_concat_dim (int): Dimension along which to concatenate parameter tensors for statistics computation.
         tracked_parameter_list (List[torch.nn.Parameter]): List of parameters to track and compute statistics over.
         scaling_shape (Tuple[int, ...]): Shape of the learned scale factor.
-        is_scale_unsigned (bool): Whether the scale is unsigned. Default: True.
         force_parameter (bool): If True, always use a tracked_parameter_list for statistics, even if only one is tracked. Default: False.
         restrict_scaling_impl (Module): Restrict the scale factor according to some criteria. Default: FloatRestrictValue().
         restrict_threshold_impl (Optional[Module]): Restrict the threshold according to some criteria. Default: None.
@@ -271,7 +262,6 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
             scaling_stats_input_concat_dim: int,
             tracked_parameter_list: List[torch.nn.Parameter],
             scaling_shape: Tuple[int, ...],
-            is_scale_unsigned: bool = True,
             force_parameter: bool = False,
             restrict_scaling_impl: Module = FloatRestrictValue(),
             restrict_threshold_impl: Optional[Module] = None,
@@ -303,8 +293,7 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
             scaling_affine_rescaling_init=scaling_affine_rescaling_init,
             scaling_affine_shifting_init=scaling_affine_shifting_init,
             dtype=dtype,
-            device=device,
-            is_scale_unsigned=is_scale_unsigned)
+            device=device)
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
         self.restrict_inplace_scaling_pre = restrict_scaling_impl.restrict_init_inplace_module()
         self.clamp_scaling = _ClampValue(scaling_min_val)
@@ -377,7 +366,6 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
     Args:
         collect_stats_steps (int): Number of calls to the forward method in training mode to collect statistics for.
         scaling_stats_impl (Module): Implementation of the statistics computed during the collection phase.
-        is_scale_unsigned (bool, optional): Whether the scale is unsigned. Default: True.
         scaling_stats_input_view_shape_impl (Module, optional): Implementation of the view applied to the runtime
             input during the statistics collection phase. Default: OverBatchOverTensorView().
         scaling_shape (Tuple[int, ...], optional): Shape of the torch.nn.Parameter used in the second phase. Default: SCALAR_SHAPE.
@@ -420,7 +408,6 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
             self,
             collect_stats_steps: int,
             scaling_stats_impl: Module,
-            is_scale_unsigned: bool = True,
             scaling_stats_input_view_shape_impl: Module = OverBatchOverTensorView(),
             scaling_shape: Tuple[int, ...] = SCALAR_SHAPE,
             restrict_scaling_impl: Module = FloatRestrictValue(),
@@ -445,7 +432,6 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
             scaling_stats_momentum, Optional[float])
         self.register_buffer('buffer', torch.full(scaling_shape, 1.0, dtype=dtype, device=device))
         self.value = Parameter(torch.full(scaling_shape, 1.0, dtype=dtype, device=device))
-        self.abs_value = _AbsValue(is_unsigned=is_scale_unsigned)
         self.restrict_scaling = _RestrictValue(restrict_scaling_impl)
         self.restrict_threshold = _RestrictValue(restrict_threshold_impl)
         self.restrict_scale_threshold = _RestrictValue(restrict_scale_threshold_impl)
@@ -510,7 +496,6 @@ class ParameterFromRuntimeStatsScaling(brevitas.jit.ScriptModule):
                 out = self.value
             threshold = self.restrict_threshold(self.restrict_threshold_pre(threshold))
             out = self.restrict_scaling(out)
-            out = self.abs_value(out)
             out = self.restrict_scale_threshold(out / threshold)
             # We can clamp after restrict val since the learned parameter is already in log-domain
             out = self.clamp_scaling(out)

--- a/src/brevitas/core/stats/__init__.py
+++ b/src/brevitas/core/stats/__init__.py
@@ -19,6 +19,7 @@ from .stats_op import MSE
 from .stats_op import NegativeMinOrZero
 from .stats_op import NegativePercentileOrZero
 from .stats_op import PercentileInterval
+from .stats_op import SignedAbsMax
 from .stats_wrapper import _ParameterListStats
 from .stats_wrapper import _RuntimeStats
 from .stats_wrapper import _Stats

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -24,11 +24,7 @@ from .stats_wrapper import SCALAR_SHAPE
 
 DEFAULT_STD_DEV_EPSILON = 1e-8
 
-# When restricting scales to powers of two, signed statistics cannot be used because
-# taking the logarithm of a negative number would result a in NaN. To avoid this issue,
-# the signedness of the statistic must be tracked. This allows raising an error at
-# dependency-injection time if a signed statistic is combined with a power-of-two
-# scale restriction.
+# The signedness of the statistics needs to be tracked to be used in subsequent checks
 SIGNEDNESS_STATS = {}
 
 

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from functools import partial
 import math
 from typing import Optional
 from typing import Tuple
-from typing import Type
 
 import torch
 from torch import Tensor
@@ -624,7 +624,7 @@ class MSE(torch.nn.Module):
         x_view = self.input_view_shape_impl(x)
         init = torch.abs(self.mse_init_op(x_view)).detach()
         base = init / self.num
-        loss_fn = lambda candidate: self.evaluate_loss(x, candidate)
+        loss_fn = partial(self.evaluate_loss, x)
         best_candidate, best_loss = self._mse_search(xl=base, xr=init, loss_fn=loss_fn, num_iter=self.num if self.restrict_scale_positive else self.num // 2)
         if not self.restrict_scale_positive:
             best_neg_candidate, best_neg_loss = self._mse_search(

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -571,7 +571,7 @@ class MSE(torch.nn.Module):
             stats_reduce_dim: Optional[int] = None,
             mse_search_method: str = 'fibonacci',
             mse_iters: int = 20,
-            is_scale_unsigned: bool = True):
+            restrict_scale_positive: bool = True):
         super(MSE, self).__init__()
         self.mse_init_op = mse_init_op
         self.input_view_shape_impl = inner_stats_input_view_shape_impl
@@ -588,7 +588,7 @@ class MSE(torch.nn.Module):
         self.search_method = mse_search_method
         self.stats_reduce_dim = stats_reduce_dim
         self.local_loss_mode: bool = False
-        self.is_scale_unsigned = is_scale_unsigned
+        self.restrict_scale_positive = restrict_scale_positive
 
     def mse_loss_fn(self, x, quant_value):
         loss = torch.nn.functional.mse_loss(x, quant_value, reduction='none')
@@ -625,8 +625,8 @@ class MSE(torch.nn.Module):
         init = torch.abs(self.mse_init_op(x_view)).detach()
         base = init / self.num
         loss_fn = lambda candidate: self.evaluate_loss(x, candidate)
-        best_candidate, best_loss = self._mse_search(xl=base, xr=init, loss_fn=loss_fn, num_iter=self.num if self.is_scale_unsigned else self.num // 2)
-        if not self.is_scale_unsigned:
+        best_candidate, best_loss = self._mse_search(xl=base, xr=init, loss_fn=loss_fn, num_iter=self.num if self.restrict_scale_positive else self.num // 2)
+        if not self.restrict_scale_positive:
             best_neg_candidate, best_neg_loss = self._mse_search(
                 xl=-init,
                 xr=-base,

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -24,6 +24,11 @@ from .stats_wrapper import SCALAR_SHAPE
 
 DEFAULT_STD_DEV_EPSILON = 1e-8
 
+# When restricting scales to powers of two, signed statistics cannot be used because
+# taking the logarithm of a negative number would result a in NaN. To avoid this issue,
+# the signedness of the statistic must be tracked. This allows raising an error at
+# dependency-injection time if a signed statistic is combined with a power-of-two
+# scale restriction.
 SIGNEDNESS_STATS = {}
 
 

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from abc import ABCMeta
 import math
 from typing import Optional
 from typing import Tuple
+from typing import Type
 
 import torch
 from torch import Tensor
@@ -25,18 +25,24 @@ from .stats_wrapper import SCALAR_SHAPE
 DEFAULT_STD_DEV_EPSILON = 1e-8
 
 
-class UnsignedScaleStat():
-
-    @property
-    def is_scale_unsigned(self):
-        return True
+class UnsignedScaleStat:
+    is_scale_unsigned = True
 
 
-class SignedScaleStat():
+class SignedScaleStat:
+    is_scale_unsigned = False
 
-    @property
-    def is_scale_unsigned(self):
-        return False
+
+def wrap_signed_stat(stat_cls: Type) -> Type:
+
+    class SignedStatWrapper(stat_cls):
+        is_scale_unsigned = True
+
+        @brevitas.jit.script_method
+        def forward(self, x: Tensor) -> Tensor:
+            return torch.abs(super().forward(x))
+
+    return SignedStatWrapper
 
 
 class NegativeMinOrZero(brevitas.jit.ScriptModule):

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -24,18 +24,23 @@ from .stats_wrapper import SCALAR_SHAPE
 
 DEFAULT_STD_DEV_EPSILON = 1e-8
 
-
-def wrap_signed_stat(stat_cls: Type) -> Type:
-
-    class SignedStatWrapper(stat_cls):
-
-        @brevitas.jit.script_method
-        def forward(self, x: Tensor) -> Tensor:
-            return torch.abs(super().forward(x))
-
-    return SignedStatWrapper
+SIGNEDNESS_STATS = {}
 
 
+def register_stats_implementation(signed: bool = False):
+    """
+    Decorator to register a stats implementation class.
+    :param signed: Indicates if the implementation returns signed values.
+    """
+
+    def decorator(cls):
+        SIGNEDNESS_STATS[cls] = signed
+        return cls
+
+    return decorator
+
+
+@register_stats_implementation(signed=False)
 class NegativeMinOrZero(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim', 'keepdim']
 
@@ -60,6 +65,7 @@ class NegativeMinOrZero(brevitas.jit.ScriptModule):
         return min_val
 
 
+@register_stats_implementation(signed=False)
 class AbsPercentile(brevitas.jit.ScriptModule):
     __constants__ = ['q', 'stats_reduce_dim', 'keepdim']
 
@@ -94,6 +100,7 @@ class AbsPercentile(brevitas.jit.ScriptModule):
         return result
 
 
+@register_stats_implementation(signed=False)
 class NegativePercentileOrZero(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim', 'q', 'keepdim']
 
@@ -128,6 +135,7 @@ class NegativePercentileOrZero(brevitas.jit.ScriptModule):
         return result
 
 
+@register_stats_implementation(signed=False)
 class PercentileInterval(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim', 'low_q', 'high_q', 'keepdim']
 
@@ -171,6 +179,7 @@ class PercentileInterval(brevitas.jit.ScriptModule):
         return abs_interval
 
 
+@register_stats_implementation(signed=False)
 class AbsMax(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
@@ -187,6 +196,7 @@ class AbsMax(brevitas.jit.ScriptModule):
             return torch.max(torch.abs(x), dim=self.stats_reduce_dim, keepdim=self.keepdim)[0]
 
 
+@register_stats_implementation(signed=True)
 class SignedAbsMax(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
@@ -207,6 +217,7 @@ class SignedAbsMax(brevitas.jit.ScriptModule):
             return scale if self.keepdim else scale.squeeze(dim=self.stats_reduce_dim)
 
 
+@register_stats_implementation(signed=False)
 class AbsMinMax(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim', 'keepdim']
 
@@ -234,6 +245,7 @@ class AbsMinMax(brevitas.jit.ScriptModule):
         return torch.abs(max_val - min_val)
 
 
+@register_stats_implementation(signed=False)
 class AbsMaxAve(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
@@ -246,6 +258,7 @@ class AbsMaxAve(brevitas.jit.ScriptModule):
         return torch.mean(torch.max(torch.abs(x), dim=self.stats_reduce_dim)[0])
 
 
+@register_stats_implementation(signed=False)
 class AbsMaxL2(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
@@ -261,6 +274,7 @@ class AbsMaxL2(brevitas.jit.ScriptModule):
         return out
 
 
+@register_stats_implementation(signed=False)
 class AbsAve(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
@@ -276,6 +290,7 @@ class AbsAve(brevitas.jit.ScriptModule):
             return torch.mean(torch.abs(x), dim=self.stats_reduce_dim)
 
 
+@register_stats_implementation(signed=False)
 class MeanSigmaStd(brevitas.jit.ScriptModule):
 
     def __init__(
@@ -296,6 +311,7 @@ class MeanSigmaStd(brevitas.jit.ScriptModule):
         return out
 
 
+@register_stats_implementation(signed=False)
 class _MeanSigmaStdImpl(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim', 'output_shape', 'epsilon']
 
@@ -321,6 +337,7 @@ class _MeanSigmaStdImpl(brevitas.jit.ScriptModule):
         return mean_val + sigma * std_val
 
 
+@register_stats_implementation(signed=False)
 class MeanLearnedSigmaStd(brevitas.jit.ScriptModule):
 
     def __init__(
@@ -359,6 +376,7 @@ class MeanLearnedSigmaStd(brevitas.jit.ScriptModule):
             missing_keys.remove(sigma_key)
 
 
+@register_stats_implementation(signed=False)
 class KLMinimizerThreshold(torch.nn.Module):
     """
     Based on:
@@ -433,6 +451,7 @@ class KLMinimizerThreshold(torch.nn.Module):
         return opt_threshold
 
 
+@register_stats_implementation(signed=False)
 class L1Norm(brevitas.jit.ScriptModule):
     """ScriptModule implementation to collect per-channel L1 normalization stats
     for weight normalization-based quantization."""
@@ -451,6 +470,7 @@ class L1Norm(brevitas.jit.ScriptModule):
             return x.norm(p=1, dim=self.stats_reduce_dim, keepdim=True)
 
 
+@register_stats_implementation(signed=False)
 class L2Norm(brevitas.jit.ScriptModule):
     """ScriptModule implementation to collect per-channel L2 normalization stats
     for weight normalization-based quantization."""

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -504,7 +504,6 @@ def _restore_params(module):
             m.allocate_params(m)
 
 
-# TODO (pml): Add guard to ensure xl <= xr?
 def mse_fib_search(xl, xr, loss_fn, num_iter):
 
     def fib_seq(n):
@@ -532,7 +531,6 @@ def mse_fib_search(xl, xr, loss_fn, num_iter):
     return torch.where(f1 <= f2, x1, x2), torch.min(f1, f2)
 
 
-# TODO (pml): Can we have a torch.no_grad()
 def mse_grid_search(xl, xr, loss_fn, num_iter):
     best_loss = loss_fn(xl)
     best_candidate = xl

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -498,6 +498,46 @@ def _restore_params(module):
             m.allocate_params(m)
 
 
+# TODO (pml): Add guard to ensure xl <= xr?
+def mse_fib_search(xl, xr, loss_fn, num_iter):
+
+    def fib_seq(n):
+        if n <= 0:
+            return [0]
+        seq = [0, 1]
+        while len(seq) <= n:
+            next = seq[-1] + seq[-2]
+            seq.append(next)
+        return seq
+
+    # vectorized variant of
+    # https://indrag49.github.io/Numerical-Optimization/solving-one-dimensional-optimization-problems.html#fibonacci-search-method
+    F = fib_seq(num_iter)
+    L0 = xr - xl
+    Li = (F[num_iter - 2] / F[num_iter]) * L0
+    for i in range(2, num_iter + 1):
+        x1 = torch.where(Li > L0 / 2, xr - Li, xl + Li)
+        x2 = torch.where(Li > L0 / 2, xl + Li, xr - Li)
+        f1, f2 = loss_fn(x1), loss_fn(x2)
+        xr = torch.where(f1 <= f2, x2, xr)
+        xl = torch.where(f1 >= f2, x1, xl)
+        Li = (F[num_iter - i] / F[num_iter - (i - 2)]) * torch.where(f1 != f2, L0, xr - xl)
+        L0 = xr - xl
+    return torch.where(f1 <= f2, x1, x2), torch.min(f1, f2)
+
+
+# TODO (pml): Can we have a torch.no_grad()
+def mse_grid_search(xl, xr, loss_fn, num_iter):
+    best_loss = loss_fn(xl)
+    best_candidate = xl
+    for ts in torch.linspace(1. / (num_iter - 1), 1., num_iter - 1):
+        candidate = (xl + (xr - xl) * ts).detach()
+        loss = loss_fn(candidate)
+        best_candidate = torch.where(loss < best_loss, candidate, best_candidate)
+        best_loss = torch.min(loss, best_loss)
+    return best_candidate, best_loss
+
+
 class MSE(torch.nn.Module):
     # References:
     # https://github.com/cornell-zhang/dnn-quant-ocs/blob/master/distiller/quantization/clip.py
@@ -510,7 +550,8 @@ class MSE(torch.nn.Module):
             inner_stats_input_view_shape_impl: torch.nn.Module,
             stats_reduce_dim: Optional[int] = None,
             mse_search_method: str = 'fibonacci',
-            mse_iters: int = 20):
+            mse_iters: int = 20,
+            is_scale_unsigned: bool = True):
         super(MSE, self).__init__()
         self.mse_init_op = mse_init_op
         self.input_view_shape_impl = inner_stats_input_view_shape_impl
@@ -527,6 +568,7 @@ class MSE(torch.nn.Module):
         self.search_method = mse_search_method
         self.stats_reduce_dim = stats_reduce_dim
         self.local_loss_mode: bool = False
+        self.is_scale_unsigned = is_scale_unsigned
 
     def mse_loss_fn(self, x, quant_value):
         loss = torch.nn.functional.mse_loss(x, quant_value, reduction='none')
@@ -550,52 +592,28 @@ class MSE(torch.nn.Module):
         self.restore_observer_mode()
         return loss
 
-    def mse_grid_search(self, xl, x):
-        best_loss = torch.tensor(float('inf'), device=x.device, dtype=x.dtype)
-        best_candidate = xl
-        for i in range(2, self.num + 1):
-            candidate = (xl * i).detach()
-            loss = self.evaluate_loss(x, candidate)
-            best_candidate = torch.where(loss < best_loss, candidate, best_candidate)
-            best_loss = torch.min(loss, best_loss)
-        return best_candidate
+    def _mse_search(self, xl, xr, loss_fn):
+        if self.search_method == 'grid':
+            return mse_grid_search(xl=xl, xr=xr, loss_fn=loss_fn, num_iter=self.num)
+        elif self.search_method == 'fibonacci':
+            return mse_fib_search(xl=xl, xr=xr, loss_fn=loss_fn, num_iter=self.num)
 
-    def mse_fib_search(self, xl, xr, x):
-
-        def fib_seq(n):
-            if n <= 0:
-                return [0]
-            seq = [0, 1]
-            while len(seq) <= n:
-                next = seq[-1] + seq[-2]
-                seq.append(next)
-            return seq
-
-        # vectorized variant of
-        # https://indrag49.github.io/Numerical-Optimization/solving-one-dimensional-optimization-problems.html#fibonacci-search-method
-        F = fib_seq(self.num)
-        L0 = xr - xl
-        Li = (F[self.num - 2] / F[self.num]) * L0
-        for i in range(2, self.num + 1):
-            x1 = torch.where(Li > L0 / 2, xr - Li, xl + Li)
-            x2 = torch.where(Li > L0 / 2, xl + Li, xr - Li)
-            f1, f2 = self.evaluate_loss(x, x1), self.evaluate_loss(x, x2)
-            xr = torch.where(f1 <= f2, x2, xr)
-            xl = torch.where(f1 >= f2, x1, xl)
-            Li = (F[self.num - i] / F[self.num - (i - 2)]) * torch.where(f1 != f2, L0, xr - xl)
-            L0 = xr - xl
-        return torch.where(f1 <= f2, x1, x2)
+        raise ValueError(f"Search method {self.search_method} not supported.")
 
     def mse_search(self, x):
         x_view = self.input_view_shape_impl(x)
-        init = self.mse_init_op(x_view).detach()
+        init = torch.abs(self.mse_init_op(x_view)).detach()
         base = init / self.num
-        if self.search_method == 'grid':
-            best_candidate = self.mse_grid_search(base, x)
-        elif self.search_method == 'fibonacci':
-            best_candidate = self.mse_fib_search(base, init, x)
-        else:
-            raise ValueError(f"Search method {self.search_method} not supported.")
+        loss_fn = lambda candidate: self.evaluate_loss(x, candidate)
+        best_candidate, best_loss = self._mse_search(xl=base, xr=init, loss_fn=loss_fn)
+        if not self.is_scale_unsigned:
+            best_neg_candidate, best_neg_loss = self._mse_search(
+                xl=-init,
+                xr=-base,
+                loss_fn=loss_fn,
+            )
+            best_candidate = torch.where(
+                best_loss <= best_neg_loss, best_candidate, best_neg_candidate)
         # Save for evaluation by other modules (e.g. zp) invoking local loss mode
         self.internal_candidate = best_candidate
         self.restore_offload_param()

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -596,11 +596,11 @@ class MSE(torch.nn.Module):
         self.restore_observer_mode()
         return loss
 
-    def _mse_search(self, xl, xr, loss_fn):
+    def _mse_search(self, xl, xr, loss_fn, num_iter):
         if self.search_method == 'grid':
-            return mse_grid_search(xl=xl, xr=xr, loss_fn=loss_fn, num_iter=self.num)
+            return mse_grid_search(xl=xl, xr=xr, loss_fn=loss_fn, num_iter=num_iter)
         elif self.search_method == 'fibonacci':
-            return mse_fib_search(xl=xl, xr=xr, loss_fn=loss_fn, num_iter=self.num)
+            return mse_fib_search(xl=xl, xr=xr, loss_fn=loss_fn, num_iter=num_iter)
 
         raise ValueError(f"Search method {self.search_method} not supported.")
 
@@ -609,12 +609,13 @@ class MSE(torch.nn.Module):
         init = torch.abs(self.mse_init_op(x_view)).detach()
         base = init / self.num
         loss_fn = lambda candidate: self.evaluate_loss(x, candidate)
-        best_candidate, best_loss = self._mse_search(xl=base, xr=init, loss_fn=loss_fn)
+        best_candidate, best_loss = self._mse_search(xl=base, xr=init, loss_fn=loss_fn, num_iter=self.num if self.is_scale_unsigned else self.num // 2)
         if not self.is_scale_unsigned:
             best_neg_candidate, best_neg_loss = self._mse_search(
                 xl=-init,
                 xr=-base,
                 loss_fn=loss_fn,
+                num_iter=self.num // 2,
             )
             best_candidate = torch.where(
                 best_loss <= best_neg_loss, best_candidate, best_neg_candidate)

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -27,16 +27,16 @@ DEFAULT_STD_DEV_EPSILON = 1e-8
 
 class UnsignedScaleStat():
 
-    @classmethod
-    def is_scale_unsigned(cls):
-        True
+    @property
+    def is_scale_unsigned(self):
+        return True
 
 
-class SignedScaleStats():
+class SignedScaleStat():
 
-    @classmethod
-    def is_scale_unsigned(cls):
-        False
+    @property
+    def is_scale_unsigned(self):
+        return False
 
 
 class NegativeMinOrZero(brevitas.jit.ScriptModule):
@@ -188,6 +188,26 @@ class AbsMax(brevitas.jit.ScriptModule, UnsignedScaleStat):
             return torch.max(torch.abs(x))
         else:
             return torch.max(torch.abs(x), dim=self.stats_reduce_dim, keepdim=self.keepdim)[0]
+
+
+class SignedAbsMax(brevitas.jit.ScriptModule, SignedScaleStat):
+    __constants__ = ['stats_reduce_dim']
+
+    def __init__(self, stats_reduce_dim: Optional[int] = None, keepdim: bool = False) -> None:
+        super(SignedAbsMax, self).__init__()
+        self.stats_reduce_dim = stats_reduce_dim
+        self.keepdim = keepdim
+
+    @brevitas.jit.script_method
+    def forward(self, x: Tensor):
+        if self.stats_reduce_dim is None:
+            x_abs = torch.abs(x)
+            indices = torch.argmax(x_abs)
+            return -torch.sign(x.view(-1)[indices]) * x_abs.view(-1)[indices]
+        else:
+            values, indices = torch.max(torch.abs(x), dim=self.stats_reduce_dim, keepdim=True)
+            scale = -torch.sign(torch.gather(x, dim=self.stats_reduce_dim, index=indices)) * values
+            return scale if self.keepdim else scale.squeeze(dim=self.stats_reduce_dim)
 
 
 class AbsMinMax(brevitas.jit.ScriptModule, UnsignedScaleStat):

--- a/src/brevitas/core/stats/stats_op.py
+++ b/src/brevitas/core/stats/stats_op.py
@@ -25,18 +25,9 @@ from .stats_wrapper import SCALAR_SHAPE
 DEFAULT_STD_DEV_EPSILON = 1e-8
 
 
-class UnsignedScaleStat:
-    is_scale_unsigned = True
-
-
-class SignedScaleStat:
-    is_scale_unsigned = False
-
-
 def wrap_signed_stat(stat_cls: Type) -> Type:
 
     class SignedStatWrapper(stat_cls):
-        is_scale_unsigned = True
 
         @brevitas.jit.script_method
         def forward(self, x: Tensor) -> Tensor:
@@ -69,7 +60,7 @@ class NegativeMinOrZero(brevitas.jit.ScriptModule):
         return min_val
 
 
-class AbsPercentile(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class AbsPercentile(brevitas.jit.ScriptModule):
     __constants__ = ['q', 'stats_reduce_dim', 'keepdim']
 
     def __init__(
@@ -137,7 +128,7 @@ class NegativePercentileOrZero(brevitas.jit.ScriptModule):
         return result
 
 
-class PercentileInterval(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class PercentileInterval(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim', 'low_q', 'high_q', 'keepdim']
 
     def __init__(
@@ -180,7 +171,7 @@ class PercentileInterval(brevitas.jit.ScriptModule, UnsignedScaleStat):
         return abs_interval
 
 
-class AbsMax(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class AbsMax(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: Optional[int] = None, keepdim: bool = False) -> None:
@@ -196,7 +187,7 @@ class AbsMax(brevitas.jit.ScriptModule, UnsignedScaleStat):
             return torch.max(torch.abs(x), dim=self.stats_reduce_dim, keepdim=self.keepdim)[0]
 
 
-class SignedAbsMax(brevitas.jit.ScriptModule, SignedScaleStat):
+class SignedAbsMax(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: Optional[int] = None, keepdim: bool = False) -> None:
@@ -216,7 +207,7 @@ class SignedAbsMax(brevitas.jit.ScriptModule, SignedScaleStat):
             return scale if self.keepdim else scale.squeeze(dim=self.stats_reduce_dim)
 
 
-class AbsMinMax(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class AbsMinMax(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim', 'keepdim']
 
     def __init__(
@@ -243,7 +234,7 @@ class AbsMinMax(brevitas.jit.ScriptModule, UnsignedScaleStat):
         return torch.abs(max_val - min_val)
 
 
-class AbsMaxAve(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class AbsMaxAve(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: int) -> None:
@@ -255,7 +246,7 @@ class AbsMaxAve(brevitas.jit.ScriptModule, UnsignedScaleStat):
         return torch.mean(torch.max(torch.abs(x), dim=self.stats_reduce_dim)[0])
 
 
-class AbsMaxL2(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class AbsMaxL2(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: int) -> None:
@@ -270,7 +261,7 @@ class AbsMaxL2(brevitas.jit.ScriptModule, UnsignedScaleStat):
         return out
 
 
-class AbsAve(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class AbsAve(brevitas.jit.ScriptModule):
     __constants__ = ['stats_reduce_dim']
 
     def __init__(self, stats_reduce_dim: Optional[int] = None) -> None:
@@ -285,7 +276,7 @@ class AbsAve(brevitas.jit.ScriptModule, UnsignedScaleStat):
             return torch.mean(torch.abs(x), dim=self.stats_reduce_dim)
 
 
-class MeanSigmaStd(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class MeanSigmaStd(brevitas.jit.ScriptModule):
 
     def __init__(
             self,
@@ -330,7 +321,7 @@ class _MeanSigmaStdImpl(brevitas.jit.ScriptModule):
         return mean_val + sigma * std_val
 
 
-class MeanLearnedSigmaStd(brevitas.jit.ScriptModule, UnsignedScaleStat):
+class MeanLearnedSigmaStd(brevitas.jit.ScriptModule):
 
     def __init__(
             self,

--- a/src/brevitas/inject/enum.py
+++ b/src/brevitas/inject/enum.py
@@ -30,6 +30,7 @@ class RestrictValueType(AutoName):
 
     """
     FP = auto()
+    POSITIVE_FP = auto()
     LOG_FP = auto()
     INT = auto()
     POWER_OF_TWO = auto()

--- a/src/brevitas/inject/enum.py
+++ b/src/brevitas/inject/enum.py
@@ -93,6 +93,7 @@ class StatsOp(AutoName):
     # Typically adopted for asymmetric quantization
     MIN_MAX = auto()
     PERCENTILE_INTERVAL = auto()
+    SIGNED_MAX = auto()
 
 
 class TruncScalingImplType(AutoName):

--- a/src/brevitas/inject/enum.py
+++ b/src/brevitas/inject/enum.py
@@ -30,7 +30,7 @@ class RestrictValueType(AutoName):
 
     """
     FP = auto()
-    POSITIVE_FP = auto()
+    SIGNED_FP = auto()
     LOG_FP = auto()
     INT = auto()
     POWER_OF_TWO = auto()

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -512,11 +512,15 @@ class MSESymmetricScaleSubInjector(ExtendedInjector):
     inner_stats_input_view_shape_impl = (this << 1).inner_stats_input_view_shape_impl
     mse_search_method = 'grid'
 
+    @value
+    def is_scale_unsigned():
+        return this.mse_init_op.is_scale_unsigned
+
 
 class MSEAsymmetricScaleSubInjector(ExtendedInjector):
     scaling_per_output = (this << 1).scaling_per_output
     proxy_module = (this << 1).proxy_module
-    mse_init_op = AbsMinMax
+    mse_init_op = AbsMax
     stats_impl = MSE
     stats_reduce_dim = (this << 1).stats_reduce_dim
     device = (this << 1).device
@@ -524,6 +528,10 @@ class MSEAsymmetricScaleSubInjector(ExtendedInjector):
     permute_dims = (this << 1).permute_dims
     inner_stats_input_view_shape_impl = (this << 1).inner_stats_input_view_shape_impl
     mse_search_method = 'grid'
+
+    @value
+    def is_scale_unsigned():
+        return this.mse_init_op.is_scale_unsigned
 
 
 class MSEZeroPointSubInjector(ExtendedInjector):
@@ -562,10 +570,6 @@ class MSEAsymmetricScale(ExtendedInjector):
     def scaling_stats_impl():
         return this.mse_scale.stats_impl
 
-    @value
-    def is_scale_unsigned():
-        return this.mse_scale.mse_init_op.is_scale_unsigned
-
 
 class MSESymmetricScale(ExtendedInjector):
     """
@@ -588,10 +592,6 @@ class MSESymmetricScale(ExtendedInjector):
     @value
     def scaling_stats_impl():
         return this.mse_scale.stats_impl
-
-    @value
-    def is_scale_unsigned():
-        return this.mse_scale.mse_init_op.is_scale_unsigned
 
 
 class MSEZeroPoint(ExtendedInjector):

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -514,7 +514,7 @@ class MSESymmetricScaleSubInjector(ExtendedInjector):
 
     @value
     def is_scale_unsigned():
-        return this.mse_init_op.is_scale_unsigned
+        return (this << 1).is_scale_unsigned
 
 
 class MSEAsymmetricScaleSubInjector(ExtendedInjector):
@@ -531,7 +531,7 @@ class MSEAsymmetricScaleSubInjector(ExtendedInjector):
 
     @value
     def is_scale_unsigned():
-        return this.mse_init_op.is_scale_unsigned
+        return (this << 1).is_scale_unsigned
 
 
 class MSEZeroPointSubInjector(ExtendedInjector):

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -55,7 +55,7 @@ from brevitas.inject.enum import ScalingPerOutputType
 from brevitas.inject.enum import StatsOp
 from brevitas.proxy import DecoupledWeightQuantProxyFromInjector
 from brevitas.proxy import DecoupledWeightQuantWithInputProxyFromInjector
-from brevitas.quant.solver.common import SolveScaleSignedness
+from brevitas.quant.solver.common import SolveRestrictScaleSign
 from brevitas.quant.solver.common import SolveStatsReduceDimFromEnum
 from brevitas.quant.solver.parameter import SolveInputViewImpl
 from brevitas.quant.solver.parameter import SolveParameterScalingShape
@@ -283,7 +283,7 @@ class PerTensorConstScaling2bit(ExtendedInjector):
 
 
 class WeightPerTensorFloatDecoupledL2Param(SolveWeightScalingStatsInputDimsFromModule,
-                                           SolveScaleSignedness):
+                                           SolveRestrictScaleSign):
     """
     Experimental narrow per-tensor signed int weight quantizer fragment with decoupled L2,inf
     normalization and learned scaling.
@@ -317,7 +317,7 @@ class WeightPerChannelFloatDecoupled(SolveStatsReduceDimFromEnum,
                                      SolveWeightScalingPerOutputChannelShapeFromModule,
                                      SolveParameterScalingShape,
                                      SolveInputViewImpl,
-                                     SolveScaleSignedness):
+                                     SolveRestrictScaleSign):
     """
     Experimental narrow per-channel signed int weight quantizer fragment with decoupled Linf
     normalization and learned scaling.
@@ -404,7 +404,7 @@ class WeightNormPerChannelFloatDecoupled(SolvePostScaleGranularity,
                                          SolveWeightScalingStatsInputDimsFromModule,
                                          SolveWeightScalingPerOutputChannelShapeFromModule,
                                          SolveParameterScalingShape,
-                                         SolveScaleSignedness,
+                                         SolveRestrictScaleSign,
                                          SolveInputViewImpl):
     """Experimental narrow per-channel weight normalization-based signed integer quantizer
     based on `Quantized Neural Networks for Low-Precision Accumulation with Guaranteed
@@ -513,8 +513,8 @@ class MSESymmetricScaleSubInjector(ExtendedInjector):
     mse_search_method = 'grid'
 
     @value
-    def is_scale_unsigned():
-        return (this << 1).is_scale_unsigned
+    def restrict_scale_positive():
+        return (this << 1).restrict_scale_positive
 
 
 class MSEAsymmetricScaleSubInjector(ExtendedInjector):
@@ -530,8 +530,8 @@ class MSEAsymmetricScaleSubInjector(ExtendedInjector):
     mse_search_method = 'grid'
 
     @value
-    def is_scale_unsigned():
-        return (this << 1).is_scale_unsigned
+    def restrict_scale_positive():
+        return (this << 1).restrict_scale_positive
 
 
 class MSEZeroPointSubInjector(ExtendedInjector):
@@ -645,8 +645,8 @@ class HQOScale(ExtendedInjector):
         return this.stats_impl_scale
 
     @value
-    def is_scale_unsigned():
-        return this.hqo_init_op_scale.is_scale_unsigned
+    def restrict_scale_positive():
+        return this.hqo_init_op_scale.restrict_scale_positive
 
 
 class HQOAsymmetricScale(HQOScale):

--- a/src/brevitas/quant/base.py
+++ b/src/brevitas/quant/base.py
@@ -520,7 +520,7 @@ class MSESymmetricScaleSubInjector(ExtendedInjector):
 class MSEAsymmetricScaleSubInjector(ExtendedInjector):
     scaling_per_output = (this << 1).scaling_per_output
     proxy_module = (this << 1).proxy_module
-    mse_init_op = AbsMax
+    mse_init_op = AbsMinMax
     stats_impl = MSE
     stats_reduce_dim = (this << 1).stats_reduce_dim
     device = (this << 1).device

--- a/src/brevitas/quant/solver/act.py
+++ b/src/brevitas/quant/solver/act.py
@@ -26,7 +26,7 @@ from brevitas.inject.enum import ScalingPerOutputType
 from brevitas.proxy import ActQuantProxyFromInjector
 from brevitas.proxy.utils import ConvertRuntimeStatsToParameter
 from brevitas.quant.solver.common import *
-from brevitas.quant.solver.common import SolveScaleSignedness
+from brevitas.quant.solver.common import SolveRestrictScaleSign
 
 
 class MinMaxScalingInit:
@@ -188,7 +188,7 @@ class ActQuantSolver(SolveActTensorQuantFromEnum,
                      SolveActScalingPerOutputChannelShape,
                      SolveUpdateStateDictImplFromEnum,
                      SolveInputViewImpl,
-                     SolveScaleSignedness):
+                     SolveRestrictScaleSign):
     """
     Translate enum directives to activation-specific quantization core modules.
     It should be placed last in the list of classes a quantizer inherits from,

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -21,7 +21,7 @@ from brevitas.core.scaling import *
 from brevitas.core.scaling import ScalingImplType
 from brevitas.core.scaling import ScalingPerOutputType
 from brevitas.core.stats import *
-from brevitas.core.stats.stats_op import wrap_signed_stat
+from brevitas.core.stats.stats_op import SIGNEDNESS_STATS
 from brevitas.function.ops import compute_max_mantissa
 from brevitas.inject import ExtendedInjector
 from brevitas.inject import value
@@ -76,13 +76,13 @@ def solve_bit_width_impl_from_enum(impl_type):
 
 # TODO (pml): For retrocompatibility, the scale is assumed to be unsigned when
 # impl_type == RestrictValueType.FP. In the future, FP should return
-# FloatRestrictValue, with SIGNED_FP being removed in favour of UNSIGNED_FP for
+# SignedRestrictValue, with SIGNED_FP being removed in favour of UNSIGNED_FP for
 # consistent naming.
 def solve_restrict_value_impl_from_enum(impl_type):
     if impl_type == RestrictValueType.FP:
-        return PositiveFloatRestrictValue
-    elif impl_type == RestrictValueType.SIGNED_FP:
         return FloatRestrictValue
+    elif impl_type == RestrictValueType.SIGNED_FP:
+        return SignedRestrictValue
     elif impl_type == RestrictValueType.LOG_FP:
         return LogFloatRestrictValue
     elif impl_type == RestrictValueType.POWER_OF_TWO:
@@ -176,13 +176,16 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
             raise RuntimeError(f"{scaling_stats_op} not recognized.")
 
         # For power of two scales, the stat needs to be unsigned
-        if restrict_scaling_type == RestrictValueType.POWER_OF_TWO and scaling_stats_op in [
-                StatsOp.SIGNED_MAX]:
-            warnings.warn(
-                f"Statistic {scaling_stats_impl.__name__} is signed, which is incompatible with the restriction to "
-                f"power of twos, so its absolute value will be taken. Consider switching to an unsigned statistic."
-            )
-            scaling_stats_impl = wrap_signed_stat(scaling_stats_impl)
+        if restrict_scaling_type == RestrictValueType.POWER_OF_TWO:
+            if scaling_stats_impl not in SIGNEDNESS_STATS:
+                raise ValueError(
+                    f"Signedness of statistic {scaling_stats_impl.__name__} is not known."
+                    f"Register the statistic using the decorator @register_stat_implementation and "
+                    f"note that only unsigned statistics can be used with power-of-two scales.")
+            if SIGNEDNESS_STATS[scaling_stats_impl]:
+                raise ValueError(
+                    f"Statistic {scaling_stats_impl.__name__} is signed but only unsigned statistics can "
+                    f"be used with power-of-two scales.")
 
         return scaling_stats_impl
 

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -74,14 +74,15 @@ def solve_bit_width_impl_from_enum(impl_type):
         raise Exception(f"{impl_type} not recognized.")
 
 
-def solve_restrict_value_impl_from_enum(impl_type, is_scale_unsigned=None):
+# TODO (pml): For retrocompatibility, the scale is assumed to be unsigned when
+# impl_type == RestrictValueType.FP. In the future, FP should return
+# FloatRestrictValue, with SIGNED_FP being removed in favour of UNSIGNED_FP for
+# consistent naming.
+def solve_restrict_value_impl_from_enum(impl_type):
     if impl_type == RestrictValueType.FP:
-        if is_scale_unsigned:
-            return PositiveFloatRestrictValue
-        else:
-            return FloatRestrictValue
-    elif impl_type == RestrictValueType.POSITIVE_FP:
         return PositiveFloatRestrictValue
+    elif impl_type == RestrictValueType.SIGNED_FP:
+        return FloatRestrictValue
     elif impl_type == RestrictValueType.LOG_FP:
         return LogFloatRestrictValue
     elif impl_type == RestrictValueType.POWER_OF_TWO:
@@ -93,8 +94,8 @@ def solve_restrict_value_impl_from_enum(impl_type, is_scale_unsigned=None):
 class SolveRestrictScalingImplFromEnum(ExtendedInjector):
 
     @value
-    def restrict_scaling_impl(restrict_scaling_type, is_scale_unsigned=None):
-        return solve_restrict_value_impl_from_enum(restrict_scaling_type, is_scale_unsigned)
+    def restrict_scaling_impl(restrict_scaling_type):
+        return solve_restrict_value_impl_from_enum(restrict_scaling_type)
 
 
 class ExponentBitWidthClass(ExtendedInjector):
@@ -175,7 +176,8 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
             raise RuntimeError(f"{scaling_stats_op} not recognized.")
 
         # For power of two scales, the stat needs to be unsigned
-        if restrict_scaling_type == RestrictValueType.POWER_OF_TWO and scaling_stats_op is not None and not scaling_stats_impl.is_scale_unsigned:
+        if restrict_scaling_type == RestrictValueType.POWER_OF_TWO and scaling_stats_op in [
+                StatsOp.SIGNED_MAX]:
             warnings.warn(
                 f"Statistic {scaling_stats_impl.__name__} is signed, which is incompatible with the restriction to "
                 f"power of twos, so its absolute value will be taken. Consider switching to an unsigned statistic."
@@ -234,6 +236,8 @@ class SolveIntScalingImplFromEnum(ExtendedInjector):
     @value
     def int_scaling_impl(restrict_scaling_type):
         if restrict_scaling_type == RestrictValueType.FP:
+            return IntScaling
+        if restrict_scaling_type == RestrictValueType.SIGNED_FP:
             return IntScaling
         elif restrict_scaling_type == RestrictValueType.LOG_FP:
             return IntScaling
@@ -309,19 +313,5 @@ class SolveDtypeDeviceFromTrackedParameterList(ExtendedInjector):
 class SolveScaleSignedness(ExtendedInjector):
 
     @value
-    def is_scale_unsigned(scaling_stats_impl=None, scaling_init=None):
-        if hasattr(scaling_stats_impl, 'is_scale_unsigned'):
-            return scaling_stats_impl.is_scale_unsigned
-        elif scaling_init is not None:
-            if not isinstance(scaling_init, torch.Tensor):
-                scaling_init = torch.tensor(scaling_init)
-
-            # Check if any of the init values is negative
-            if scaling_init.shape == ():
-                is_scale_negative = scaling_init < 0
-            else:
-                is_scale_negative = any(scaling_init.flatten() < 0)
-            return not is_scale_negative
-        else:
-            # If it is not possible to infer the scale of the sign, we assume it is unsigned
-            return True
+    def is_scale_unsigned(restrict_scaling_type=None):
+        return restrict_scaling_type in [RestrictValueType.FP, RestrictValueType.POWER_OF_TWO]

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -161,6 +161,8 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
             return AbsMinMax
         elif scaling_stats_op == StatsOp.PERCENTILE_INTERVAL:
             return PercentileInterval
+        elif scaling_stats_op == StatsOp.SIGNED_MAX:
+            return SignedAbsMax
         else:
             raise RuntimeError(f"{scaling_stats_op} not recognized.")
 
@@ -290,7 +292,9 @@ class SolveScaleSignedness(ExtendedInjector):
 
     @value
     def is_scale_unsigned(scaling_stats_impl=None, scaling_init=None):
-        if scaling_init is not None:
+        if hasattr(scaling_stats_impl, 'is_scale_unsigned'):
+            return scaling_stats_impl.is_scale_unsigned
+        elif scaling_init is not None:
             if not isinstance(scaling_init, torch.Tensor):
                 scaling_init = torch.tensor(scaling_init)
 
@@ -300,8 +304,6 @@ class SolveScaleSignedness(ExtendedInjector):
             else:
                 is_scale_negative = any(scaling_init.flatten() < 0)
             return not is_scale_negative
-        elif hasattr(scaling_stats_impl, 'is_scale_unsigned'):
-            return scaling_stats_impl.is_scale_unsigned
         else:
             # If it is not possible to infer the scale of the sign, we assume it is unsigned
             return True

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -291,8 +291,11 @@ class SolveDtypeDeviceFromTrackedParameterList(ExtendedInjector):
 class SolveScaleSignedness(ExtendedInjector):
 
     @value
-    def is_scale_unsigned(scaling_stats_impl=None, scaling_init=None):
-        if hasattr(scaling_stats_impl, 'is_scale_unsigned'):
+    def is_scale_unsigned(restrict_scaling_impl=None, scaling_stats_impl=None, scaling_init=None):
+        # TODO (pml): Should I handle LOG_FP too?
+        if isinstance(restrict_scaling_impl, PowerOfTwoRestrictValue):
+            return True
+        elif hasattr(scaling_stats_impl, 'is_scale_unsigned'):
             return scaling_stats_impl.is_scale_unsigned
         elif scaling_init is not None:
             if not isinstance(scaling_init, torch.Tensor):

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -74,9 +74,12 @@ def solve_bit_width_impl_from_enum(impl_type):
         raise Exception(f"{impl_type} not recognized.")
 
 
-def solve_restrict_value_impl_from_enum(impl_type):
+def solve_restrict_value_impl_from_enum(impl_type, is_scale_unsigned=None):
     if impl_type == RestrictValueType.FP:
-        return FloatRestrictValue
+        if is_scale_unsigned:
+            return PositiveFloatRestrictValue
+        else:
+            return FloatRestrictValue
     elif impl_type == RestrictValueType.POSITIVE_FP:
         return PositiveFloatRestrictValue
     elif impl_type == RestrictValueType.LOG_FP:
@@ -90,8 +93,8 @@ def solve_restrict_value_impl_from_enum(impl_type):
 class SolveRestrictScalingImplFromEnum(ExtendedInjector):
 
     @value
-    def restrict_scaling_impl(restrict_scaling_type):
-        return solve_restrict_value_impl_from_enum(restrict_scaling_type)
+    def restrict_scaling_impl(restrict_scaling_type, is_scale_unsigned=None):
+        return solve_restrict_value_impl_from_enum(restrict_scaling_type, is_scale_unsigned)
 
 
 class ExponentBitWidthClass(ExtendedInjector):

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -164,6 +164,8 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
             scaling_stats_impl = AbsMinMax
         elif scaling_stats_op == StatsOp.PERCENTILE_INTERVAL:
             scaling_stats_impl = PercentileInterval
+        elif scaling_stats_op == StatsOp.SIGNED_MAX:
+            scaling_stats_impl = SignedAbsMax
         else:
             raise RuntimeError(f"{scaling_stats_op} not recognized.")
 

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -76,13 +76,13 @@ def solve_bit_width_impl_from_enum(impl_type):
 
 # TODO (pml): For retrocompatibility, the scale is assumed to be unsigned when
 # impl_type == RestrictValueType.FP. In the future, FP should return
-# SignedRestrictValue, with SIGNED_FP being removed in favour of UNSIGNED_FP for
+# SignedFloatRestrictValue, with SIGNED_FP being removed in favour of UNSIGNED_FP for
 # consistent naming.
 def solve_restrict_value_impl_from_enum(impl_type):
     if impl_type == RestrictValueType.FP:
         return FloatRestrictValue
     elif impl_type == RestrictValueType.SIGNED_FP:
-        return SignedRestrictValue
+        return SignedFloatRestrictValue
     elif impl_type == RestrictValueType.LOG_FP:
         return LogFloatRestrictValue
     elif impl_type == RestrictValueType.POWER_OF_TWO:

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -175,7 +175,7 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
             raise RuntimeError(f"{scaling_stats_op} not recognized.")
 
         # For power of two scales, the stat needs to be unsigned
-        if restrict_scaling_type == RestrictValueType.POWER_OF_TWO and not scaling_stats_impl.is_scale_unsigned:
+        if restrict_scaling_type == RestrictValueType.POWER_OF_TWO and scaling_stats_op is not None and not scaling_stats_impl.is_scale_unsigned:
             warnings.warn(
                 f"Statistic {scaling_stats_impl.__name__} is signed, which is incompatible with the restriction to "
                 f"power of twos, so its absolute value will be taken. Consider switching to an unsigned statistic."

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -146,20 +146,26 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
 
     @value
     def scaling_stats_impl(scaling_stats_op=None, restrict_scaling_type=None):
-        STATS_IMPL_MAP = {
-            StatsOp.MAX.name: AbsMax,
-            StatsOp.MAX_AVE.name: AbsMaxAve,
-            StatsOp.AVE.name: AbsAve,
-            StatsOp.MEAN_SIGMA_STD.name: MeanSigmaStd,
-            StatsOp.MEAN_LEARN_SIGMA_STD.name: MeanLearnedSigmaStd,
-            StatsOp.PERCENTILE.name: AbsPercentile,
-            StatsOp.MIN_MAX.name: AbsMinMax,
-            StatsOp.PERCENTILE_INTERVAL.name: PercentileInterval,
-            StatsOp.SIGNED_MAX.name: SignedAbsMax,}
-        if scaling_stats_op.name not in STATS_IMPL_MAP:
+        if scaling_stats_op is None:
+            scaling_stats_op = None
+        if scaling_stats_op == StatsOp.MAX:
+            scaling_stats_op = AbsMax
+        elif scaling_stats_op == StatsOp.MAX_AVE:
+            scaling_stats_op = AbsMaxAve
+        elif scaling_stats_op == StatsOp.AVE:
+            scaling_stats_op = AbsAve
+        elif scaling_stats_op == StatsOp.MEAN_SIGMA_STD:
+            scaling_stats_op = MeanSigmaStd
+        elif scaling_stats_op == StatsOp.MEAN_LEARN_SIGMA_STD:
+            scaling_stats_op = MeanLearnedSigmaStd
+        elif scaling_stats_op == StatsOp.PERCENTILE:
+            scaling_stats_op = AbsPercentile
+        elif scaling_stats_op == StatsOp.MIN_MAX:
+            scaling_stats_op = AbsMinMax
+        elif scaling_stats_op == StatsOp.PERCENTILE_INTERVAL:
+            scaling_stats_op = PercentileInterval
+        else:
             raise RuntimeError(f"{scaling_stats_op} not recognized.")
-
-        scaling_stats_impl = STATS_IMPL_MAP[scaling_stats_op.name]
 
         # For power of two scales, the stat needs to be unsigned
         if restrict_scaling_type == RestrictValueType.POWER_OF_TWO and not scaling_stats_impl.is_scale_unsigned:

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -41,7 +41,7 @@ __all__ = [
     'SolveStatsReduceDimFromEnum',
     'SolveScalingStatsInputViewShapeImplFromEnum',
     'SolveDtypeDeviceFromTrackedParameterList',
-    'SolveScaleSignedness']
+    'SolveRestrictScaleSign']
 
 
 def solve_float_to_int_impl_from_enum(impl_type):
@@ -180,8 +180,7 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
             if scaling_stats_impl not in SIGNEDNESS_STATS:
                 raise ValueError(
                     f"Signedness of statistic {scaling_stats_impl.__name__} is not known."
-                    f"Register the statistic using the decorator @register_stat_implementation and "
-                    f"note that only unsigned statistics can be used with power-of-two scales.")
+                    f"Register the statistic using the decorator @register_stat_implementation.")
             if SIGNEDNESS_STATS[scaling_stats_impl]:
                 raise ValueError(
                     f"Statistic {scaling_stats_impl.__name__} is signed but only unsigned statistics can "
@@ -313,8 +312,8 @@ class SolveDtypeDeviceFromTrackedParameterList(ExtendedInjector):
             return None
 
 
-class SolveScaleSignedness(ExtendedInjector):
+class SolveRestrictScaleSign(ExtendedInjector):
 
     @value
-    def is_scale_unsigned(restrict_scaling_type=None):
+    def restrict_scale_positive(restrict_scaling_type=None):
         return restrict_scaling_type in [RestrictValueType.FP, RestrictValueType.POWER_OF_TWO]

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
+
 from dependencies import this
 
 from brevitas.core.bit_width import *
@@ -19,6 +21,7 @@ from brevitas.core.scaling import *
 from brevitas.core.scaling import ScalingImplType
 from brevitas.core.scaling import ScalingPerOutputType
 from brevitas.core.stats import *
+from brevitas.core.stats.stats_op import wrap_signed_stat
 from brevitas.function.ops import compute_max_mantissa
 from brevitas.inject import ExtendedInjector
 from brevitas.inject import value
@@ -142,29 +145,31 @@ class SolveBitWidthImplFromEnum(ExtendedInjector):
 class SolveScalingStatsOpFromEnum(ExtendedInjector):
 
     @value
-    def scaling_stats_impl(scaling_stats_op=None):
-        if scaling_stats_op is None:
-            return None
-        if scaling_stats_op == StatsOp.MAX:
-            return AbsMax
-        elif scaling_stats_op == StatsOp.MAX_AVE:
-            return AbsMaxAve
-        elif scaling_stats_op == StatsOp.AVE:
-            return AbsAve
-        elif scaling_stats_op == StatsOp.MEAN_SIGMA_STD:
-            return MeanSigmaStd
-        elif scaling_stats_op == StatsOp.MEAN_LEARN_SIGMA_STD:
-            return MeanLearnedSigmaStd
-        elif scaling_stats_op == StatsOp.PERCENTILE:
-            return AbsPercentile
-        elif scaling_stats_op == StatsOp.MIN_MAX:
-            return AbsMinMax
-        elif scaling_stats_op == StatsOp.PERCENTILE_INTERVAL:
-            return PercentileInterval
-        elif scaling_stats_op == StatsOp.SIGNED_MAX:
-            return SignedAbsMax
-        else:
+    def scaling_stats_impl(scaling_stats_op=None, restrict_scaling_type=None):
+        STATS_IMPL_MAP = {
+            StatsOp.MAX.name: AbsMax,
+            StatsOp.MAX_AVE.name: AbsMaxAve,
+            StatsOp.AVE.name: AbsAve,
+            StatsOp.MEAN_SIGMA_STD.name: MeanSigmaStd,
+            StatsOp.MEAN_LEARN_SIGMA_STD.name: MeanLearnedSigmaStd,
+            StatsOp.PERCENTILE.name: AbsPercentile,
+            StatsOp.MIN_MAX.name: AbsMinMax,
+            StatsOp.PERCENTILE_INTERVAL.name: PercentileInterval,
+            StatsOp.SIGNED_MAX.name: SignedAbsMax,}
+        if scaling_stats_op.name not in STATS_IMPL_MAP:
             raise RuntimeError(f"{scaling_stats_op} not recognized.")
+
+        scaling_stats_impl = STATS_IMPL_MAP[scaling_stats_op.name]
+
+        # For power of two scales, the stat needs to be unsigned
+        if restrict_scaling_type == RestrictValueType.POWER_OF_TWO and not scaling_stats_impl.is_scale_unsigned:
+            warnings.warn(
+                f"Statistic {scaling_stats_impl.__name__} is signed, which is incompatible with the restriction to "
+                f"power of twos, so its absolute value will be taken. Consider switching to an unsigned statistic."
+            )
+            scaling_stats_impl = wrap_signed_stat(scaling_stats_impl)
+
+        return scaling_stats_impl
 
 
 class SolveAffineRescalingFromEnum(ExtendedInjector):

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -77,6 +77,8 @@ def solve_bit_width_impl_from_enum(impl_type):
 def solve_restrict_value_impl_from_enum(impl_type):
     if impl_type == RestrictValueType.FP:
         return FloatRestrictValue
+    elif impl_type == RestrictValueType.POSITIVE_FP:
+        return PositiveFloatRestrictValue
     elif impl_type == RestrictValueType.LOG_FP:
         return LogFloatRestrictValue
     elif impl_type == RestrictValueType.POWER_OF_TWO:

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -147,23 +147,23 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
     @value
     def scaling_stats_impl(scaling_stats_op=None, restrict_scaling_type=None):
         if scaling_stats_op is None:
-            scaling_stats_op = None
+            scaling_stats_impl = None
         if scaling_stats_op == StatsOp.MAX:
-            scaling_stats_op = AbsMax
+            scaling_stats_impl = AbsMax
         elif scaling_stats_op == StatsOp.MAX_AVE:
-            scaling_stats_op = AbsMaxAve
+            scaling_stats_impl = AbsMaxAve
         elif scaling_stats_op == StatsOp.AVE:
-            scaling_stats_op = AbsAve
+            scaling_stats_impl = AbsAve
         elif scaling_stats_op == StatsOp.MEAN_SIGMA_STD:
-            scaling_stats_op = MeanSigmaStd
+            scaling_stats_impl = MeanSigmaStd
         elif scaling_stats_op == StatsOp.MEAN_LEARN_SIGMA_STD:
-            scaling_stats_op = MeanLearnedSigmaStd
+            scaling_stats_impl = MeanLearnedSigmaStd
         elif scaling_stats_op == StatsOp.PERCENTILE:
-            scaling_stats_op = AbsPercentile
+            scaling_stats_impl = AbsPercentile
         elif scaling_stats_op == StatsOp.MIN_MAX:
-            scaling_stats_op = AbsMinMax
+            scaling_stats_impl = AbsMinMax
         elif scaling_stats_op == StatsOp.PERCENTILE_INTERVAL:
-            scaling_stats_op = PercentileInterval
+            scaling_stats_impl = PercentileInterval
         else:
             raise RuntimeError(f"{scaling_stats_op} not recognized.")
 

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -153,7 +153,7 @@ class SolveScalingStatsOpFromEnum(ExtendedInjector):
     def scaling_stats_impl(scaling_stats_op=None, restrict_scaling_type=None):
         if scaling_stats_op is None:
             scaling_stats_impl = None
-        if scaling_stats_op == StatsOp.MAX:
+        elif scaling_stats_op == StatsOp.MAX:
             scaling_stats_impl = AbsMax
         elif scaling_stats_op == StatsOp.MAX_AVE:
             scaling_stats_impl = AbsMaxAve

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -296,11 +296,8 @@ class SolveDtypeDeviceFromTrackedParameterList(ExtendedInjector):
 class SolveScaleSignedness(ExtendedInjector):
 
     @value
-    def is_scale_unsigned(restrict_scaling_impl=None, scaling_stats_impl=None, scaling_init=None):
-        # TODO (pml): Should I handle LOG_FP too?
-        if isinstance(restrict_scaling_impl, PowerOfTwoRestrictValue):
-            return True
-        elif hasattr(scaling_stats_impl, 'is_scale_unsigned'):
+    def is_scale_unsigned(scaling_stats_impl=None, scaling_init=None):
+        if hasattr(scaling_stats_impl, 'is_scale_unsigned'):
             return scaling_stats_impl.is_scale_unsigned
         elif scaling_init is not None:
             if not isinstance(scaling_init, torch.Tensor):

--- a/src/brevitas/quant/solver/weight.py
+++ b/src/brevitas/quant/solver/weight.py
@@ -106,7 +106,7 @@ class WeightQuantSolver(SolveStatsReduceDimFromEnum,
                         SolveWeightTensorQuantFromEnum,
                         SolveDtypeDeviceFromTrackedParameterList,
                         SolveInputViewImpl,
-                        SolveScaleSignedness):
+                        SolveRestrictScaleSign):
     """
     Translate enum and shape directives to weight-specific quantization core modules.
     It should be placed last in the list of classes a quantizer inherits from,

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -125,7 +125,7 @@ def test_signed_scale_stats_injector_restrict_val_positive_scale():
         scaling_impl_type = ScalingImplType.STATS
         scaling_stats_op = StatsOp.SIGNED_MAX
         scaling_stats_input_view_shape_impl = Identity
-        restrict_scaling_type = RestrictValueType.POSITIVE_FP
+        restrict_scaling_type = RestrictValueType.FP
         scaling_shape = SCALAR_SHAPE
         scaling_min_val = SCALING_MIN_VAL
 

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -11,6 +11,11 @@ from brevitas.core.scaling.runtime import StatsFromParameterScaling
 from brevitas.core.stats.stats_op import AbsMax
 from brevitas.core.stats.stats_op import SignedAbsMax
 from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
+from brevitas.inject.enum import ScalingImplType
+from brevitas.inject.enum import StatsOp
+from brevitas.quant.solver.act import SolveActScalingImplFromEnum
+from brevitas.quant.solver.common import SolveScaleSignedness
+from brevitas.quant.solver.common import SolveScalingStatsOpFromEnum
 
 SCALING_MIN_VAL = 1e-6
 
@@ -64,6 +69,23 @@ def test_signed_scale_stats():
         scaling_shape=SCALAR_SHAPE,
         is_scale_unsigned=False,
         scaling_min_val=SCALING_MIN_VAL)
+    inp = torch.tensor([-0.5, 0.0, 1.0])
+    pre_scale = scaling_op(inp)
+    assert pre_scale.item() == -1.
+
+
+def test_signed_scale_stats_injector():
+
+    class SignedStatsScaling(SolveActScalingImplFromEnum,
+                             SolveScalingStatsOpFromEnum,
+                             SolveScaleSignedness):
+        scaling_impl_type = ScalingImplType.STATS
+        scaling_stats_op = StatsOp.SIGNED_MAX
+        scaling_stats_input_view_shape_impl = Identity
+        scaling_shape = SCALAR_SHAPE
+        scaling_min_val = SCALING_MIN_VAL
+
+    scaling_op = SignedStatsScaling.scaling_impl
     inp = torch.tensor([-0.5, 0.0, 1.0])
     pre_scale = scaling_op(inp)
     assert pre_scale.item() == -1.

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from brevitas.core.function_wrapper.misc import Identity
-from brevitas.core.restrict_val import PositiveFloatRestrictValue
+from brevitas.core.restrict_val import FloatRestrictValue
 from brevitas.core.restrict_val import PowerOfTwoRestrictValue
 from brevitas.core.scaling.runtime import RuntimeDynamicGroupStatsScaling
 from brevitas.core.scaling.runtime import RuntimeStatsScaling
@@ -113,7 +113,7 @@ def test_unsigned_scale_stats_injector_restrict_val_positive_scale():
     pre_scale = scaling_op(inp)
     assert isinstance(
         scaling_op.stats_scaling_impl.restrict_clamp_scaling.restrict_value_impl,
-        PositiveFloatRestrictValue)
+        FloatRestrictValue)
     assert pre_scale.item() == 1.
 
 
@@ -163,5 +163,5 @@ def test_signed_scale_stats_injector_restrict_val_po2_scale():
 
     # Verify that an exception is raised when using power of 2 scales
     # with a signed statistic
-    with pytest.raises(ValueError, match=r"Statistic SignedAbsMax is signed*power-of-two scales"):
+    with pytest.raises(ValueError, match=r"Statistic SignedAbsMax is signed*"):
         SignedStatsScaling.scaling_impl

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -14,6 +14,7 @@ from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
 from brevitas.inject.enum import RestrictValueType
 from brevitas.inject.enum import ScalingImplType
 from brevitas.inject.enum import StatsOp
+from brevitas.quant.base import MSESymmetricScale
 from brevitas.quant.solver.act import SolveActScalingImplFromEnum
 from brevitas.quant.solver.common import SolveRestrictScalingImplFromEnum
 from brevitas.quant.solver.common import SolveScaleSignedness
@@ -123,3 +124,21 @@ def test_signed_scale_stats_injector_restrict_val():
     inp = torch.tensor([-0.5, 0.0, 1.0])
     pre_scale = scaling_op(inp)
     assert pre_scale.item() == 1.
+
+
+def test_signed_scale_stats_injector_mse():
+
+    class SignedStatsScaling(MSESymmetricScale):
+        scaling_impl_type = ScalingImplType.STATS
+        scaling_stats_op = StatsOp.SIGNED_MAX
+        scaling_stats_input_view_shape_impl = Identity
+        scaling_shape = SCALAR_SHAPE
+        scaling_min_val = SCALING_MIN_VAL
+
+    class SignedStatsScaling(MSESymmetricScale):
+        scaling_impl_type = ScalingImplType.STATS
+
+    scaling_op = SignedStatsScaling.scaling_impl
+    inp = torch.tensor([-0.5, 0.0, 1.0])
+    pre_scale = scaling_op(inp)
+    assert pre_scale.item() == -1.

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import pytest
 import torch
 
 from brevitas.core.function_wrapper.misc import Identity
@@ -160,7 +161,7 @@ def test_signed_scale_stats_injector_restrict_val_po2_scale():
         scaling_shape = SCALAR_SHAPE
         scaling_min_val = SCALING_MIN_VAL
 
-    scaling_op = SignedStatsScaling.scaling_impl
-    inp = torch.tensor([-0.5, 0.0, 1.0])
-    pre_scale = scaling_op(inp)
-    assert pre_scale.item() == 1.
+    # Verify that an exception is raised when using power of 2 scales
+    # with a signed statistic
+    with pytest.raises(ValueError, match=r"Statistic SignedAbsMax is signed*power-of-two scales"):
+        SignedStatsScaling.scaling_impl

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -7,6 +7,7 @@ import torch
 from brevitas.core.function_wrapper.misc import Identity
 from brevitas.core.restrict_val import FloatRestrictValue
 from brevitas.core.restrict_val import PowerOfTwoRestrictValue
+from brevitas.core.restrict_val import SignedFloatRestrictValue
 from brevitas.core.scaling.runtime import RuntimeDynamicGroupStatsScaling
 from brevitas.core.scaling.runtime import RuntimeStatsScaling
 from brevitas.core.scaling.runtime import StatsFromParameterScaling
@@ -71,6 +72,7 @@ def test_signed_scale_stats():
     scaling_op = RuntimeStatsScaling(
         scaling_stats_impl=SignedAbsMax(),
         scaling_stats_input_view_shape_impl=Identity(),
+        restrict_scaling_impl=SignedFloatRestrictValue(),
         scaling_shape=SCALAR_SHAPE,
         scaling_min_val=SCALING_MIN_VAL)
     inp = torch.tensor([-0.5, 0.0, 1.0])
@@ -82,10 +84,12 @@ def test_signed_scale_stats_injector():
 
     class SignedStatsScaling(SolveActScalingImplFromEnum,
                              SolveScalingStatsOpFromEnum,
+                             SolveRestrictScalingImplFromEnum,
                              SolveScaleSignedness):
         scaling_impl_type = ScalingImplType.STATS
         scaling_stats_op = StatsOp.SIGNED_MAX
         scaling_stats_input_view_shape_impl = Identity
+        restrict_scaling_type = RestrictValueType.SIGNED_FP
         scaling_shape = SCALAR_SHAPE
         scaling_min_val = SCALING_MIN_VAL
 

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -93,7 +93,26 @@ def test_signed_scale_stats_injector():
     assert pre_scale.item() == -1.
 
 
-def test_signed_scale_stats_restrict_val():
+def test_signed_scale_stats_injector_restrict_val_positive_scale():
+
+    class SignedStatsScaling(SolveActScalingImplFromEnum,
+                             SolveScalingStatsOpFromEnum,
+                             SolveRestrictScalingImplFromEnum,
+                             SolveScaleSignedness):
+        scaling_impl_type = ScalingImplType.STATS
+        scaling_stats_op = StatsOp.SIGNED_MAX
+        scaling_stats_input_view_shape_impl = Identity
+        restrict_scaling_type = RestrictValueType.POSITIVE_FP
+        scaling_shape = SCALAR_SHAPE
+        scaling_min_val = SCALING_MIN_VAL
+
+    scaling_op = SignedStatsScaling.scaling_impl
+    inp = torch.tensor([-0.5, 0.0, 1.0])
+    pre_scale = scaling_op(inp)
+    assert pre_scale.item() == 1.
+
+
+def test_signed_scale_stats_restrict_val_po2_scale():
     scaling_op = RuntimeStatsScaling(
         scaling_stats_impl=SignedAbsMax(),
         scaling_stats_input_view_shape_impl=Identity(),
@@ -105,7 +124,7 @@ def test_signed_scale_stats_restrict_val():
     assert torch.all(torch.isnan(pre_scale))
 
 
-def test_signed_scale_stats_injector_restrict_val():
+def test_signed_scale_stats_injector_restrict_val_po2_scale():
 
     class SignedStatsScaling(SolveActScalingImplFromEnum,
                              SolveScalingStatsOpFromEnum,

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -70,7 +70,6 @@ def test_signed_scale_stats():
         scaling_stats_impl=SignedAbsMax(),
         scaling_stats_input_view_shape_impl=Identity(),
         scaling_shape=SCALAR_SHAPE,
-        is_scale_unsigned=False,
         scaling_min_val=SCALING_MIN_VAL)
     inp = torch.tensor([-0.5, 0.0, 1.0])
     pre_scale = scaling_op(inp)
@@ -99,12 +98,11 @@ def test_signed_scale_stats_restrict_val():
         scaling_stats_impl=SignedAbsMax(),
         scaling_stats_input_view_shape_impl=Identity(),
         scaling_shape=SCALAR_SHAPE,
-        is_scale_unsigned=True,
         restrict_scaling_impl=PowerOfTwoRestrictValue(),
         scaling_min_val=SCALING_MIN_VAL)
     inp = torch.tensor([-0.5, 0.0, 1.0])
     pre_scale = scaling_op(inp)
-    assert pre_scale.item() == 1.
+    assert torch.all(torch.isnan(pre_scale))
 
 
 def test_signed_scale_stats_injector_restrict_val():
@@ -124,21 +122,3 @@ def test_signed_scale_stats_injector_restrict_val():
     inp = torch.tensor([-0.5, 0.0, 1.0])
     pre_scale = scaling_op(inp)
     assert pre_scale.item() == 1.
-
-
-def test_signed_scale_stats_injector_mse():
-
-    class SignedStatsScaling(MSESymmetricScale):
-        scaling_impl_type = ScalingImplType.STATS
-        scaling_stats_op = StatsOp.SIGNED_MAX
-        scaling_stats_input_view_shape_impl = Identity
-        scaling_shape = SCALAR_SHAPE
-        scaling_min_val = SCALING_MIN_VAL
-
-    class SignedStatsScaling(MSESymmetricScale):
-        scaling_impl_type = ScalingImplType.STATS
-
-    scaling_op = SignedStatsScaling.scaling_impl
-    inp = torch.tensor([-0.5, 0.0, 1.0])
-    pre_scale = scaling_op(inp)
-    assert pre_scale.item() == -1.

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -11,9 +11,11 @@ from brevitas.core.scaling.runtime import StatsFromParameterScaling
 from brevitas.core.stats.stats_op import AbsMax
 from brevitas.core.stats.stats_op import SignedAbsMax
 from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
+from brevitas.inject.enum import RestrictValueType
 from brevitas.inject.enum import ScalingImplType
 from brevitas.inject.enum import StatsOp
 from brevitas.quant.solver.act import SolveActScalingImplFromEnum
+from brevitas.quant.solver.common import SolveRestrictScalingImplFromEnum
 from brevitas.quant.solver.common import SolveScaleSignedness
 from brevitas.quant.solver.common import SolveScalingStatsOpFromEnum
 
@@ -89,3 +91,35 @@ def test_signed_scale_stats_injector():
     inp = torch.tensor([-0.5, 0.0, 1.0])
     pre_scale = scaling_op(inp)
     assert pre_scale.item() == -1.
+
+
+def test_signed_scale_stats_restrict_val():
+    scaling_op = RuntimeStatsScaling(
+        scaling_stats_impl=SignedAbsMax(),
+        scaling_stats_input_view_shape_impl=Identity(),
+        scaling_shape=SCALAR_SHAPE,
+        is_scale_unsigned=True,
+        restrict_scaling_impl=PowerOfTwoRestrictValue(),
+        scaling_min_val=SCALING_MIN_VAL)
+    inp = torch.tensor([-0.5, 0.0, 1.0])
+    pre_scale = scaling_op(inp)
+    assert pre_scale.item() == 1.
+
+
+def test_signed_scale_stats_injector_restrict_val():
+
+    class SignedStatsScaling(SolveActScalingImplFromEnum,
+                             SolveScalingStatsOpFromEnum,
+                             SolveRestrictScalingImplFromEnum,
+                             SolveScaleSignedness):
+        scaling_impl_type = ScalingImplType.STATS
+        scaling_stats_op = StatsOp.SIGNED_MAX
+        scaling_stats_input_view_shape_impl = Identity
+        restrict_scaling_type = RestrictValueType.POWER_OF_TWO
+        scaling_shape = SCALAR_SHAPE
+        scaling_min_val = SCALING_MIN_VAL
+
+    scaling_op = SignedStatsScaling.scaling_impl
+    inp = torch.tensor([-0.5, 0.0, 1.0])
+    pre_scale = scaling_op(inp)
+    assert pre_scale.item() == 1.

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -9,6 +9,7 @@ from brevitas.core.scaling.runtime import RuntimeDynamicGroupStatsScaling
 from brevitas.core.scaling.runtime import RuntimeStatsScaling
 from brevitas.core.scaling.runtime import StatsFromParameterScaling
 from brevitas.core.stats.stats_op import AbsMax
+from brevitas.core.stats.stats_op import SignedAbsMax
 from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
 
 SCALING_MIN_VAL = 1e-6
@@ -54,3 +55,15 @@ def test_scaling_min_val_dynamic_group():
     pre_scale = scaling_op(inp)
     pre_scale.sum().backward()
     assert not torch.isnan(inp.grad).any()
+
+
+def test_signed_scale_stats():
+    scaling_op = RuntimeStatsScaling(
+        scaling_stats_impl=SignedAbsMax(),
+        scaling_stats_input_view_shape_impl=Identity(),
+        scaling_shape=SCALAR_SHAPE,
+        is_scale_unsigned=False,
+        scaling_min_val=SCALING_MIN_VAL)
+    inp = torch.tensor([-0.5, 0.0, 1.0])
+    pre_scale = scaling_op(inp)
+    assert pre_scale.item() == -1.

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -17,10 +17,9 @@ from brevitas.core.stats.stats_wrapper import SCALAR_SHAPE
 from brevitas.inject.enum import RestrictValueType
 from brevitas.inject.enum import ScalingImplType
 from brevitas.inject.enum import StatsOp
-from brevitas.quant.base import MSESymmetricScale
 from brevitas.quant.solver.act import SolveActScalingImplFromEnum
+from brevitas.quant.solver.common import SolveRestrictScaleSign
 from brevitas.quant.solver.common import SolveRestrictScalingImplFromEnum
-from brevitas.quant.solver.common import SolveScaleSignedness
 from brevitas.quant.solver.common import SolveScalingStatsOpFromEnum
 
 SCALING_MIN_VAL = 1e-6
@@ -85,7 +84,7 @@ def test_signed_scale_stats_injector():
     class SignedStatsScaling(SolveActScalingImplFromEnum,
                              SolveScalingStatsOpFromEnum,
                              SolveRestrictScalingImplFromEnum,
-                             SolveScaleSignedness):
+                             SolveRestrictScaleSign):
         scaling_impl_type = ScalingImplType.STATS
         scaling_stats_op = StatsOp.SIGNED_MAX
         scaling_stats_input_view_shape_impl = Identity
@@ -104,7 +103,7 @@ def test_unsigned_scale_stats_injector_restrict_val_positive_scale():
     class SignedStatsScaling(SolveActScalingImplFromEnum,
                              SolveScalingStatsOpFromEnum,
                              SolveRestrictScalingImplFromEnum,
-                             SolveScaleSignedness):
+                             SolveRestrictScaleSign):
         scaling_impl_type = ScalingImplType.STATS
         scaling_stats_op = StatsOp.MAX
         scaling_stats_input_view_shape_impl = Identity
@@ -126,7 +125,7 @@ def test_signed_scale_stats_injector_restrict_val_positive_scale():
     class SignedStatsScaling(SolveActScalingImplFromEnum,
                              SolveScalingStatsOpFromEnum,
                              SolveRestrictScalingImplFromEnum,
-                             SolveScaleSignedness):
+                             SolveRestrictScaleSign):
         scaling_impl_type = ScalingImplType.STATS
         scaling_stats_op = StatsOp.SIGNED_MAX
         scaling_stats_input_view_shape_impl = Identity
@@ -157,7 +156,7 @@ def test_signed_scale_stats_injector_restrict_val_po2_scale():
     class SignedStatsScaling(SolveActScalingImplFromEnum,
                              SolveScalingStatsOpFromEnum,
                              SolveRestrictScalingImplFromEnum,
-                             SolveScaleSignedness):
+                             SolveRestrictScaleSign):
         scaling_impl_type = ScalingImplType.STATS
         scaling_stats_op = StatsOp.SIGNED_MAX
         scaling_stats_input_view_shape_impl = Identity

--- a/tests/brevitas/core/test_runtime_scaling.py
+++ b/tests/brevitas/core/test_runtime_scaling.py
@@ -4,6 +4,7 @@
 import torch
 
 from brevitas.core.function_wrapper.misc import Identity
+from brevitas.core.restrict_val import PositiveFloatRestrictValue
 from brevitas.core.restrict_val import PowerOfTwoRestrictValue
 from brevitas.core.scaling.runtime import RuntimeDynamicGroupStatsScaling
 from brevitas.core.scaling.runtime import RuntimeStatsScaling
@@ -91,6 +92,28 @@ def test_signed_scale_stats_injector():
     inp = torch.tensor([-0.5, 0.0, 1.0])
     pre_scale = scaling_op(inp)
     assert pre_scale.item() == -1.
+
+
+def test_unsigned_scale_stats_injector_restrict_val_positive_scale():
+
+    class SignedStatsScaling(SolveActScalingImplFromEnum,
+                             SolveScalingStatsOpFromEnum,
+                             SolveRestrictScalingImplFromEnum,
+                             SolveScaleSignedness):
+        scaling_impl_type = ScalingImplType.STATS
+        scaling_stats_op = StatsOp.MAX
+        scaling_stats_input_view_shape_impl = Identity
+        restrict_scaling_type = RestrictValueType.FP
+        scaling_shape = SCALAR_SHAPE
+        scaling_min_val = SCALING_MIN_VAL
+
+    scaling_op = SignedStatsScaling.scaling_impl
+    inp = torch.tensor([-0.5, 0.0, 1.0])
+    pre_scale = scaling_op(inp)
+    assert isinstance(
+        scaling_op.stats_scaling_impl.restrict_clamp_scaling.restrict_value_impl,
+        PositiveFloatRestrictValue)
+    assert pre_scale.item() == 1.
 
 
 def test_signed_scale_stats_injector_restrict_val_positive_scale():

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -12,6 +12,7 @@ from brevitas.core.stats import PercentileInterval
 from brevitas.core.stats import SignedAbsMax
 from brevitas.core.stats.stats_op import mse_fib_search
 from brevitas.core.stats.stats_op import mse_grid_search
+from brevitas.inject.enum import RestrictValueType
 from brevitas.nn.quant_linear import QuantLinear
 from brevitas.quant.base import MSESymmetricScaleSubInjector
 from brevitas.quant.scaled_int import Int8WeightPerChannelFloatMSE
@@ -156,6 +157,7 @@ class TestMSE:
             mse_scale = _Override
 
             bit_width = 2
+            restrict_scaling_type = RestrictValueType.SIGNED_FP
             narrow_range = False
 
         # Create a model with the given quantizer

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -147,7 +147,7 @@ class TestMSE:
         _mse_search_method = mse_search_method
 
         class SignedInt2WeightPerChannelFloatMSE(Int8WeightPerChannelFloatMSE):
-            # Ensure a signed scale stats is sued within MSE
+            # Ensure a signed scale stats is used within MSE
             class _Override(MSESymmetricScaleSubInjector):
                 mse_init_op = SignedAbsMax
                 mse_iters = 100

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -150,7 +150,7 @@ class TestMSE:
             # Ensure a signed scale stats is used within MSE
             class _Override(MSESymmetricScaleSubInjector):
                 mse_init_op = SignedAbsMax
-                mse_iters = 100
+                mse_iters = 200
                 mse_search_method = _mse_search_method
 
             mse_scale = _Override

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -10,8 +10,14 @@ from brevitas.core.stats import AbsPercentile
 from brevitas.core.stats import NegativePercentileOrZero
 from brevitas.core.stats import PercentileInterval
 from brevitas.core.stats import SignedAbsMax
+from brevitas.core.stats.stats_op import mse_fib_search
+from brevitas.core.stats.stats_op import mse_grid_search
+from brevitas.nn.quant_linear import QuantLinear
+from brevitas.quant.base import MSESymmetricScaleSubInjector
+from brevitas.quant.scaled_int import Int8WeightPerChannelFloatMSE
 # Use custom implementation of kthvalue as work around to (b)float16 kernel limitations
 from brevitas.utils.torch_utils import kthvalue
+from tests.conftest import SEED
 
 
 def test_abs_percentile_per_tensor():
@@ -107,3 +113,60 @@ class TestPercentile:
         low_result = torch.clamp(range[0], max=torch.tensor(0.0))
         expected_out = torch.abs(range[1] - low_result)
         assert torch.allclose(out, expected_out)
+
+
+class TestMSE:
+
+    @pytest.mark.parametrize("xl, xr, exp_sol_x", [(0.5, 5., 1.), (-5., -0.5, -1.)])
+    @pytest.mark.parametrize("mse_solver", [mse_grid_search, mse_fib_search])
+    def test_mse_solver(self, xl, xr, exp_sol_x, mse_solver):
+        num_iter = 10
+        exp_sol_x = torch.tensor(exp_sol_x)
+        xl, xr = torch.tensor(xl), torch.tensor(xr)
+        loss_fn = lambda x: torch.square(x - exp_sol_x)
+        sol_x, _ = mse_solver(xl, xr, loss_fn, num_iter)
+        assert torch.dist(sol_x, exp_sol_x) <= torch.abs(xr - xl) / num_iter
+
+    @pytest.mark.parametrize("mse_search_method", ["grid", "fibonacci"])
+    def test_mse_quant_linear(self, mse_search_method):
+        IN_FEATURES = 3
+        OUT_FEATURES = 4
+        INPS = torch.randn((1, IN_FEATURES))
+        ABS_TOL = 1e-2
+        # Optimal MSE scale
+        exp_value = torch.tensor([
+            [-1.8645],
+            [1.0992],
+            [1.6788],
+            [-0.9831],])
+        # Initialize weights
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(SEED)
+        w = torch.randn((OUT_FEATURES, IN_FEATURES), generator=generator)
+
+        _mse_search_method = mse_search_method
+
+        class SignedInt2WeightPerChannelFloatMSE(Int8WeightPerChannelFloatMSE):
+            # Ensure a signed scale stats is sued within MSE
+            class _Override(MSESymmetricScaleSubInjector):
+                mse_init_op = SignedAbsMax
+                mse_iters = 100
+                mse_search_method = _mse_search_method
+
+            mse_scale = _Override
+
+            bit_width = 2
+            narrow_range = False
+
+        # Create a model with the given quantizer
+        quant_linear = QuantLinear(
+            in_features=IN_FEATURES,
+            out_features=OUT_FEATURES,
+            weight_quant=SignedInt2WeightPerChannelFloatMSE)
+        quant_linear.weight.data = w
+        # Run a forward to initialize the scales
+        quant_linear(INPS)
+        # Verify that scales match the expected values
+        assert torch.all(
+            torch.abs(quant_linear.weight_quant.tensor_quant.scaling_impl.value -
+                      exp_value) < ABS_TOL)

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -3,6 +3,7 @@
 
 import math
 
+import pytest
 import torch
 
 from brevitas.core.stats import AbsPercentile
@@ -34,12 +35,25 @@ def test_abs_percentile_per_channel():
 
 class TestSignedAbsMax:
 
-    def test_signed_abs_percentile_per_tensor(self):
-        values = [-0.5, 0., 1.]
-        tensor = torch.tensor(values)
-        signed_abs_max = SignedAbsMax()
+    @pytest.mark.parametrize(
+        "values, exp_out, exp_grad",
+        [
+            # Maximum absolute value is positive
+            ([-0.5, 0.0, 1.0], -1.0, [0., 0., -1.]),
+            # Maximum absolute value is negative
+            ([-1.0, 0.0, 0.5], 1.0, [-1., 0., 0.]),
+            # All values are zero
+            ([0.0, 0.0, 0.0], 0.0, [0.0, 0.0, 0.0]),
+            # Maximum absolute value is in two entries
+            ([0.0, 1.0, 1.0], -1.0, [0.0, -1.0, 0.0])])
+    @pytest.mark.parametrize("stats_reduce_dim", [None, 0])
+    def test_signed_abs_out_grad(self, values, exp_out, exp_grad, stats_reduce_dim):
+        tensor = torch.tensor(values, requires_grad=True)
+        signed_abs_max = SignedAbsMax(stats_reduce_dim)
         out = signed_abs_max(tensor)
-        assert out.item() == -1.
+        out.backward()
+        assert out.isclose(torch.tensor(exp_out)).all().item()
+        assert tensor.grad.isclose(torch.tensor(exp_grad)).all().item()
 
     def test_signed_abs_percentile_per_channel(self):
         values = [-0.5, 0., 1.]

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -166,6 +166,8 @@ class TestMSE:
         quant_linear.weight.data = w
         # Run a forward to initialize the scales
         quant_linear(INPS)
+
+        assert not quant_linear.weight_quant.tensor_quant.scaling_impl.parameter_list_stats.stats.stats_impl.is_scale_unsigned
         # Verify that scales match the expected values
         assert torch.all(
             torch.abs(quant_linear.weight_quant.tensor_quant.scaling_impl.value -

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -19,6 +19,7 @@ from brevitas.quant.scaled_int import Int8WeightPerChannelFloatMSE
 # Use custom implementation of kthvalue as work around to (b)float16 kernel limitations
 from brevitas.utils.torch_utils import kthvalue
 from tests.conftest import SEED
+from tests.marker import jit_disabled_for_local_loss
 
 
 def test_abs_percentile_per_tensor():
@@ -129,6 +130,7 @@ class TestMSE:
         assert torch.dist(sol_x, exp_sol_x) <= torch.abs(xr - xl) / num_iter
 
     @pytest.mark.parametrize("mse_search_method", ["grid", "fibonacci"])
+    @jit_disabled_for_local_loss()
     def test_mse_quant_linear(self, mse_search_method):
         IN_FEATURES = 3
         OUT_FEATURES = 4

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -8,6 +8,7 @@ import torch
 from brevitas.core.stats import AbsPercentile
 from brevitas.core.stats import NegativePercentileOrZero
 from brevitas.core.stats import PercentileInterval
+from brevitas.core.stats import SignedAbsMax
 # Use custom implementation of kthvalue as work around to (b)float16 kernel limitations
 from brevitas.utils.torch_utils import kthvalue
 
@@ -29,6 +30,24 @@ def test_abs_percentile_per_channel():
     abs_percentile = AbsPercentile(v, stats_reduce_dim=1)
     out = abs_percentile(tensor)
     assert out.isclose(torch.Tensor([9, 9])).all().item()
+
+
+class TestSignedAbsMax:
+
+    def test_signed_abs_percentile_per_tensor(self):
+        values = [-0.5, 0., 1.]
+        tensor = torch.tensor(values)
+        signed_abs_max = SignedAbsMax()
+        out = signed_abs_max(tensor)
+        assert out.item() == -1.
+
+    def test_signed_abs_percentile_per_channel(self):
+        values = [-0.5, 0., 1.]
+        tensor = torch.Tensor(values)
+        tensor = tensor.repeat(2, 1)
+        signed_abs_max = SignedAbsMax(stats_reduce_dim=1)
+        out = signed_abs_max(tensor)
+        assert out.isclose(torch.Tensor([-1., -1.])).all().item()
 
 
 class TestPercentile:

--- a/tests/brevitas/core/test_stats.py
+++ b/tests/brevitas/core/test_stats.py
@@ -169,7 +169,7 @@ class TestMSE:
         # Run a forward to initialize the scales
         quant_linear(INPS)
 
-        assert not quant_linear.weight_quant.tensor_quant.scaling_impl.parameter_list_stats.stats.stats_impl.is_scale_unsigned
+        assert not quant_linear.weight_quant.tensor_quant.scaling_impl.parameter_list_stats.stats.stats_impl.restrict_scale_positive
         # Verify that scales match the expected values
         assert torch.all(
             torch.abs(quant_linear.weight_quant.tensor_quant.scaling_impl.value -

--- a/tests/brevitas/core/test_stats_view_wrapper.py
+++ b/tests/brevitas/core/test_stats_view_wrapper.py
@@ -3,11 +3,8 @@
 
 import warnings
 
-import pytest
-import torch
 import torch.nn as nn
 
-from brevitas.core.stats.stats_op import AbsMax
 from brevitas.core.stats.view_wrapper import _ViewCatParameterWrapper
 from brevitas.core.stats.view_wrapper import _ViewParameterWrapper
 

--- a/tests/brevitas/proxy/test_act_scaling.py
+++ b/tests/brevitas/proxy/test_act_scaling.py
@@ -3,9 +3,9 @@
 
 import torch
 
-from brevitas.core.function_wrapper.misc import Abs
-from brevitas.core.function_wrapper.misc import Identity
 from brevitas.core.quant import QuantType
+from brevitas.core.restrict_val import FloatRestrictValue
+from brevitas.core.restrict_val import PositiveFloatRestrictValue
 from brevitas.core.scaling import ScalingImplType
 from brevitas.core.stats import StatsOp
 from brevitas.inject.enum import RestrictValueType
@@ -98,7 +98,10 @@ class TestQuantReLU:
             scaling_stats_op=StatsOp.MAX,
             collect_stats_steps=1,
             scaling_min_val=None)
-        assert stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.stats.stats_impl.is_scale_unsigned
+        assert isinstance(
+            stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl
+            .restrict_scaling.restrict_value_impl,
+            PositiveFloatRestrictValue)
 
     def test_signed_abs_stats_signedness(self):
         # Check that SignedAbsMax is correctly resolved as signed scale
@@ -108,12 +111,17 @@ class TestQuantReLU:
             scaling_impl_type=ScalingImplType.PARAMETER_FROM_STATS,
             scaling_stats_permute_dims=None,
             scaling_stats_op=StatsOp.SIGNED_MAX,
+            restrict_scaling_type=RestrictValueType.SIGNED_FP,
             collect_stats_steps=1,
             scaling_min_val=None)
-        assert not stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.stats.stats_impl.is_scale_unsigned
+        assert isinstance(
+            stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl
+            .restrict_scaling.restrict_value_impl,
+            FloatRestrictValue)
 
     def test_po2_signed_abs_stats_signedness(self):
-        # Check that SignedAbsMax is resolved as unsigned for po2 scale
+        # Check that SignedAbsMax is wrapped with an absolute value to prevent taking the logarithm
+        # on a negative number
         stats_act = QuantReLU(
             bit_width=BIT_WIDTH,
             quant_type=QuantType.INT,
@@ -123,4 +131,4 @@ class TestQuantReLU:
             scaling_stats_op=StatsOp.SIGNED_MAX,
             collect_stats_steps=1,
             scaling_min_val=None)
-        assert stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.stats.stats_impl.is_scale_unsigned
+        assert stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.stats.stats_impl.__class__.__name__ == "SignedStatWrapper"

--- a/tests/brevitas/proxy/test_act_scaling.py
+++ b/tests/brevitas/proxy/test_act_scaling.py
@@ -6,7 +6,7 @@ import torch
 
 from brevitas.core.quant import QuantType
 from brevitas.core.restrict_val import FloatRestrictValue
-from brevitas.core.restrict_val import PositiveFloatRestrictValue
+from brevitas.core.restrict_val import SignedFloatRestrictValue
 from brevitas.core.scaling import ScalingImplType
 from brevitas.core.stats import StatsOp
 from brevitas.inject.enum import RestrictValueType
@@ -102,7 +102,7 @@ class TestQuantReLU:
         assert isinstance(
             stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl
             .restrict_scaling.restrict_value_impl,
-            PositiveFloatRestrictValue)
+            FloatRestrictValue)
 
     def test_signed_abs_stats_signedness(self):
         # Check that SignedAbsMax is correctly resolved as signed scale
@@ -118,13 +118,12 @@ class TestQuantReLU:
         assert isinstance(
             stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl
             .restrict_scaling.restrict_value_impl,
-            FloatRestrictValue)
+            SignedFloatRestrictValue)
 
     def test_po2_signed_abs_stats_signedness(self):
         # Verify that an exception is raised when using power of 2 scales
         # with a signed statistic
-        with pytest.raises(ValueError,
-                           match=r"Statistic SignedAbsMax is signed*power-of-two scales"):
+        with pytest.raises(ValueError, match=r"Statistic SignedAbsMax is signed*"):
             QuantReLU(
                 bit_width=BIT_WIDTH,
                 quant_type=QuantType.INT,

--- a/tests/brevitas/proxy/test_act_scaling.py
+++ b/tests/brevitas/proxy/test_act_scaling.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import pytest
 import torch
 
 from brevitas.core.quant import QuantType
@@ -120,15 +121,16 @@ class TestQuantReLU:
             FloatRestrictValue)
 
     def test_po2_signed_abs_stats_signedness(self):
-        # Check that SignedAbsMax is wrapped with an absolute value to prevent taking the logarithm
-        # on a negative number
-        stats_act = QuantReLU(
-            bit_width=BIT_WIDTH,
-            quant_type=QuantType.INT,
-            restrict_scaling_type=RestrictValueType.POWER_OF_TWO,
-            scaling_impl_type=ScalingImplType.PARAMETER_FROM_STATS,
-            scaling_stats_permute_dims=None,
-            scaling_stats_op=StatsOp.SIGNED_MAX,
-            collect_stats_steps=1,
-            scaling_min_val=None)
-        assert stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.stats.stats_impl.__class__.__name__ == "SignedStatWrapper"
+        # Verify that an exception is raised when using power of 2 scales
+        # with a signed statistic
+        with pytest.raises(ValueError,
+                           match=r"Statistic SignedAbsMax is signed*power-of-two scales"):
+            QuantReLU(
+                bit_width=BIT_WIDTH,
+                quant_type=QuantType.INT,
+                restrict_scaling_type=RestrictValueType.POWER_OF_TWO,
+                scaling_impl_type=ScalingImplType.PARAMETER_FROM_STATS,
+                scaling_stats_permute_dims=None,
+                scaling_stats_op=StatsOp.SIGNED_MAX,
+                collect_stats_steps=1,
+                scaling_min_val=None)

--- a/tests/brevitas/proxy/test_act_scaling.py
+++ b/tests/brevitas/proxy/test_act_scaling.py
@@ -8,6 +8,7 @@ from brevitas.core.function_wrapper.misc import Identity
 from brevitas.core.quant import QuantType
 from brevitas.core.scaling import ScalingImplType
 from brevitas.core.stats import StatsOp
+from brevitas.inject.enum import RestrictValueType
 from brevitas.nn import QuantReLU
 
 BIT_WIDTH = 8
@@ -97,38 +98,29 @@ class TestQuantReLU:
             scaling_stats_op=StatsOp.MAX,
             collect_stats_steps=1,
             scaling_min_val=None)
-        print(stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.abs_value)
-        assert isinstance(
-            stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.abs_value
-            .apply_abs,
-            Abs)
+        assert stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.stats.stats_impl.is_scale_unsigned
 
-    def test_parameter_negative_signedness(self):
-        # Check that a negative init value with parameter scaliing will cause the scale to be signed
+    def test_signed_abs_stats_signedness(self):
+        # Check that SignedAbsMax is correctly resolved as signed scale
         stats_act = QuantReLU(
             bit_width=BIT_WIDTH,
             quant_type=QuantType.INT,
-            scaling_impl_type=ScalingImplType.PARAMETER,
+            scaling_impl_type=ScalingImplType.PARAMETER_FROM_STATS,
             scaling_stats_permute_dims=None,
-            scaling_init=torch.tensor(-1.),
-            collect_stats_steps=1)
-        assert isinstance(
-            stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl
-            .restrict_clamp_scaling.apply_abs,
-            Identity)
-
-    def test_parameter_forced_signedness(self):
-        # Check that a positive init value but with `is_scale_unsigned` set to False
-        # will cause the scale to also be signed
-        stats_act = QuantReLU(
-            bit_width=BIT_WIDTH,
-            quant_type=QuantType.INT,
-            scaling_impl_type=ScalingImplType.PARAMETER,
-            scaling_stats_permute_dims=None,
-            scaling_init=torch.tensor(1.),
+            scaling_stats_op=StatsOp.SIGNED_MAX,
             collect_stats_steps=1,
-            is_scale_unsigned=False)
-        assert isinstance(
-            stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl
-            .restrict_clamp_scaling.apply_abs,
-            Identity)
+            scaling_min_val=None)
+        assert not stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.stats.stats_impl.is_scale_unsigned
+
+    def test_po2_signed_abs_stats_signedness(self):
+        # Check that SignedAbsMax is resolved as unsigned for po2 scale
+        stats_act = QuantReLU(
+            bit_width=BIT_WIDTH,
+            quant_type=QuantType.INT,
+            restrict_scaling_type=RestrictValueType.POWER_OF_TWO,
+            scaling_impl_type=ScalingImplType.PARAMETER_FROM_STATS,
+            scaling_stats_permute_dims=None,
+            scaling_stats_op=StatsOp.SIGNED_MAX,
+            collect_stats_steps=1,
+            scaling_min_val=None)
+        assert stats_act.act_quant.fused_activation_quant_proxy.tensor_quant.scaling_impl.stats.stats_impl.is_scale_unsigned


### PR DESCRIPTION
## Reason for this PR

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

Provides support for signed scales by tackling some of the outstanding items in [1309](https://github.com/Xilinx/brevitas/issues/1309), specifically the handling of the power of two scales and MSE scale optimization for signed scales. Closely related to [1308](https://github.com/Xilinx/brevitas/pull/1308) and [1347](https://github.com/Xilinx/brevitas/pull/1347).

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

Minor refactoring of the MSE class, and fixes in the passing of `is_scale_unsigned` in the dependency injector.

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

Adds tests for `SignedAbsMax`.

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
