### PR TITLE
Fix (export/onnx): import GLOBALS from correct location depending on torch version

### DIFF
--- a/src/brevitas/export/onnx/__init__.py
+++ b/src/brevitas/export/onnx/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
-
+from brevitas import torch_version
+from packaging import version
 
 def onnx_export_opset():
     try:
@@ -9,7 +10,11 @@ def onnx_export_opset():
         opset = getattr(cfg, ATR_NAME)
 
     except:
-        from torch.onnx._globals import GLOBALS as cfg
+        if torch_version < version.parse('2.9.0'):
+            from torch.onnx._globals import GLOBALS as cfg
+        else:
+            from torch.onnx._internal.torchscript_exporter._globals import GLOBALS as cfg
+
         ATR_NAME = 'export_onnx_opset_version'
         opset = getattr(cfg, ATR_NAME)
 

--- a/src/brevitas/export/onnx/__init__.py
+++ b/src/brevitas/export/onnx/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
-from brevitas import torch_version
 from packaging import version
+
+from brevitas import torch_version
+
 
 def onnx_export_opset():
     try:


### PR DESCRIPTION
## Reason for this PR

Exporting with `export_onnx_qcdq` was not working for PyTorch 2.9.0 even with `dynamo=False` as described in [this issue](https://github.com/Xilinx/brevitas/issues/1397). The reason for this is a change in location from `torch.onnx._globals` to `torch.onnx._internal.torchscript_importer._globals` in  PyTorch 2.9.0 (see [this pytorch commit](https://github.com/pytorch/pytorch/commit/524b78d4f67045b83bb69edc56ab16efe282971c)).
<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR
Edited the file `brevitas/export/onnx/__init__.py` to import `GLOBALS` from the right location depending on the torch version. An `if`/`else` statement that checks the torch version was added in the import of `GLOBALS` to make the correct import according to the torch version. This approach was chosen instead of using `try`/`except` to make it easier to search for code related to specific torch versions in future changes.
<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Detail any notable implementation details.
-->

## Testing Summary
- Tests run locally
<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->
