### PR TITLE
deps (onnxscript): limit `onnxscript<0.5.4`

### DIFF
--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,4 +1,4 @@
 onnx==1.17.0
 onnxoptimizer
-onnxscript
+onnxscript<0.5.4
 qonnx

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -2,6 +2,6 @@ bitstring
 onnx==1.17.0
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
-onnxscript
+onnxscript<0.5.4
 qonnx
 toposort

--- a/requirements/requirements-ort-integration.txt
+++ b/requirements/requirements-ort-integration.txt
@@ -1,5 +1,5 @@
 onnx==1.17.0
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
-onnxscript
+onnxscript<0.5.4
 qonnx


### PR DESCRIPTION
Workaround for [this issue](https://github.com/microsoft/onnxscript/issues/2651) - the incompatibility between batchnorm ONNX export, PyTorch 2.6 and onnxscript 0.5.4.