### PR TITLE
Fix (core/scaling): fix dtype for threshold

### DIFF
--- a/src/brevitas/core/scaling/int_scaling.py
+++ b/src/brevitas/core/scaling/int_scaling.py
@@ -16,7 +16,10 @@ class IntScaling(brevitas.jit.ScriptModule):
     __constants__ = ['signed', 'narrow_range']
 
     def __init__(
-            self, narrow_range: bool, signed: Optional[bool] = None, dtype: torch.dtype = None):
+            self,
+            narrow_range: bool,
+            signed: Optional[bool] = None,
+            dtype: Optional[torch.dtype] = None):
         super(IntScaling, self).__init__()
         self.signed = signed
         self.narrow_range = narrow_range

--- a/src/brevitas/core/scaling/int_scaling.py
+++ b/src/brevitas/core/scaling/int_scaling.py
@@ -4,6 +4,7 @@
 from typing import Optional
 from typing import Union
 
+import torch
 from torch import Tensor
 
 import brevitas
@@ -14,10 +15,12 @@ from brevitas.function.ops import min_int
 class IntScaling(brevitas.jit.ScriptModule):
     __constants__ = ['signed', 'narrow_range']
 
-    def __init__(self, narrow_range: bool, signed: Optional[bool] = None):
+    def __init__(
+            self, narrow_range: bool, signed: Optional[bool] = None, dtype: torch.dtype = None):
         super(IntScaling, self).__init__()
         self.signed = signed
         self.narrow_range = narrow_range
+        self.dtype = dtype
 
     @brevitas.jit.script_method
     def forward(self, bit_width: Tensor, signed: Optional[Union[bool, Tensor]] = None) -> Tensor:
@@ -28,9 +31,9 @@ class IntScaling(brevitas.jit.ScriptModule):
         # Workaround: required for compatibility with the JIT for PT=2.2.2
         is_signed = bool(is_signed.item()) if isinstance(is_signed, Tensor) else is_signed
         if is_signed:
-            return -min_int(is_signed, self.narrow_range, bit_width)
+            return -min_int(is_signed, self.narrow_range, bit_width).to(dtype=self.dtype)
         else:
-            return max_int(is_signed, self.narrow_range, bit_width)
+            return max_int(is_signed, self.narrow_range, bit_width).to(dtype=self.dtype)
 
 
 class PowerOfTwoIntScaling(brevitas.jit.ScriptModule):


### PR DESCRIPTION
## Reason for this PR

In some circumstances, we see that the result of:
```python
2 ** bit_width
```
where bit_width is a `torch.float16` number might return a `torch.float32` value, causing typing mismatches.

We already have a similar mechanism for `float_scaling.py`, so this also helps with consistency.


## Changes Made in this PR

Explicit dtype cast

## Testing Summary

Unsure still how to reproduce the behaviour, but it happens in the wild.
