### PR TITLE
Feat (gpxq): enabling optimization of device and dtype

### DIFF
--- a/src/brevitas/graph/gpfq.py
+++ b/src/brevitas/graph/gpfq.py
@@ -28,22 +28,31 @@ class GPFQ(GPxQ):
     https://epubs.siam.org/doi/abs/10.1137/22M1511709
     """
 
-    def __init__(self, layer, name, act_order, len_parallel_layers, create_weight_orig) -> None:
-        super().__init__(layer, name, act_order, len_parallel_layers, create_weight_orig)
+    def __init__(
+            self,
+            layer,
+            name,
+            act_order,
+            len_parallel_layers,
+            create_weight_orig,
+            device='cpu',
+            dtype=torch.float32) -> None:
+        super().__init__(
+            layer, name, act_order, len_parallel_layers, create_weight_orig, device, dtype)
         # Initialize covariance matrices. We need them in float32
         # H = \hat{X} \hat{X}^T
-        self.H: Tensor = torch.zeros((self.groups, self.columns, self.columns),
-                                     device="cpu",
-                                     dtype=torch.float32)
+        self.H = torch.zeros((self.groups, self.columns, self.columns),
+                             device=self.device,
+                             dtype=self.dtype)
         # G = \hat{X} X^T
-        self.G: Tensor = torch.zeros((self.groups, self.columns, self.columns),
-                                     device="cpu",
-                                     dtype=torch.float32)
-        # buffer to speed-up GPU to CPU transfer
-        self.B: Tensor = torch.zeros((self.groups, self.columns, self.columns),
-                                     device="cpu",
-                                     dtype=torch.float32,
-                                     pin_memory=torch.cuda.is_available())
+        self.G = torch.zeros((self.groups, self.columns, self.columns),
+                             device=self.device,
+                             dtype=self.dtype)
+        if self.use_intermediate_buffer:
+            self.B = torch.zeros((self.groups, self.columns, self.columns),
+                                 device=self.device,
+                                 dtype=self.dtype,
+                                 pin_memory=torch.cuda.is_available())
         self.nsamples = 0
 
         self.quant_input = None
@@ -63,7 +72,7 @@ class GPFQ(GPxQ):
         batch_size = inp_processed.shape[-1]
 
         # Normalizing for numerical stability
-        inp_processed = math.sqrt(1 / batch_size) * inp_processed.to(torch.float32)
+        inp_processed = math.sqrt(1 / batch_size) * inp_processed.to(self.dtype)
 
         # NOTE: in the gpfq_mode context manager, we first collect quant inputs, then
         # we collect float inputs for the same batch. We assume this pattern here, but
@@ -72,14 +81,20 @@ class GPFQ(GPxQ):
         # if quant is not enabled, then it is the float input; if it is a float input
         # then a quant input has already happened and we can update G
         if not is_quant_enabled:
-            # Computing the normalized G matrix using CPU buffer
-            self.B.copy_(self.quant_input.bmm(inp_processed.transpose(2, 1)))
-            self.G += self.B
+            # Compute the normalized G matrix
+            if self.use_intermediate_buffer:
+                self.B.copy_(self.quant_input.bmm(inp_processed.transpose(2, 1)))
+                self.G += self.B
+            else:
+                self.G += self.quant_input.bmm(inp_processed.transpose(2, 1))
             self.quant_input = None  # NOTE: set back to None now that we've used it
         else:
-            # Computing the normalized H matrix using CPU buffer
-            self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
-            self.H += self.B
+            # Compute the normalized H matrix
+            if self.use_intermediate_buffer:
+                self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
+                self.H += self.B
+            else:
+                self.H += inp_processed.bmm(inp_processed.transpose(2, 1))
             # store the quantized input for computing the H matrix
             assert self.quant_input is None
             self.quant_input = inp_processed
@@ -99,7 +114,8 @@ class GPFQ(GPxQ):
             "Error: GPFQ requires the original weights to be stored, see `create_weight_orig`."
         if hasattr(self.layer, 'allocate_params'):
             self.layer.allocate_params(self.layer)
-        del self.B  # free up memory by deleting the buffer
+        if self.use_intermediate_buffer:
+            del self.B  # free memory
 
         weight = self.layer.weight.data
         weight_orig = self.layer.weight_orig.data
@@ -143,16 +159,16 @@ class GPFQ(GPxQ):
             perm = perm.to(weight.device)
             permutation_list.append(perm)
 
-        Dg = torch.zeros((self.groups, self.columns), dtype=torch.float32)
-        Dh = torch.zeros((self.groups, self.columns), dtype=torch.float32)
+        Dg = torch.zeros((self.groups, self.columns), dtype=self.dtype, device=self.device)
+        Dh = torch.zeros((self.groups, self.columns), dtype=self.dtype, device=self.device)
         for group_index in range(self.groups):
             Dg[group_index].copy_(self.G[group_index].diag())
             Dh[group_index].copy_(self.H[group_index].diag())
         # if either norms are 0, the weight is effectively pruned
         Ds = torch.where(Dg * Dh != 0, Dg / Dh, torch.zeros_like(Dg))  # \hat{D}_tt / D_tt
 
-        Lg = torch.zeros((self.groups, self.columns, self.columns), device=dev, dtype=torch.float32)
-        Lh = torch.zeros((self.groups, self.columns, self.columns), device=dev, dtype=torch.float32)
+        Lg = torch.zeros((self.groups, self.columns, self.columns), device=dev, dtype=self.dtype)
+        Lh = torch.zeros((self.groups, self.columns, self.columns), device=dev, dtype=self.dtype)
         for group_index in range(self.groups):
             L0g = torch.tril(self.G[group_index], -1)  # L0
             L0h = torch.tril(self.H[group_index], -1)  # \hat{L0}
@@ -170,11 +186,11 @@ class GPFQ(GPxQ):
                 # t := time step (Lg, Lh, and Ds are re-ordered in time)
                 # i := input channel index (weight and error are not re-ordered)
                 i = permutation_list[group_index][t]
-                w = weight_orig[group_index, :, permutation_list[group_index][:t]].to(torch.float32)
-                q = q_groups[group_index].to(torch.float32)
+                w = weight_orig[group_index, :, permutation_list[group_index][:t]].to(self.dtype)
+                q = q_groups[group_index].to(self.dtype)
                 Lw = w.matmul(Lg[group_index, t, :t])
                 Lq = q.matmul(Lh[group_index, t, :t])
-                q_arg = Ds[group_index, t] * weight[group_index, :, i].to(torch.float32) + Lw - Lq
+                q_arg = Ds[group_index, t] * weight[group_index, :, i].to(self.dtype) + Lw - Lq
                 assert not torch.isnan(q_arg).any()
                 weight[group_index, :, i] = q_arg.to(dtype)
 
@@ -203,6 +219,8 @@ class gpfq_mode(gpxq_mode):
             Default: False
         algorithm_impl (GPFQ): The uninitialized class to execute the algorithm.
             Default: `brevitas.graph.gpfq.GPFQ`
+        device (str): Device the buffers are stored on. Default: cpu
+        dtype (torch.dtype): Datatype the buffers are stored in. Default: torch.float32
 
     Example:
         >>> with torch.no_grad():
@@ -224,7 +242,9 @@ class gpfq_mode(gpxq_mode):
             use_quant_activations: bool = True,
             return_forward_output: bool = False,
             act_order: bool = False,
-            algorithm_impl: GPFQ = GPFQ) -> None:
+            algorithm_impl: GPFQ = GPFQ,
+            device: str = 'cpu',
+            dtype: torch.dtype = torch.float32) -> None:
         if not inplace:
             model = deepcopy(model)
         super().__init__(
@@ -234,7 +254,9 @@ class gpfq_mode(gpxq_mode):
             create_weight_orig,
             use_quant_activations,
             act_order,
-            return_forward_output)
+            return_forward_output,
+            device,
+            dtype)
 
         self.algorithm_impl = algorithm_impl
 
@@ -275,4 +297,6 @@ class gpfq_mode(gpxq_mode):
             name=name,
             act_order=self.act_order,
             len_parallel_layers=len_parallel_layers,
-            create_weight_orig=create_weight_orig)
+            create_weight_orig=create_weight_orig,
+            device=self.device,
+            dtype=self.dtype)

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -43,24 +43,31 @@ class GPTQ(GPxQ):
     """
 
     def __init__(
-            self, layer, name, act_order, len_parallel_layers, create_weight_orig,
-            num_blocks) -> None:
-        super().__init__(layer, name, act_order, len_parallel_layers, create_weight_orig)
+            self,
+            layer,
+            name,
+            act_order,
+            len_parallel_layers,
+            create_weight_orig,
+            num_blocks,
+            device='cpu',
+            dtype=torch.float32) -> None:
+        super().__init__(
+            layer, name, act_order, len_parallel_layers, create_weight_orig, device, dtype)
 
         # Define how many columns to update in each mini-block
         self.blocksize = math.ceil(self.columns / num_blocks)
 
         # Initialize Hessian matrix and counter. We need it in float32 to compute the inverse
-        self.H = torch.zeros(
-            (self.groups, self.columns, self.columns),
-            device='cpu',
-            dtype=torch.float32,
-        )
-        self.B = torch.zeros(
-            (self.groups, self.columns, self.columns),
-            device='cpu',
-            dtype=torch.float32,
-        )
+        self.H = torch.zeros((self.groups, self.columns, self.columns),
+                             device=self.device,
+                             dtype=self.dtype)
+        if self.use_intermediate_buffer:
+            # Creating an intermediate buffer with pinned memory to improve transfer speeds
+            self.B = torch.zeros((self.groups, self.columns, self.columns),
+                                 pin_memory=torch.cuda.is_available(),
+                                 device=self.device,
+                                 dtype=self.dtype)
         self.nsamples = 0
 
         assert torch_version >= version.parse('1.10'), "GPTQ requires torch 1.10 or higher"
@@ -74,10 +81,13 @@ class GPTQ(GPxQ):
         # Calcuate the covariance matrix
         self.H *= self.nsamples / (self.nsamples + batch_size)
         self.nsamples += batch_size
-        inp_processed = math.sqrt(2 / self.nsamples) * inp_processed.to(torch.float32)
-        # Optimizing CPU to GPU transfer using in-place copy to pinned memory
-        self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
-        self.H += self.B
+        inp_processed = math.sqrt(2 / self.nsamples) * inp_processed.to(self.dtype)
+        if self.use_intermediate_buffer:
+            # Optimizing CPU to GPU transfer using in-place copy to pinned memory
+            self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
+            self.H += self.B
+        else:
+            self.H += inp_processed.bmm(inp_processed.transpose(2, 1))
 
     def update_batch(self, module, input, current_layer):
         if self.disable_pre_forward_hook:
@@ -97,6 +107,8 @@ class GPTQ(GPxQ):
         assert not self.layer.weight_quant.requires_quant_input, "Error: GPTQ does not support weight quantizers that require quantized inputs."
         if hasattr(self.layer, 'allocate_params'):
             self.layer.allocate_params(self.layer)
+        if self.use_intermediate_buffer:
+            del self.B  # free memory
         weight = self.layer.weight.data
         dev = weight.device
 
@@ -140,7 +152,7 @@ class GPTQ(GPxQ):
         try:
             for i in range(self.groups):
                 damp = percdamp * torch.mean(torch.diag(self.H[i, :, :]))
-                diag = torch.arange(self.columns, device='cpu')
+                diag = torch.arange(self.columns, device=self.device)
                 self.H[i, diag, diag] += damp
                 self.H[i, :, :] = torch.linalg.cholesky(self.H[i, :, :])
                 self.H[i, :, :] = torch.cholesky_inverse(self.H[i, :, :])
@@ -155,21 +167,21 @@ class GPTQ(GPxQ):
                 f'Increasing the number of samples might fix this issue')
             return
         finally:
-            del self.H, self.B
+            del self.H
 
         for i1 in range(0, self.columns, self.blocksize):
             i2 = min(i1 + self.blocksize, self.columns)
             count = i2 - i1
             error_block = torch.zeros_like(
-                weight[:, :, perm[i1:i2]], dtype=torch.float32)  # [groups, OC/groups, i2-i1]
+                weight[:, :, perm[i1:i2]], dtype=self.dtype)  # [groups, OC/groups, i2-i1]
 
             h_inv_block = h_inv[:, i1:i2, i1:i2]
             for i in range(count):
                 q_groups = self.get_quant_weights(i, i1, permutation_list)  # [groups, OC/groups]
                 for group_index in range(self.groups):
                     perm = permutation_list[group_index]
-                    q = q_groups[group_index].to(torch.float32)  # [OC/groups]
-                    w = weight[group_index, :, perm[i1:i2][i]].to(torch.float32)  # [OC/groups]
+                    q = q_groups[group_index].to(self.dtype)  # [OC/groups]
+                    w = weight[group_index, :, perm[i1:i2][i]].to(self.dtype)  # [OC/groups]
                     d = h_inv_block[group_index, i, i]  # [1]
                     error = (w - q) / d  # [OC/groups]
                     error_block[group_index, :, i] = error
@@ -205,6 +217,8 @@ class gptq_mode(gpxq_mode):
         return_forward_output (bool): If True, returns the output of the forward pass. Otherwise the
             forward call inside the context manager returns None. Default: False
         gptq_class (GPTQ): The uninitialized class to perform GPTQ. Default: `brevitas.graph.gptq.GPTQ`
+        device (str): Device the buffers are stored on. Default: cpu
+        dtype (torch.dtype): Datatype the buffers are stored in. Default: torch.float32
 
     Example:
         >>> with torch.no_grad():
@@ -227,7 +241,9 @@ class gptq_mode(gpxq_mode):
             num_blocks: int = 100,
             return_forward_output: bool = False,
             act_order: bool = False,
-            gptq_class: GPTQ = GPTQ) -> None:
+            gptq_class: GPTQ = GPTQ,
+            device: str = 'cpu',
+            dtype: torch.dtype = torch.float32) -> None:
         if not inplace:
             model = deepcopy(model)
         super().__init__(
@@ -237,7 +253,9 @@ class gptq_mode(gpxq_mode):
             create_weight_orig,
             use_quant_activations,
             act_order,
-            return_forward_output)
+            return_forward_output,
+            device,
+            dtype)
 
         # How many subblock to use during GPTQ for each layer
         self.num_blocks = num_blocks
@@ -265,4 +283,6 @@ class gptq_mode(gpxq_mode):
             act_order=self.act_order,
             len_parallel_layers=len_parallel_layers,
             create_weight_orig=create_weight_orig,
-            num_blocks=self.num_blocks)
+            num_blocks=self.num_blocks,
+            device=self.device,
+            dtype=self.dtype)

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -50,6 +50,7 @@ class gpxq_mode(quantization_status_manager):
         use_quant_activations (bool): Wheter to leave quantize activations enabled while performing
             GPxQ. Default: False
         act_order (bool): Whether to order greedy path following by Hessian approximation. Default: False
+        device ()
         return_forward_output (bool): If True, returns the output of the forward pass. Otherwise the
             forward call inside the context manager returns None. Default: False
 
@@ -72,7 +73,9 @@ class gpxq_mode(quantization_status_manager):
             create_weight_orig: bool = True,
             use_quant_activations: bool = True,
             act_order: bool = False,
-            return_forward_output: bool = False) -> None:
+            return_forward_output: bool = False,
+            device: str = 'cpu',
+            dtype: torch.dtype = torch.float32) -> None:
         if not inplace:
             model = deepcopy(model)
         # Note that if use_quant_activations = True, the super() context manager
@@ -93,6 +96,9 @@ class gpxq_mode(quantization_status_manager):
         self.num_layers = 0
         # Quantize following magnitude of activation
         self.act_order = act_order
+        # the device and dtype of the buffers
+        self.device = device
+        self.dtype = dtype
 
         self.group_of_parallel_layers = group_of_parallel_layers
         self.return_forward_output = return_forward_output
@@ -179,11 +185,21 @@ class gpxq_mode(quantization_status_manager):
 class GPxQ(ABC):
 
     def __init__(
-            self, layer, name, act_order, len_parallel_layers=1, create_weight_orig=True) -> None:
+            self,
+            layer,
+            name,
+            act_order,
+            len_parallel_layers=1,
+            create_weight_orig=True,
+            device='cpu',
+            dtype=torch.float32) -> None:
         self.layer = layer
         self.name = name
         self.act_order = act_order
         self.create_weight_orig = create_weight_orig
+        # device and dtype of buffers; auto for device means using the same device for the buffer as the layer weights
+        self.device = layer.weight.device if device == 'auto' else device
+        self.dtype = dtype
 
         weight_shape = torch.tensor(layer.weight.shape)
 
@@ -206,6 +222,14 @@ class GPxQ(ABC):
         self.disable_pre_forward_hook = False
         # Some layers require knowledge from quant inputs to compute quant weights
         self.quant_metadata = None
+
+    @property
+    def use_intermediate_buffer(self):
+        # By default, we are optimizing for minimumizing peak memory usage, which is
+        # when self.device=='cpu'. Since the compute is done on the GPU but the buffers
+        # are on the GPU, we optimize the CPU to GPU transfer using in-place copy to pinned
+        # memory in an intermediate buffer, usually self.B
+        return self.device == 'cpu'
 
     def process_input(self, inp):
         # Input is a tuple, so we take first element

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -228,7 +228,7 @@ class GPxQ(ABC):
     def use_intermediate_buffer(self):
         # By default, we are optimizing for minimizing peak memory usage, which is
         # when self.device=='cpu'. Since the compute is done on the GPU but the buffers
-        # are on the GPU, we optimize the CPU to GPU transfer using in-place copy to 
+        # are on the GPU, we optimize the CPU to GPU transfer using in-place copy to
         # pinned memory in an intermediate buffer, usually self.B
         return self.device == 'cpu'
 

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -50,9 +50,10 @@ class gpxq_mode(quantization_status_manager):
         use_quant_activations (bool): Wheter to leave quantize activations enabled while performing
             GPxQ. Default: False
         act_order (bool): Whether to order greedy path following by Hessian approximation. Default: False
-        device ()
         return_forward_output (bool): If True, returns the output of the forward pass. Otherwise the
             forward call inside the context manager returns None. Default: False
+        device (str): Device the buffers are stored on. Default: cpu
+        dtype (torch.dtype): Datatype the buffers are stored in. Default: torch.float32
 
     Example:
         >>> with torch.no_grad():

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -198,8 +198,8 @@ class GPxQ(ABC):
         self.name = name
         self.act_order = act_order
         self.create_weight_orig = create_weight_orig
-        # device and dtype of buffers; auto for device means using the same device for the buffer as the layer weights
-        self.device = layer.weight.device if device == 'auto' else device
+        # device and dtype of buffers; 'same' means using the same device for the buffer as the layer weights
+        self.device = layer.weight.device if device == 'same' else device
         self.dtype = dtype
 
         weight_shape = torch.tensor(layer.weight.shape)

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -226,10 +226,10 @@ class GPxQ(ABC):
 
     @property
     def use_intermediate_buffer(self):
-        # By default, we are optimizing for minimumizing peak memory usage, which is
+        # By default, we are optimizing for minimizing peak memory usage, which is
         # when self.device=='cpu'. Since the compute is done on the GPU but the buffers
-        # are on the GPU, we optimize the CPU to GPU transfer using in-place copy to pinned
-        # memory in an intermediate buffer, usually self.B
+        # are on the GPU, we optimize the CPU to GPU transfer using in-place copy to 
+        # pinned memory in an intermediate buffer, usually self.B
         return self.device == 'cpu'
 
     def process_input(self, inp):

--- a/src/brevitas/graph/magr.py
+++ b/src/brevitas/graph/magr.py
@@ -81,23 +81,26 @@ class MagR(GPTQ):
             create_weight_orig,
             gradient_steps: int = 200,
             power_steps: int = 30,
-            alpha: float = 0.01) -> None:
+            alpha: float = 0.01,
+            device='cpu',
+            dtype=torch.float32) -> None:
         # Note: using GPxQ initialization to avoid blocksize initialization and the
         # torch versioning assertion
-        GPxQ.__init__(self, layer, name, None, len_parallel_layers, create_weight_orig)
+        GPxQ.__init__(
+            self, layer, name, None, len_parallel_layers, create_weight_orig, device, dtype)
         self.gradient_steps = gradient_steps
         self.power_steps = power_steps
         self.alpha = alpha
 
         # Initialize covariance matrix and counter. We need it in float32 to compute the inverse
         self.H = torch.zeros((self.groups, self.columns, self.columns),
-                             device='cpu',
-                             dtype=torch.float32,
-                             pin_memory=torch.cuda.is_available())
-        self.B = torch.zeros((self.groups, self.columns, self.columns),
-                             device='cpu',
-                             dtype=torch.float32,
-                             pin_memory=torch.cuda.is_available())
+                             device=self.device,
+                             dtype=self.dtype)
+        if self.use_intermediate_buffer:
+            self.B = torch.zeros((self.groups, self.columns, self.columns),
+                                 device=self.device,
+                                 dtype=self.dtype,
+                                 pin_memory=torch.cuda.is_available())
         self.nsamples = 0
 
     def update_batch(self, module, input, current_layer):
@@ -138,8 +141,8 @@ class MagR(GPTQ):
             # approximate maximum singular value (ie, matrix L2 norm)
             eta = 1. / _power_iteration(self.H[group_index], steps=self.power_steps)
             alpha = self.alpha / (eta * torch.linalg.norm(self.H[group_index], ord=1))
-            wk = weight[group_index].to(torch.float32)
-            gk = weight_orig[group_index].to(torch.float32)  # ground
+            wk = weight[group_index].to(self.dtype)
+            gk = weight_orig[group_index].to(self.dtype)  # ground
             for _ in tqdm(range(self.gradient_steps), leave=False):
                 vk = wk - eta * (wk - gk).matmul(
                     self.H[group_index])  # argument of the proximal operator
@@ -166,6 +169,8 @@ class magr_mode(gpxq_mode):
             MagR. These weights will be used anytime quantization is disabled. Default: True
         return_forward_output (bool): If True, returns the output of the forward pass. Otherwise the
             forward call inside the context manager returns None. Default: False
+        device (str): Device the buffers are stored on. Default: cpu
+        dtype (torch.dtype): Datatype the buffers are stored in. Default: torch.float32
 
     Example:
         >>> with torch.no_grad():
@@ -186,7 +191,9 @@ class magr_mode(gpxq_mode):
             group_of_parallel_layers: Optional[List[str]] = None,
             inplace: bool = True,
             create_weight_orig: bool = True,
-            return_forward_output: bool = False) -> None:
+            return_forward_output: bool = False,
+            device: str = 'cpu',
+            dtype: torch.dtype = torch.float32) -> None:
         if not inplace:
             model = deepcopy(model)
         super().__init__(
@@ -194,7 +201,9 @@ class magr_mode(gpxq_mode):
             group_of_parallel_layers=group_of_parallel_layers,
             inplace=inplace,
             create_weight_orig=create_weight_orig,
-            return_forward_output=return_forward_output)
+            return_forward_output=return_forward_output,
+            device=device,
+            dtype=dtype)
         self.num_steps = num_steps
         self.alpha = alpha
 
@@ -225,4 +234,6 @@ class magr_mode(gpxq_mode):
             len_parallel_layers=len_parallel_layers,
             create_weight_orig=create_weight_orig,
             gradient_steps=self.num_steps,
-            alpha=self.alpha)
+            alpha=self.alpha,
+            device=self.device,
+            dtype=self.dtype)

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -145,7 +145,7 @@ class Qronos(GPFQ):
         assert not torch.isnan(self.H).any(), f"Error in {self.name}"
         assert not torch.isnan(self.G).any(), f"Error in {self.name}"
 
-        Dh: Tensor = torch.zeros((self.groups, self.columns), dtype=self.dtype)
+        Dh: Tensor = torch.zeros((self.groups, self.columns), device=self.device, dtype=self.dtype)
         for group_index in range(self.groups):
             Dh[group_index].copy_(self.H[group_index].diag())
         Dhi = torch.where(Dh != 0, 1. / Dh, torch.zeros_like(Dh)).to(dev)  # D^{-1}

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -32,8 +32,11 @@ class Qronos(GPFQ):
             len_parallel_layers,
             create_weight_orig,
             num_blocks: int = 100,
-            alpha: float = 1e-6) -> None:
-        super().__init__(layer, name, act_order, len_parallel_layers, create_weight_orig)
+            alpha: float = 1e-6,
+            device: str = 'cpu',
+            dtype: torch.dtype = torch.float32) -> None:
+        super().__init__(
+            layer, name, act_order, len_parallel_layers, create_weight_orig, device, dtype)
         self.blocksize = math.ceil(self.columns / num_blocks)
         self.alpha = alpha
 
@@ -45,7 +48,7 @@ class Qronos(GPFQ):
         current_layer.layer_names.add(self.name)
         # NOTE: batch_size = seqlen for language models here
         inp_processed = self.process_input(input)  # [groups, in_features, batch_size]
-        inp_processed = inp_processed.to(torch.float32)
+        inp_processed = inp_processed.to(self.dtype)
         batch_size = inp_processed.shape[-1]
 
         is_quant_enabled = module.weight_quant.is_quant_enabled
@@ -57,17 +60,23 @@ class Qronos(GPFQ):
         # if quant is not enabled, then it is the float input; if it is a float input
         # then a quant input has already happened and we can update G
         if not is_quant_enabled:
-            # Computing the normalized G matrix using CPU buffer
-            self.B.copy_(inp_processed.bmm(self.quant_input.transpose(2, 1)))
+            # Computing the normalized G matrix
             self.G *= (self.nsamples - batch_size) / self.nsamples
-            self.G += (self.B / self.nsamples)
+            if self.use_intermediate_buffer:
+                self.B.copy_(inp_processed.bmm(self.quant_input.transpose(2, 1)))
+                self.G += (self.B / self.nsamples)
+            else:
+                self.G += inp_processed.bmm(self.quant_input.transpose(2, 1))
             self.quant_input = None  # NOTE: set back to None now that we've used it
         else:
-            # Computing the normalized H matrix using CPU buffer
+            # Computing the normalized H matrix
             self.nsamples += batch_size  # NOTE: only increment with quant inputs
-            self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
             self.H *= (self.nsamples - batch_size) / self.nsamples
-            self.H += (self.B / self.nsamples)
+            if self.use_intermediate_buffer:
+                self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
+                self.H += (self.B / self.nsamples)
+            else:
+                self.H += inp_processed.bmm(inp_processed.transpose(2, 1))
             # store the quantized input for computing the H matrix
             assert self.quant_input is None
             self.quant_input = inp_processed
@@ -88,7 +97,8 @@ class Qronos(GPFQ):
             "Error: Qronos requires the original weights to be stored, see `create_weight_orig`."
         if hasattr(self.layer, 'allocate_params'):
             self.layer.allocate_params(self.layer)
-        del self.B  # free up memory by deleting the buffer
+        if self.use_intermediate_buffer:
+            del self.B  # free memory
 
         weight: Tensor = self.layer.weight.data
         weight_orig: Tensor = self.layer.weight_orig.data
@@ -135,21 +145,21 @@ class Qronos(GPFQ):
         assert not torch.isnan(self.H).any(), f"Error in {self.name}"
         assert not torch.isnan(self.G).any(), f"Error in {self.name}"
 
-        Dh: Tensor = torch.zeros((self.groups, self.columns), dtype=torch.float32)
+        Dh: Tensor = torch.zeros((self.groups, self.columns), dtype=self.dtype)
         for group_index in range(self.groups):
             Dh[group_index].copy_(self.H[group_index].diag())
         Dhi = torch.where(Dh != 0, 1. / Dh, torch.zeros_like(Dh)).to(dev)  # D^{-1}
 
         Uh: Tensor = torch.zeros((self.groups, self.columns, self.columns),
                                  device=dev,
-                                 dtype=torch.float32)
+                                 dtype=self.dtype)
         for group_index in range(self.groups):
             Uh[group_index].copy_(torch.triu(self.H[group_index], 1))  # upper (for future)
 
         # Try/Except in case the inverse cannot be computed
         self.iH = self.H.clone()
-        diag = torch.arange(self.columns, device='cpu')
-        damp = torch.zeros(self.groups, device='cpu')
+        diag = torch.arange(self.columns, device=self.device)
+        damp = torch.zeros(self.groups, device=self.device)
         try:
             for group_index in range(self.groups):
                 # using power iteration to estimate the maximum singular value
@@ -175,9 +185,9 @@ class Qronos(GPFQ):
         q_groups = self.get_quant_weights(0, 0, permutation_list, with_quant_history=True)
         for group_index in range(self.groups):
             perm = permutation_list[group_index]
-            q: Tensor = q_groups[group_index].to(torch.float32)
-            v: Tensor = weight[group_index, :, perm].to(torch.float32)
-            w: Tensor = weight_orig[group_index, :, perm].to(torch.float32)
+            q: Tensor = q_groups[group_index].to(self.dtype)
+            v: Tensor = weight[group_index, :, perm].to(self.dtype)
+            w: Tensor = weight_orig[group_index, :, perm].to(self.dtype)
             Gw = w.matmul(self.G[group_index, :, 0] * Dhi[group_index, 0])
             Uv = v.matmul(Uh[group_index, 0, :] * Dhi[group_index, 0])
             q_arg = Gw - Uv
@@ -195,8 +205,8 @@ class Qronos(GPFQ):
         q_groups = self.get_quant_weights(0, 1, permutation_list, with_quant_history=True)
         for group_index in range(self.groups):
             perm = permutation_list[group_index]
-            q: Tensor = q_groups[group_index].to(torch.float32)
-            w: Tensor = weight_orig[group_index, :, perm].to(torch.float32)
+            q: Tensor = q_groups[group_index].to(self.dtype)
+            w: Tensor = weight_orig[group_index, :, perm].to(self.dtype)
             Ih = torch.diag(torch.full((self.columns,), damp[group_index], device=dev))
             Gh = self.G[group_index] + Ih
             Gw = w.matmul(Gh[:, 1:] @ self.iH[group_index])
@@ -224,7 +234,7 @@ class Qronos(GPFQ):
             i2 = min(i1 + self.blocksize, self.columns)
             count = i2 - i1
             error_block = torch.zeros_like(
-                weight[:, :, perm[i1:i2]], dtype=torch.float32)  # [groups, OC/groups, i2-i1]
+                weight[:, :, perm[i1:i2]], dtype=self.dtype)  # [groups, OC/groups, i2-i1]
             # we need to decrement once because of the Sherman-Morrison-Woodbury update
             h_inv_block = self.L[:, i1 - 1:i2 - 1, i1 - 1:i2 - 1]
             # correct error within the block
@@ -233,9 +243,9 @@ class Qronos(GPFQ):
                 q_groups = self.get_quant_weights(i, i1, permutation_list)  # [groups, OC/groups]
                 for group_index in range(self.groups):
                     perm = permutation_list[group_index]
-                    q = q_groups[group_index].to(torch.float32)  # [OC/groups]
-                    w = weight[group_index, :, perm[i1:i2][i]].to(torch.float32)  # [OC/groups]
-                    d = h_inv_block[group_index, i, i].to(torch.float32)  # [1]
+                    q = q_groups[group_index].to(self.dtype)  # [OC/groups]
+                    w = weight[group_index, :, perm[i1:i2][i]].to(self.dtype)  # [OC/groups]
+                    d = h_inv_block[group_index, i, i].to(self.dtype)  # [1]
                     error = (w - q) / d  # [OC/groups]
                     error_block[group_index, :, i] = error
                     # update the weights

--- a/src/brevitas_examples/common/axe.py
+++ b/src/brevitas_examples/common/axe.py
@@ -176,9 +176,18 @@ class A2GPTQ(_AXE, GPTQ):
             create_weight_orig,
             num_blocks,
             max_accumulator_bit_width,
-            max_accumulator_tile_size) -> None:
+            max_accumulator_tile_size,
+            device='cpu',
+            dtype=torch.float32) -> None:
         super().__init__(
-            layer, name, act_order, len_parallel_layers, create_weight_orig, num_blocks)
+            layer,
+            name,
+            act_order,
+            len_parallel_layers,
+            create_weight_orig,
+            num_blocks,
+            device,
+            dtype)
         assert max_accumulator_bit_width is not None, \
             "Error: max_accumulator_bit_width is not specified."
         if not isinstance(max_accumulator_bit_width, Tensor):
@@ -203,6 +212,8 @@ class A2GPTQ(_AXE, GPTQ):
             )
         if hasattr(self.layer, "allocate_params"):
             self.layer.allocate_params(self.layer)
+        if self.use_intermediate_buffer:
+            del self.B  # free memory
         weight = self.layer.weight.data
         dev = weight.device
 
@@ -256,7 +267,7 @@ class A2GPTQ(_AXE, GPTQ):
         try:
             for i in range(self.groups):
                 damp = percdamp * torch.mean(torch.diag(self.H[i, :, :]))
-                diag = torch.arange(self.columns, device='cpu')
+                diag = torch.arange(self.columns, device=self.device)
                 self.H[i, diag, diag] += damp
                 self.H[i, :, :] = torch.linalg.cholesky(self.H[i, :, :])
                 self.H[i, :, :] = torch.cholesky_inverse(self.H[i, :, :])
@@ -271,7 +282,7 @@ class A2GPTQ(_AXE, GPTQ):
                 f'Increasing the number of samples might fix this issue')
             return
         finally:
-            del self.H, self.B
+            del self.H
 
         # initialize cumulative l1-norm
         lim_dtype = torch.int32 if self.max_accumulator_bit_width < 33 else torch.int64
@@ -284,7 +295,7 @@ class A2GPTQ(_AXE, GPTQ):
             count = i2 - i1
             error_block = torch.zeros_like(
                 weight[:, :, permutation_list[-1][i1:i2]],
-                dtype=torch.float32)  # [groups, OC/groups, i2-i1]
+                dtype=self.dtype)  # [groups, OC/groups, i2-i1]
             h_inv_block = h_inv[:, i1:i2, i1:i2]
             for i in range(count):
                 # need to apply soft thresholding and clamping before quantization
@@ -296,7 +307,7 @@ class A2GPTQ(_AXE, GPTQ):
                     n = neg_limits[group_index, bx]
                     p = pos_limits[group_index, bx]
                     q_arg: Tensor = weight[group_index, :,
-                                           perm[i1:i2][i]].to(torch.float32)  # [OC/groups]
+                                           perm[i1:i2][i]].to(self.dtype)  # [OC/groups]
                     u = self.upper_lim(n, p)
                     l = self.lower_lim(n, p)
                     assert (u - l + 1 >= 0).all()
@@ -310,8 +321,8 @@ class A2GPTQ(_AXE, GPTQ):
                 q_groups = self.get_quant_weights(i, i1, permutation_list)  # [Groups, OC/groups]
                 for group_index in range(self.groups):
                     perm = permutation_list[group_index]
-                    q = q_groups[group_index].to(torch.float32)  # [OC/groups]
-                    w = weight[group_index, :, perm[i1:i2][i]].to(torch.float32)  # [OC/groups]
+                    q = q_groups[group_index].to(self.dtype)  # [OC/groups]
+                    w = weight[group_index, :, perm[i1:i2][i]].to(self.dtype)  # [OC/groups]
                     d = h_inv_block[group_index, i, i]  # [1]
                     error = (w - q) / d  # [OC/groups]
                     error_block[group_index, :, i] = error
@@ -359,8 +370,11 @@ class A2GPFQ(_AXE, GPFQ):
             len_parallel_layers,
             create_weight_orig,
             max_accumulator_bit_width,
-            max_accumulator_tile_size) -> None:
-        super().__init__(layer, name, act_order, len_parallel_layers, create_weight_orig)
+            max_accumulator_tile_size,
+            device='cpu',
+            dtype=torch.float32) -> None:
+        super().__init__(
+            layer, name, act_order, len_parallel_layers, create_weight_orig, device, dtype)
         assert max_accumulator_bit_width is not None, \
             "Error: max_accumulator_bit_width must be specified."
         if not isinstance(max_accumulator_bit_width, Tensor):
@@ -385,7 +399,8 @@ class A2GPFQ(_AXE, GPFQ):
             )
         if hasattr(self.layer, "allocate_params"):
             self.layer.allocate_params(self.layer)
-        del self.B  # memory management
+        if self.use_intermediate_buffer:
+            del self.B  # free memory
 
         weight = self.layer.weight.data
         if self.create_weight_orig:
@@ -440,8 +455,8 @@ class A2GPFQ(_AXE, GPFQ):
             perm = perm.to(weight.device)
             permutation_list.append(perm)
 
-        Dg: Tensor = torch.zeros((self.groups, self.columns), dtype=torch.float32)
-        Dh: Tensor = torch.zeros((self.groups, self.columns), dtype=torch.float32)
+        Dg: Tensor = torch.zeros((self.groups, self.columns), dtype=self.dtype, device=self.device)
+        Dh: Tensor = torch.zeros((self.groups, self.columns), dtype=self.dtype, device=self.device)
         for group_index in range(self.groups):
             Dg[group_index].copy_(self.G[group_index].diag())
             Dh[group_index].copy_(self.H[group_index].diag())
@@ -450,10 +465,10 @@ class A2GPFQ(_AXE, GPFQ):
 
         Lg: Tensor = torch.zeros((self.groups, self.columns, self.columns),
                                  device=dev,
-                                 dtype=torch.float32)
+                                 dtype=self.dtype)
         Lh: Tensor = torch.zeros((self.groups, self.columns, self.columns),
                                  device=dev,
-                                 dtype=torch.float32)
+                                 dtype=self.dtype)
         for group_index in range(self.groups):
             L0g = torch.tril(self.G[group_index], -1)  # L0
             L0h = torch.tril(self.H[group_index], -1)  # \hat{L0}
@@ -480,15 +495,15 @@ class A2GPFQ(_AXE, GPFQ):
                 perm = permutation_list[group_index]
                 i = perm[t]
                 bx = i // self.max_accumulator_tile_size
-                w = weight_orig[group_index, :, perm[:t]].to(torch.float32)
-                q = q_groups[group_index].to(torch.float32)
+                w = weight_orig[group_index, :, perm[:t]].to(self.dtype)
+                q = q_groups[group_index].to(self.dtype)
                 Lw = w.matmul(Lg[group_index, t, :t])
                 Lq = q.matmul(Lh[group_index, t, :t])
-                q_arg = Ds[group_index, t] * weight[group_index, :, i].to(torch.float32) + Lw - Lq
+                q_arg = Ds[group_index, t] * weight[group_index, :, i].to(self.dtype) + Lw - Lq
                 assert not torch.isnan(q_arg).any()
 
                 # calculate the q_max and q_min for the right group and right block
-                s = scales[group_index, bx].to(torch.float32)
+                s = scales[group_index, bx].to(self.dtype)
                 n = neg_limits[group_index, bx]
                 p = pos_limits[group_index, bx]
                 u = self.upper_lim(n, p)

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -7,6 +7,8 @@ from typing import List
 from typing import Optional
 from warnings import warn
 
+import torch
+
 from brevitas_examples.common.parse_utils import create_entrypoint_args_parser
 from brevitas_examples.common.parse_utils import quant_format_validator
 
@@ -57,6 +59,17 @@ def create_args_parser() -> ArgumentParser:
         help=
         'Block name for faster GPxQ optimization. It works only if FX is not needed (default: %(default)s)'
     )
+    parser.add_argument(
+        '--gpxq-buffer-device',
+        type=str,
+        choices=['auto', 'cpu', 'cuda'],
+        default='cpu',
+        help='Device for GPxQ buffers. Default %(default)s')
+    parser.add_argument(
+        '--gpxq-buffer-dtype',
+        type=lambda s: getattr(torch, s),
+        default=torch.float32,
+        help='Datatype for the GPxQ buffers. Default: %(default)s')
     parser.add_argument(
         '--weight-bit-width', type=int, default=8, help='Weight bit width. Default: 8.')
     parser.add_argument(

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -68,11 +68,6 @@ def create_args_parser() -> ArgumentParser:
         'Device for GPxQ buffers. "same" means using the same device for the buffer as the layer weights. Default %(default)s'
     )
     parser.add_argument(
-        '--gpxq-buffer-dtype',
-        type=lambda s: getattr(torch, s),
-        default=torch.float32,
-        help='Datatype for the GPxQ buffers. Default: %(default)s')
-    parser.add_argument(
         '--weight-bit-width', type=int, default=8, help='Weight bit width. Default: 8.')
     parser.add_argument(
         '--weight-param-method',

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -62,9 +62,11 @@ def create_args_parser() -> ArgumentParser:
     parser.add_argument(
         '--gpxq-buffer-device',
         type=str,
-        choices=['auto', 'cpu', 'cuda'],
+        choices=['cpu', 'same'],
         default='cpu',
-        help='Device for GPxQ buffers. Default %(default)s')
+        help=
+        'Device for GPxQ buffers. "same" means using the same device for the buffer as the layer weights. Default %(default)s'
+    )
     parser.add_argument(
         '--gpxq-buffer-dtype',
         type=lambda s: getattr(torch, s),

--- a/src/brevitas_examples/llm/llm_quant/gpxq.py
+++ b/src/brevitas_examples/llm/llm_quant/gpxq.py
@@ -118,7 +118,9 @@ def apply_gptq(
         group_of_parallel_layers=None,
         block_name=None,
         max_accumulator_bit_width=None,
-        max_accumulator_tile_size=None):
+        max_accumulator_tile_size=None,
+        buffer_device='cpu',
+        buffer_dtype=torch.float32):
     if max_accumulator_bit_width is not None:
         # Use accumulator-aware extension (AXE) framework
         print(f"Using AXE to target {max_accumulator_bit_width}-bit accumulation...")
@@ -134,7 +136,9 @@ def apply_gptq(
             'group_of_parallel_layers': group_of_parallel_layers,
             'create_weight_orig': create_weight_orig,
             'use_quant_activations': use_quant_activations,
-            'gptq_class': gptq_class}
+            'gptq_class': gptq_class,
+            'device': buffer_device,
+            'dtype': buffer_dtype}
         block_optimization(model, dataloader, block_name, gptq_mode, context_manager_kwargs)
     else:
         with gptq_mode(model,
@@ -142,7 +146,9 @@ def apply_gptq(
                        group_of_parallel_layers=group_of_parallel_layers,
                        act_order=act_order,
                        create_weight_orig=create_weight_orig,
-                       gptq_class=gptq_class) as gptq:
+                       gptq_class=gptq_class,
+                       device=buffer_device,
+                       dtype=buffer_dtype) as gptq:
             gptq_model = gptq.model
             for _ in tqdm(range(gptq.num_layers)):
                 for inps in dataloader:
@@ -156,7 +162,9 @@ def _dual_optimization_callback(
         act_order=True,
         block_name=None,
         group_of_parallel_layers=None,
-        algorithm_impl=GPFQ):
+        algorithm_impl=GPFQ,
+        device='cpu',
+        dtype=torch.float32):
     """
     This wraps gpfq_mode, which can be used for any layerwise PTQ algorithm that
     optimizes the mismatched objective function || XW - \tilde{X}Q ||, where
@@ -170,14 +178,18 @@ def _dual_optimization_callback(
             'act_order': act_order,
             'group_of_parallel_layers': group_of_parallel_layers,
             'create_weight_orig': True,
-            'algorithm_impl': algorithm_impl}
+            'algorithm_impl': algorithm_impl,
+            'device': device,
+            'dtype': dtype}
         block_optimization(model, dataloader, block_name, gpfq_mode, context_manager_kwargs)
     else:
         with gpfq_mode(model,
                        act_order=act_order,
                        group_of_parallel_layers=group_of_parallel_layers,
                        create_weight_orig=True,
-                       algorithm_impl=algorithm_impl) as algo:
+                       algorithm_impl=algorithm_impl,
+                       device=device,
+                       dtype=dtype) as algo:
             algo_model = algo.model
             for _ in tqdm(range(algo.num_layers)):
                 for inps in dataloader:
@@ -193,7 +205,9 @@ def apply_gpfq(
         group_of_parallel_layers=None,
         block_name=None,
         max_accumulator_bit_width=None,
-        max_accumulator_tile_size=None):
+        max_accumulator_tile_size=None,
+        buffer_device='cpu',
+        buffer_dtype=torch.float32):
     if max_accumulator_bit_width is not None:
         # Use accumulator-aware extension (AXE) framework
         print(f"Using AXE to target {max_accumulator_bit_width}-bit accumulation...")
@@ -211,7 +225,9 @@ def apply_gpfq(
         act_order=act_order,
         block_name=block_name,
         group_of_parallel_layers=group_of_parallel_layers,
-        algorithm_impl=algorithm_impl)
+        algorithm_impl=algorithm_impl,
+        device=buffer_device,
+        dtype=buffer_dtype)
 
 
 @torch.no_grad()
@@ -221,7 +237,9 @@ def apply_qronos(
         act_order=True,
         group_of_parallel_layers=None,
         block_name=None,
-        alpha=1e-6):
+        alpha=1e-6,
+        buffer_device='cpu',
+        buffer_dtype=torch.float32):
     assert alpha > 0, "Error: alpha needs to be strictly positive"
     # We use the dual optimization callback, which uses two forward passes to correct
     # quantization error in both the weights and activations from previous layers
@@ -231,7 +249,9 @@ def apply_qronos(
         act_order=act_order,
         block_name=block_name,
         group_of_parallel_layers=group_of_parallel_layers,
-        algorithm_impl=partial(Qronos, alpha=alpha))
+        algorithm_impl=partial(Qronos, alpha=alpha),
+        device=buffer_device,
+        dtype=buffer_dtype)
 
 
 @torch.no_grad()
@@ -242,13 +262,17 @@ def apply_magr(
         group_of_parallel_layers=None,
         block_name=None,
         alpha=0.01,
-        num_steps=200):
+        num_steps=200,
+        buffer_device='cpu',
+        buffer_dtype=torch.float32):
     if block_name is not None:
         context_manager_kwargs = {
             'group_of_parallel_layers': group_of_parallel_layers,
             'create_weight_orig': create_weight_orig,
             'alpha': alpha,
-            'num_steps': num_steps}
+            'num_steps': num_steps,
+            'device': buffer_device,
+            'dtype': buffer_dtype}
         block_optimization(
             model,
             dataloader,
@@ -261,7 +285,9 @@ def apply_magr(
                        group_of_parallel_layers=group_of_parallel_layers,
                        create_weight_orig=create_weight_orig,
                        num_steps=num_steps,
-                       alpha=alpha) as magr:
+                       alpha=alpha,
+                       device=buffer_device,
+                       dtype=buffer_dtype) as magr:
             magr_model = magr.model
             for inps in tqdm(dataloader, desc="Calculating covariances..."):
                 magr_model(**inps)

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -365,7 +365,9 @@ def quantize_llm(args, extra_args=None):
             model,
             calibration_loader,
             create_weight_orig=not args.disable_create_weight_orig,
-            alpha=args.magr_alpha)
+            alpha=args.magr_alpha,
+            buffer_dtype=args.gpxq_buffer_dtype,
+            buffer_device=args.gpxq_buffer_device)
         remove_hooks(model)
         print(f"MagR applied.")
 
@@ -587,6 +589,8 @@ def quantize_llm(args, extra_args=None):
                 use_quant_activations=args.gpxq_use_quant_activations,
                 create_weight_orig=not args.disable_create_weight_orig,
                 block_name=args.gpxq_block_name,
+                buffer_dtype=args.gpxq_buffer_dtype,
+                buffer_device=args.gpxq_buffer_device,
                 max_accumulator_bit_width=args.gpxq_max_accumulator_bit_width,
                 max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
             print("GPTQ applied.")
@@ -598,6 +602,8 @@ def quantize_llm(args, extra_args=None):
                 calibration_loader,
                 act_order=args.gpxq_act_order,
                 block_name=args.gpxq_block_name,
+                buffer_dtype=args.gpxq_buffer_dtype,
+                buffer_device=args.gpxq_buffer_device,
                 max_accumulator_bit_width=args.gpxq_max_accumulator_bit_width,
                 max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
             print("GPFQ applied.")
@@ -609,7 +615,9 @@ def quantize_llm(args, extra_args=None):
                 calibration_loader,
                 alpha=args.qronos_alpha,
                 act_order=args.gpxq_act_order,
-                block_name=args.gpxq_block_name)
+                block_name=args.gpxq_block_name,
+                buffer_dtype=args.gpxq_buffer_dtype,
+                buffer_device=args.gpxq_buffer_device)
             print("Qronos applied.")
 
         if args.bias_corr and not args.load_checkpoint:

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -366,7 +366,6 @@ def quantize_llm(args, extra_args=None):
             calibration_loader,
             create_weight_orig=not args.disable_create_weight_orig,
             alpha=args.magr_alpha,
-            buffer_dtype=args.gpxq_buffer_dtype,
             buffer_device=args.gpxq_buffer_device)
         remove_hooks(model)
         print(f"MagR applied.")
@@ -589,7 +588,6 @@ def quantize_llm(args, extra_args=None):
                 use_quant_activations=args.gpxq_use_quant_activations,
                 create_weight_orig=not args.disable_create_weight_orig,
                 block_name=args.gpxq_block_name,
-                buffer_dtype=args.gpxq_buffer_dtype,
                 buffer_device=args.gpxq_buffer_device,
                 max_accumulator_bit_width=args.gpxq_max_accumulator_bit_width,
                 max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
@@ -602,7 +600,6 @@ def quantize_llm(args, extra_args=None):
                 calibration_loader,
                 act_order=args.gpxq_act_order,
                 block_name=args.gpxq_block_name,
-                buffer_dtype=args.gpxq_buffer_dtype,
                 buffer_device=args.gpxq_buffer_device,
                 max_accumulator_bit_width=args.gpxq_max_accumulator_bit_width,
                 max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
@@ -616,7 +613,6 @@ def quantize_llm(args, extra_args=None):
                 alpha=args.qronos_alpha,
                 act_order=args.gpxq_act_order,
                 block_name=args.gpxq_block_name,
-                buffer_dtype=args.gpxq_buffer_dtype,
                 buffer_device=args.gpxq_buffer_device)
             print("Qronos applied.")
 


### PR DESCRIPTION
## Reason for this PR

Currently, GPxQ algorithms (GPTQ, GPFQ, Qronos, and MagR) are hard-coded to store the buffers (`self.H`, `self.G`, and `self.B`) in CPU memory, which optimizes for minimizing peak memory usage. However, when we have enough GPU memory to store the buffers, we can avoid the overheads of CPU-to-GPU transfer in GPxQ algorithms by keeping `self.H` (and `self.G` in GPFQ and Qronos) on the same device as the layer we are quantizing. This can lead to substantial performance gains in some cases. So, this PR introduces `--gpxq-buffer-device={cpu, same}` to expose control over such an optimization to the CLI.

Example: 
```shell
brevitas_ptq_llm --config=papers/qronos/llama3-w4-base.yml --gpxq-buffer-device=cpu --gptq
```

Initial ad-hoc testing of the above example gave ~18x speedup for GPTQ and ~38x speedup for Qronos when switching to `--gpxq-buffer-device=same` on an AMD Instinct MI325X.

**Disclaimer:** this was a single run with no extra checks and results might vary significantly based on system configuration.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

- Removed hard-coding of the device and dtype for GPxQ buffers
- Added `--gpxq-buffer-device={cpu, same}`

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [x] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
