### PR TITLE
feat (quant/mx): Added midmax scale rounding option to MX types

### DIFF
--- a/src/brevitas/core/scaling/__init__.py
+++ b/src/brevitas/core/scaling/__init__.py
@@ -10,6 +10,7 @@ assert ScalingPerOutputType
 from brevitas.core.stats import SCALAR_SHAPE
 
 from .float_scaling import FloatScaling
+from .float_scaling import RoundMidMaxSte
 from .int_scaling import IntScaling
 from .int_scaling import PowerOfTwoIntScaling
 from .pre_scaling import AccumulatorAwareParameterPreScaling

--- a/src/brevitas/core/scaling/float_scaling.py
+++ b/src/brevitas/core/scaling/float_scaling.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 
 import brevitas
 from brevitas.core.utils import StatelessBuffer
+from brevitas.function.ops import calculate_midmax_bias
 from brevitas.function.ops import max_float
 from brevitas.function.ops_ste import ceil_ste
 
@@ -48,13 +49,6 @@ class FloatScaling(brevitas.jit.ScriptModule):
         return max_value
 
 
-@brevitas.jit.script
-def _calculate_midmax_bias(mantissa_bit_width: Tensor, midmax_mantissa_bit_bias: float) -> Tensor:
-    return torch.log2(
-        (2 -
-         2 ** (-mantissa_bit_width - 1 + midmax_mantissa_bit_bias)))  # extra 1 for the implicit bit
-
-
 class RoundMidMaxSte(brevitas.jit.ScriptModule):
 
     def __init__(self, mantissa_bit_width_impl: nn.Module, midmax_mantissa_bit_bias: float = 0.0):
@@ -66,4 +60,4 @@ class RoundMidMaxSte(brevitas.jit.ScriptModule):
     def forward(self, x: Tensor) -> Tensor:
         return ceil_ste(
             x -
-            _calculate_midmax_bias(self.mantissa_bit_width_impl(), self.midmax_mantissa_bit_bias))
+            calculate_midmax_bias(self.mantissa_bit_width_impl(), self.midmax_mantissa_bit_bias))

--- a/src/brevitas/core/scaling/float_scaling.py
+++ b/src/brevitas/core/scaling/float_scaling.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import torch
 from torch import Tensor
+import torch.nn as nn
 
 import brevitas
 from brevitas.core.utils import StatelessBuffer

--- a/src/brevitas/core/scaling/float_scaling.py
+++ b/src/brevitas/core/scaling/float_scaling.py
@@ -7,10 +7,12 @@ from typing import Tuple
 
 import torch
 from torch import Tensor
+import torch.nn as nn
 
 import brevitas
 from brevitas.core.utils import StatelessBuffer
 from brevitas.function.ops import max_float
+from brevitas.function.ops_ste import floor_ste
 
 
 class FloatScaling(brevitas.jit.ScriptModule):
@@ -44,3 +46,17 @@ class FloatScaling(brevitas.jit.ScriptModule):
         max_value = max_value if self.max_available_float is None else torch.min(
             max_value, self.max_available_float())
         return max_value
+
+
+def _calculate_midmax_bias(mantissa_bit_width: Tensor):
+    return 1 - torch.log2((2 - 2 ** (-mantissa_bit_width - 1)))  # extra 1 for the implicit bit
+
+
+class RoundMidMaxSte(nn.Module):
+
+    def __init__(self, mantissa_bit_width_impl: nn.Module):
+        super().__init__()
+        self.mantissa_bit_width_impl = mantissa_bit_width_impl
+
+    def forward(self, x: Tensor):
+        return floor_ste(x + _calculate_midmax_bias(self.mantissa_bit_width_impl()))

--- a/src/brevitas/core/scaling/float_scaling.py
+++ b/src/brevitas/core/scaling/float_scaling.py
@@ -12,7 +12,7 @@ import torch.nn as nn
 import brevitas
 from brevitas.core.utils import StatelessBuffer
 from brevitas.function.ops import max_float
-from brevitas.function.ops_ste import floor_ste
+from brevitas.function.ops_ste import ceil_ste
 
 
 class FloatScaling(brevitas.jit.ScriptModule):
@@ -48,15 +48,15 @@ class FloatScaling(brevitas.jit.ScriptModule):
         return max_value
 
 
-def _calculate_midmax_bias(mantissa_bit_width: Tensor):
-    return 1 - torch.log2((2 - 2 ** (-mantissa_bit_width - 1)))  # extra 1 for the implicit bit
+def _calculate_midmax_bias(mantissa_bit_width: Tensor, midmax_mantissa_bit_bias: float):
+    return torch.log2((2 - 2**(-mantissa_bit_width - 1 + midmax_mantissa_bit_bias))) # extra 1 for the implicit bit
 
 
 class RoundMidMaxSte(nn.Module):
-
-    def __init__(self, mantissa_bit_width_impl: nn.Module):
+    def __init__(self, mantissa_bit_width_impl: nn.Module, midmax_mantissa_bit_bias: float = 0.0):
         super().__init__()
         self.mantissa_bit_width_impl = mantissa_bit_width_impl
+        self.midmax_mantissa_bit_bias = midmax_mantissa_bit_bias
 
     def forward(self, x: Tensor):
-        return floor_ste(x + _calculate_midmax_bias(self.mantissa_bit_width_impl()))
+        return ceil_ste(x - _calculate_midmax_bias(self.mantissa_bit_width_impl(), self.midmax_mantissa_bit_bias))

--- a/src/brevitas/core/scaling/float_scaling.py
+++ b/src/brevitas/core/scaling/float_scaling.py
@@ -49,14 +49,19 @@ class FloatScaling(brevitas.jit.ScriptModule):
 
 
 def _calculate_midmax_bias(mantissa_bit_width: Tensor, midmax_mantissa_bit_bias: float):
-    return torch.log2((2 - 2**(-mantissa_bit_width - 1 + midmax_mantissa_bit_bias))) # extra 1 for the implicit bit
+    return torch.log2(
+        (2 -
+         2 ** (-mantissa_bit_width - 1 + midmax_mantissa_bit_bias)))  # extra 1 for the implicit bit
 
 
 class RoundMidMaxSte(nn.Module):
+
     def __init__(self, mantissa_bit_width_impl: nn.Module, midmax_mantissa_bit_bias: float = 0.0):
         super().__init__()
         self.mantissa_bit_width_impl = mantissa_bit_width_impl
         self.midmax_mantissa_bit_bias = midmax_mantissa_bit_bias
 
     def forward(self, x: Tensor):
-        return ceil_ste(x - _calculate_midmax_bias(self.mantissa_bit_width_impl(), self.midmax_mantissa_bit_bias))
+        return ceil_ste(
+            x -
+            _calculate_midmax_bias(self.mantissa_bit_width_impl(), self.midmax_mantissa_bit_bias))

--- a/src/brevitas/core/scaling/float_scaling.py
+++ b/src/brevitas/core/scaling/float_scaling.py
@@ -7,7 +7,6 @@ from typing import Tuple
 
 import torch
 from torch import Tensor
-import torch.nn as nn
 
 import brevitas
 from brevitas.core.utils import StatelessBuffer
@@ -48,20 +47,22 @@ class FloatScaling(brevitas.jit.ScriptModule):
         return max_value
 
 
-def _calculate_midmax_bias(mantissa_bit_width: Tensor, midmax_mantissa_bit_bias: float):
+@brevitas.jit.script
+def _calculate_midmax_bias(mantissa_bit_width: Tensor, midmax_mantissa_bit_bias: float) -> Tensor:
     return torch.log2(
         (2 -
          2 ** (-mantissa_bit_width - 1 + midmax_mantissa_bit_bias)))  # extra 1 for the implicit bit
 
 
-class RoundMidMaxSte(nn.Module):
+class RoundMidMaxSte(brevitas.jit.ScriptModule):
 
     def __init__(self, mantissa_bit_width_impl: nn.Module, midmax_mantissa_bit_bias: float = 0.0):
         super().__init__()
         self.mantissa_bit_width_impl = mantissa_bit_width_impl
         self.midmax_mantissa_bit_bias = midmax_mantissa_bit_bias
 
-    def forward(self, x: Tensor):
+    @brevitas.jit.script_method
+    def forward(self, x: Tensor) -> Tensor:
         return ceil_ste(
             x -
             _calculate_midmax_bias(self.mantissa_bit_width_impl(), self.midmax_mantissa_bit_bias))

--- a/src/brevitas/core/scaling/int_scaling.py
+++ b/src/brevitas/core/scaling/int_scaling.py
@@ -5,6 +5,7 @@ from typing import Optional
 from typing import Union
 
 import torch
+from torch import nn
 from torch import Tensor
 
 import brevitas

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -212,6 +212,13 @@ def max_float(exponent_bit_width: Tensor, max_mantissa: Tensor, exponent_bias: T
     return max_val
 
 
+@brevitas.jit.script
+def calculate_midmax_bias(mantissa_bit_width: Tensor, midmax_mantissa_bit_bias: float) -> Tensor:
+    return torch.log2(
+        (2 -
+         2 ** (-mantissa_bit_width - 1 + midmax_mantissa_bit_bias)))  # extra 1 for the implicit bit
+
+
 def get_upper_bound_on_l1_norm(
         accumulator_bit_width: Tensor, input_bit_width: Tensor, input_is_signed: bool) -> Tensor:
     """Calculate the upper bound on the l1-norm of the weights needed to guarantee overflow avoidance

--- a/src/brevitas/quant/experimental/mx_quant_ocp.py
+++ b/src/brevitas/quant/experimental/mx_quant_ocp.py
@@ -29,6 +29,7 @@ from brevitas.quant.experimental.float_quant_ocp import FpOCPAct
 from brevitas.quant.experimental.float_quant_ocp import FpOCPWeight
 from brevitas.quant.solver.act import ActQuantSolver
 from brevitas.quant.solver.weight import WeightQuantSolver
+from brevitas.utils.float_quant_utils import get_midmax_mantissa_bit_bias
 
 
 class GroupwiseWeightFloatProxyMixin(ExtendedInjector):
@@ -52,7 +53,7 @@ class RestrictThresholdMixin(ExtendedInjector):
     restrict_scaling_impl = PowerOfTwoRestrictValue
 
 
-class MXWeightMixin(ExtendedInjector):
+class MXMixin(ExtendedInjector):
     threshold_mixin = RestrictThresholdMixin
     group_size = 32
     restrict_scaling_type = RestrictValueType.POWER_OF_TWO
@@ -63,14 +64,22 @@ class MXWeightMixin(ExtendedInjector):
     def restrict_threshold_impl():
         return this.threshold_mixin.restrict_scaling_impl
 
+    @value
+    def midmax_mantissa_bit_bias(
+            exponent_bit_width, mantissa_bit_width, exponent_bias, nan_values, inf_values,
+            saturating):
+        return get_midmax_mantissa_bit_bias(
+            mantissa_bit_width,
+            nan_values,
+            inf_values)
 
-class MXActMixin(ExtendedInjector):
-    threshold_mixin = RestrictThresholdMixin
-    group_size = 32
-    restrict_scaling_type = RestrictValueType.POWER_OF_TWO
-    restrict_value_float_to_int_impl = FloorSte
+
+class MXWeightMixin(MXMixin):
+    pass
+
+
+class MXActMixin(MXMixin):
     scaling_impl = RuntimeDynamicGroupStatsScaling
-    scaling_per_output_type = ScalingPerOutputType.GROUP
 
     @value
     def stats_reduce_dim(group_dim):
@@ -79,10 +88,6 @@ class MXActMixin(ExtendedInjector):
             return -1
         else:
             return group_dim + 1
-
-    @value
-    def restrict_threshold_impl():
-        return this.threshold_mixin.restrict_scaling_impl
 
 
 class MXFloat8e4m3Weight(MXWeightMixin,

--- a/src/brevitas/quant/experimental/mx_quant_ocp.py
+++ b/src/brevitas/quant/experimental/mx_quant_ocp.py
@@ -68,10 +68,7 @@ class MXMixin(ExtendedInjector):
     def midmax_mantissa_bit_bias(
             exponent_bit_width, mantissa_bit_width, exponent_bias, nan_values, inf_values,
             saturating):
-        return get_midmax_mantissa_bit_bias(
-            mantissa_bit_width,
-            nan_values,
-            inf_values)
+        return get_midmax_mantissa_bit_bias(mantissa_bit_width, nan_values, inf_values)
 
 
 class MXWeightMixin(MXMixin):

--- a/src/brevitas/quant/experimental/mx_quant_ocp.py
+++ b/src/brevitas/quant/experimental/mx_quant_ocp.py
@@ -65,9 +65,7 @@ class MXMixin(ExtendedInjector):
         return this.threshold_mixin.restrict_scaling_impl
 
     @value
-    def midmax_mantissa_bit_bias(
-            exponent_bit_width, mantissa_bit_width, exponent_bias, nan_values, inf_values,
-            saturating):
+    def midmax_mantissa_bit_bias(mantissa_bit_width, nan_values, inf_values):
         return get_midmax_mantissa_bit_bias(mantissa_bit_width, nan_values, inf_values)
 
 

--- a/src/brevitas/utils/float_quant_utils.py
+++ b/src/brevitas/utils/float_quant_utils.py
@@ -97,6 +97,7 @@ def get_min_available_float(
     return min_value
 
 
+# TODO: Allow dynamically changing this value at runtime
 def get_midmax_mantissa_bit_bias(
         mantissa_bit_width: int, nan_values: Tuple[str], inf_values: Tuple[str]) -> float:
     # Calculate how much bias needs to be added midmax calculation, based on the amount of reserved values for inf, nan

--- a/src/brevitas/utils/float_quant_utils.py
+++ b/src/brevitas/utils/float_quant_utils.py
@@ -95,3 +95,20 @@ def get_min_available_float(
     min_value = get_minifloat_value(
         exponent=exponent, mantissa=mantissa, exponent_bias=exponent_bias)
     return min_value
+
+
+def get_midmax_mantissa_bit_bias(
+        mantissa_bit_width: int,
+        nan_values: Tuple[str],
+        inf_values: Tuple[str]) -> float:
+    # Calculate how much bias needs to be added midmax calculation, based on the amount of reserved values for inf, nan
+    num_inf_values = 0 if inf_values is None else len(inf_values)
+    num_nan_values = 0 if nan_values is None else len(nan_values)
+    total_reserved_values = num_inf_values + num_nan_values
+    excess_reserved_values = total_reserved_values % 2**mantissa_bit_width  # How many extra values are reserved for the highest valid exponent
+    if excess_reserved_values == 0:
+        return 0.0  # No special reserved mantissa values at maximum valid mantissa
+    elif (excess_reserved_values + 1) == 2**mantissa_bit_width:
+        return 0.0  # Edge case when only f'0{mantissa_bit_width}b' is representable at the maximum mantissa
+    else:
+        return torch.log2(torch.tensor(excess_reserved_values + 1)).item()  # The number of bits of the mantissa that are consumed by the reserved values

--- a/src/brevitas/utils/float_quant_utils.py
+++ b/src/brevitas/utils/float_quant_utils.py
@@ -98,17 +98,16 @@ def get_min_available_float(
 
 
 def get_midmax_mantissa_bit_bias(
-        mantissa_bit_width: int,
-        nan_values: Tuple[str],
-        inf_values: Tuple[str]) -> float:
+        mantissa_bit_width: int, nan_values: Tuple[str], inf_values: Tuple[str]) -> float:
     # Calculate how much bias needs to be added midmax calculation, based on the amount of reserved values for inf, nan
     num_inf_values = 0 if inf_values is None else len(inf_values)
     num_nan_values = 0 if nan_values is None else len(nan_values)
     total_reserved_values = num_inf_values + num_nan_values
-    excess_reserved_values = total_reserved_values % 2**mantissa_bit_width  # How many extra values are reserved for the highest valid exponent
+    excess_reserved_values = total_reserved_values % 2 ** mantissa_bit_width  # How many extra values are reserved for the highest valid exponent
     if excess_reserved_values == 0:
         return 0.0  # No special reserved mantissa values at maximum valid mantissa
-    elif (excess_reserved_values + 1) == 2**mantissa_bit_width:
+    elif (excess_reserved_values + 1) == 2 ** mantissa_bit_width:
         return 0.0  # Edge case when only f'0{mantissa_bit_width}b' is representable at the maximum mantissa
     else:
-        return torch.log2(torch.tensor(excess_reserved_values + 1)).item()  # The number of bits of the mantissa that are consumed by the reserved values
+        return torch.log2(torch.tensor(excess_reserved_values + 1)).item(
+        )  # The number of bits of the mantissa that are consumed by the reserved values

--- a/src/brevitas_examples/common/generative/quant_blocks.py
+++ b/src/brevitas_examples/common/generative/quant_blocks.py
@@ -5,12 +5,14 @@ Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 
 from typing import Callable
 
+import torch
 from torch import Tensor
 import torch.nn as nn
 
 from brevitas.core.restrict_val import _RestrictClampValue
 from brevitas.core.zero_point import _ScaleShiftZeroPoint
 from brevitas.function.ops_ste import abs_binary_sign_grad
+from brevitas.function.ops_ste import floor_ste
 
 
 # TODO: restore JIT compatibility
@@ -74,3 +76,17 @@ class RuntimeDynamicStatsZeroPoint(nn.Module):
         x = abs_binary_sign_grad(x)
         x = self.scale_shift_zero_point(x, scale, bit_width)
         return x
+
+
+def _calculate_midmax_bias(mantissa_bit_width):
+    return 1 - torch.log2(torch.tensor((2 - 2**(-mantissa_bit_width - 1)))).detach() # extra 1 for the implicit bit
+
+
+class RoundMidMaxSte(nn.Module):
+    def __init__(self, mantissa_bit_width):
+        super().__init__()
+        self.mantissa_bit_width = mantissa_bit_width
+        self.midmax_round_bias = _calculate_midmax_bias(mantissa_bit_width) # Only works with static mantissa bitwidth
+
+    def forward(self, x):
+        return floor_ste(x + self.midmax_round_bias)

--- a/src/brevitas_examples/common/generative/quant_blocks.py
+++ b/src/brevitas_examples/common/generative/quant_blocks.py
@@ -5,7 +5,8 @@ Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 
 from typing import Callable
 
-import torch
+from torch import Tensor
+import torch.nn as nn
 
 from brevitas.core.restrict_val import _RestrictClampValue
 from brevitas.core.zero_point import _ScaleShiftZeroPoint

--- a/src/brevitas_examples/common/generative/quant_blocks.py
+++ b/src/brevitas_examples/common/generative/quant_blocks.py
@@ -6,13 +6,10 @@ Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 from typing import Callable
 
 import torch
-from torch import Tensor
-import torch.nn as nn
 
 from brevitas.core.restrict_val import _RestrictClampValue
 from brevitas.core.zero_point import _ScaleShiftZeroPoint
 from brevitas.function.ops_ste import abs_binary_sign_grad
-from brevitas.function.ops_ste import floor_ste
 
 
 # TODO: restore JIT compatibility
@@ -76,17 +73,3 @@ class RuntimeDynamicStatsZeroPoint(nn.Module):
         x = abs_binary_sign_grad(x)
         x = self.scale_shift_zero_point(x, scale, bit_width)
         return x
-
-
-def _calculate_midmax_bias(mantissa_bit_width):
-    return 1 - torch.log2(torch.tensor((2 - 2**(-mantissa_bit_width - 1)))).detach() # extra 1 for the implicit bit
-
-
-class RoundMidMaxSte(nn.Module):
-    def __init__(self, mantissa_bit_width):
-        super().__init__()
-        self.mantissa_bit_width = mantissa_bit_width
-        self.midmax_round_bias = _calculate_midmax_bias(mantissa_bit_width) # Only works with static mantissa bitwidth
-
-    def forward(self, x):
-        return floor_ste(x + self.midmax_round_bias)

--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -79,6 +79,7 @@ from brevitas_examples.common.generative.quantizers import RuntimeDynamicStatsZe
 from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerGroupFloat
 from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerRowFloat
 from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerTensorFloat
+from brevitas_examples.common.generative.quant_blocks import RoundMidMaxSte
 
 WEIGHT_QUANT_MAP = {
     'int': {
@@ -306,7 +307,7 @@ def generate_quantizers(
         attn_kwargs = dict()
 
     if scale_rounding_func_type is not None:
-        scale_rounding_func_dict = {'ceil': CeilSte, 'floor': FloorSte, 'round': RoundSte}
+        scale_rounding_func_dict = {'ceil': CeilSte, 'floor': FloorSte, 'round': RoundSte, 'midmax': RoundMidMaxSte}
         scale_type = scale_rounding_func_dict[scale_rounding_func_type]
         input_kwargs = {**input_kwargs, **{'restrict_value_float_to_int_impl': scale_type}}
 
@@ -371,7 +372,7 @@ def generate_quantizers(
         **weight_float_format)
 
     if scale_rounding_func_type is not None:
-        scale_rounding_func_dict = {'ceil': CeilSte, 'floor': FloorSte, 'round': RoundSte}
+        scale_rounding_func_dict = {'ceil': CeilSte, 'floor': FloorSte, 'round': RoundSte, 'midmax': RoundMidMaxSte}
         scale_type = scale_rounding_func_dict[scale_rounding_func_type]
         weight_quant = weight_quant.let(**{'restrict_value_float_to_int_impl': scale_type})
 

--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -12,6 +12,7 @@ from brevitas import nn as qnn
 from brevitas.core.function_wrapper import CeilSte
 from brevitas.core.function_wrapper import FloorSte
 from brevitas.core.restrict_val import RoundSte
+from brevitas.core.scaling import RoundMidMaxSte
 from brevitas.core.stats import NegativeMinOrZero
 from brevitas.core.zero_point import ParameterFromStatsFromParameterZeroPoint
 from brevitas.graph.quantize import layerwise_quantize
@@ -79,7 +80,6 @@ from brevitas_examples.common.generative.quantizers import RuntimeDynamicStatsZe
 from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerGroupFloat
 from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerRowFloat
 from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerTensorFloat
-from brevitas_examples.common.generative.quant_blocks import RoundMidMaxSte
 
 WEIGHT_QUANT_MAP = {
     'int': {
@@ -307,7 +307,8 @@ def generate_quantizers(
         attn_kwargs = dict()
 
     if scale_rounding_func_type is not None:
-        scale_rounding_func_dict = {'ceil': CeilSte, 'floor': FloorSte, 'round': RoundSte, 'midmax': RoundMidMaxSte}
+        scale_rounding_func_dict = {
+            'ceil': CeilSte, 'floor': FloorSte, 'round': RoundSte, 'midmax': RoundMidMaxSte}
         scale_type = scale_rounding_func_dict[scale_rounding_func_type]
         input_kwargs = {**input_kwargs, **{'restrict_value_float_to_int_impl': scale_type}}
 
@@ -372,7 +373,8 @@ def generate_quantizers(
         **weight_float_format)
 
     if scale_rounding_func_type is not None:
-        scale_rounding_func_dict = {'ceil': CeilSte, 'floor': FloorSte, 'round': RoundSte, 'midmax': RoundMidMaxSte}
+        scale_rounding_func_dict = {
+            'ceil': CeilSte, 'floor': FloorSte, 'round': RoundSte, 'midmax': RoundMidMaxSte}
         scale_type = scale_rounding_func_dict[scale_rounding_func_type]
         weight_quant = weight_quant.let(**{'restrict_value_float_to_int_impl': scale_type})
 

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -113,7 +113,7 @@ def create_args_parser() -> ArgumentParser:
         '--scale-rounding-func-type',
         type=str,
         default=None,
-        choices=['round', 'ceil', 'floor'],
+        choices=['round', 'ceil', 'floor', 'midmax'],
         help='Rounding function to use with Po2 scale. Default: None.')
     parser.add_argument(
         '--weight-group-dim',

--- a/tests/brevitas/core/test_quant_mx.py
+++ b/tests/brevitas/core/test_quant_mx.py
@@ -142,7 +142,7 @@ class MXFP:
 
 MAP = {"e4m3": (4, 3), "e5m2": (5, 2), "e2m3": (2, 3), "e3m2": (3, 2), "e2m1": (2, 1)}
 SCALE_ROUNDING = ["floor", "midmax"]
-RANGE = 1e10
+RANGE = 1e9
 
 edge_cases = [
     torch.tensor([[7.5 if i == 0 else 1.0 for i in range(32)]]),  # MXFP4, MidMax
@@ -162,8 +162,6 @@ def test_act_mx(inp, bit_widths, scale_rounding):
     # Default rounding should be 'floor', so only create this dict if we are overriding the default
     if scale_rounding == "midmax":
         extra_kwargs["restrict_value_float_to_int_impl"] = RoundMidMaxSte
-        if bit_widths == "e4m3":
-            extra_kwargs["midmax_mantissa_bit_bias"] = 1.0
     act_quant = QuantIdentity(
         MXFloat8e4m3Act,
         exponent_bit_width=exp,
@@ -196,8 +194,6 @@ def test_weight_mx(inp, bit_widths, scale_rounding, weight_quant_type):
     # Default rounding should be 'floor', so only create this dict if we are overriding the default
     if scale_rounding == "midmax":
         extra_kwargs["weight_restrict_value_float_to_int_impl"] = RoundMidMaxSte
-        if bit_widths == "e4m3":
-            extra_kwargs["weight_midmax_mantissa_bit_bias"] = 1.0
     weight_quant = QuantLinear(
         32,
         1,

--- a/tests/brevitas/core/test_quant_mx.py
+++ b/tests/brevitas/core/test_quant_mx.py
@@ -149,6 +149,7 @@ edge_cases = [
     torch.tensor([[3.875 if i == 0 else 1.0 for i in range(32)]]),  # MXFP8E4M3, MidMax
 ]
 
+
 @example(inp=edge_cases[0])
 @example(inp=edge_cases[1])
 @given(inp=float_tensor_nz_st(shape=(1, 32), max_val=RANGE, min_val=-RANGE))

--- a/tests/brevitas/core/test_quant_mx.py
+++ b/tests/brevitas/core/test_quant_mx.py
@@ -145,8 +145,8 @@ SCALE_ROUNDING = ["floor", "midmax"]
 RANGE = 1e10
 
 edge_cases = [
-    torch.tensor([[7.5 if i == 0 else 1.0 for i in range(32)]]), # MXFP4, MidMax
-    torch.tensor([[3.875 if i == 0 else 1.0 for i in range(32)]]), # MXFP8E4M3, MidMax
+    torch.tensor([[7.5 if i == 0 else 1.0 for i in range(32)]]),  # MXFP4, MidMax
+    torch.tensor([[3.875 if i == 0 else 1.0 for i in range(32)]]),  # MXFP8E4M3, MidMax
 ]
 
 @example(inp=edge_cases[0])

--- a/tests/brevitas/core/test_quant_mx.py
+++ b/tests/brevitas/core/test_quant_mx.py
@@ -11,10 +11,12 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from hypothesis import example
 from hypothesis import given
 import pytest_cases
 import torch
 
+from brevitas.core.scaling import RoundMidMaxSte
 from brevitas.nn.quant_activation import QuantIdentity
 from brevitas.nn.quant_linear import QuantLinear
 from brevitas.quant.experimental.mx_quant_ocp import MXFloat8e4m3Act
@@ -139,21 +141,37 @@ class MXFP:
 
 
 MAP = {"e4m3": (4, 3), "e5m2": (5, 2), "e2m3": (2, 3), "e3m2": (3, 2), "e2m1": (2, 1)}
+SCALE_ROUNDING = ["floor", "midmax"]
+RANGE = 1e10
 
+edge_cases = [
+    torch.tensor([[7.5 if i == 0 else 1.0 for i in range(32)]]), # MXFP4, MidMax
+    torch.tensor([[3.875 if i == 0 else 1.0 for i in range(32)]]), # MXFP8E4M3, MidMax
+]
 
-@given(inp=float_tensor_nz_st(shape=(1, 32), max_val=1e10, min_val=-1e10))
+@example(inp=edge_cases[0])
+@example(inp=edge_cases[1])
+@given(inp=float_tensor_nz_st(shape=(1, 32), max_val=RANGE, min_val=-RANGE))
 @pytest_cases.parametrize('bit_widths', list(MAP.keys()))
-def test_act_mx(inp, bit_widths):
+@pytest_cases.parametrize('scale_rounding', SCALE_ROUNDING)
+def test_act_mx(inp, bit_widths, scale_rounding):
     torch.set_printoptions(precision=12, sci_mode=False)
     exp, mant = MAP[bit_widths]
 
+    extra_kwargs = {}
+    # Default rounding should be 'floor', so only create this dict if we are overriding the default
+    if scale_rounding == "midmax":
+        extra_kwargs["restrict_value_float_to_int_impl"] = RoundMidMaxSte
+        if bit_widths == "e4m3":
+            extra_kwargs["midmax_mantissa_bit_bias"] = 1.0
     act_quant = QuantIdentity(
         MXFloat8e4m3Act,
         exponent_bit_width=exp,
         mantissa_bit_width=mant,
         bit_width=mant + exp + 1,
         group_dim=1,
-        return_quant_tensor=True)
+        return_quant_tensor=True,
+        **extra_kwargs)
     act_quant.eval()
     x = inp
 
@@ -161,16 +179,25 @@ def test_act_mx(inp, bit_widths):
 
     qx = act_quant(x)
 
-    y = quantizer.quantize(x)
+    y = quantizer.quantize(x, select=scale_rounding == "midmax")
     assert torch.allclose(qx.value, y, atol=1e-8)
 
 
-@given(inp=float_tensor_nz_st(shape=(1, 32), max_val=1e10, min_val=-1e10))
+@example(inp=edge_cases[0])
+@example(inp=edge_cases[1])
+@given(inp=float_tensor_nz_st(shape=(1, 32), max_val=RANGE, min_val=-RANGE))
 @pytest_cases.parametrize('bit_widths', list(MAP.keys()))
+@pytest_cases.parametrize('scale_rounding', SCALE_ROUNDING)
 @pytest_cases.parametrize('weight_quant_type', ['stats', 'parameter_from_stats'])
-def test_weight_mx(inp, bit_widths, weight_quant_type):
+def test_weight_mx(inp, bit_widths, scale_rounding, weight_quant_type):
     torch.set_printoptions(precision=12, sci_mode=False)
     exp, mant = MAP[bit_widths]
+    extra_kwargs = {}
+    # Default rounding should be 'floor', so only create this dict if we are overriding the default
+    if scale_rounding == "midmax":
+        extra_kwargs["weight_restrict_value_float_to_int_impl"] = RoundMidMaxSte
+        if bit_widths == "e4m3":
+            extra_kwargs["weight_midmax_mantissa_bit_bias"] = 1.0
     weight_quant = QuantLinear(
         32,
         1,
@@ -179,7 +206,8 @@ def test_weight_mx(inp, bit_widths, weight_quant_type):
         weight_scaling_impl_type=weight_quant_type,
         weight_exponent_bit_width=exp,
         weight_mantissa_bit_width=mant,
-        weight_bit_width=mant + exp + 1)
+        weight_bit_width=mant + exp + 1,
+        **extra_kwargs)
 
     x = inp
     weight_quant.weight.data = x
@@ -189,6 +217,6 @@ def test_weight_mx(inp, bit_widths, weight_quant_type):
     qx_weight = weight_quant.quant_weight()
     qx_weight_two = weight_quant.quant_weight()
 
-    y = quantizer.quantize(x)
+    y = quantizer.quantize(x, select=scale_rounding == "midmax")
     assert torch.allclose(qx_weight.value, y, atol=1e-8)
     assert torch.allclose(qx_weight_two.value, y, atol=1e-8)


### PR DESCRIPTION
Add "midmax" scaling for MX datatypes. Midmax is a rounding mode for the shared scale in MX datatypes. Also, plugs MidMax scaling into the LLM example. The standard mode (as referenced in the [OCP MX datatype spec](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf)) is "floor" and does the following:

$$ po2\\_shared\\_scale = \lfloor log_2 (\\| x \\|_\infty) \rfloor $$

Midmax replaces this floor operation with a special rounding mode that reduces the rounding error in the maximum value in $x$, the the cost of potentially increasing the rounding error in the smallest values in $x$.

Rerunning the [experiments](https://github.com/Xilinx/brevitas/tree/master/src/brevitas_examples/papers/expansion) from the [Post-Training Model Expansion](https://arxiv.org/abs/2503.17513) paper, we get the following results:

| model | spinquant | expansion_step | scale_round_func | float_ppl | quant_ppl | ARC-C | ARC-E | HS | WG | PIQA | all_acc |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| meta-llama/Llama-3.2-1B | False | 0 | floor | 8.938 | 11.694 | **0.289** | 0.597 | 0.418 | **0.559** | 0.693 | 0.511 |
| meta-llama/Llama-3.2-1B | False | 0 | midmax | 8.938 | **11.574** | **0.289** | **0.610** | **0.425** | 0.556 | **0.712** | **0.519** |
| meta-llama/Llama-3.2-1B | False | 7 | floor | 8.938 | 11.452 | **0.283** | 0.611 | 0.426 | **0.575** | **0.701** | **0.519** |
| meta-llama/Llama-3.2-1B | False | 7 | midmax | 8.938 | **11.241** | 0.272 | **0.619** | **0.430** | 0.574 | **0.701** | **0.519** |
| meta-llama/Llama-3.2-1B | True | 0 | floor | 8.938 | **11.518** | **0.305** | **0.628** | 0.422 | **0.569** | **0.709** | **0.527** |
| meta-llama/Llama-3.2-1B | True | 0 | midmax | 8.938 | 11.552 | 0.293 | 0.595 | **0.424** | 0.562 | 0.707 | 0.516 |
| meta-llama/Llama-3.2-1B | True | 7 | floor | 8.938 | 11.359 | 0.298 | 0.590 | **0.433** | 0.556 | 0.697 | 0.515 |
| meta-llama/Llama-3.2-1B | True | 7 | midmax | 8.938 | **11.294** | **0.303** | **0.606** | 0.430 | **0.559** | **0.699** | **0.519** |

Note that beyond the [OCP MX v1 spec datatypes](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf), MidMax is not thoroughly tested and should tested further when looking beyond these types.

Also, while adding this feature, I took the opportunity to remove some duplicated code between `MXWeightMixin` and `MXActMixin` into a parent class (`MXMixin`).