### PR TITLE
Fix (equalize): Fix LayerwiseActivationRotation

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1774,6 +1774,17 @@ class RotationEqualization(GraphTransform):
                 full_name = prefix + '.' + name if prefix != '' else name
                 self.find_module_by_name(module, regions, full_name)
 
+    def transform_model(
+            self, model: nn.Module, rewriters: List[Transform], delay_rewriters: bool) -> nn.Module:
+        # In some circumstances, it might be useful to apply model transformations at a later moment
+        # The user should not be resposible for this in any case
+        if delay_rewriters:
+            return model
+        if is_model_offloaded_accelerate(model):
+            return apply_rewriters_accelerate(model, rewriters)
+        else:
+            return apply_rewriters(model, rewriters)
+
 
 class GraphRotationEqualization(RotationEqualization):
 
@@ -2005,16 +2016,6 @@ class GraphRotationEqualization(RotationEqualization):
         else:
             return graph_model
 
-    def transform_model(self, model, rewriters, delay_rewriters):
-        # In some circumstances, it might be useful to apply model transformations at a later moment
-        # The user should not be resposible for this in any case
-        if delay_rewriters:
-            return model
-        if is_model_offloaded_accelerate(model):
-            return apply_rewriters_accelerate(model, rewriters)
-        else:
-            return apply_rewriters(model, rewriters)
-
 
 @torch.no_grad()
 def apply_rewriters(
@@ -2114,9 +2115,10 @@ class LayerwiseActivationRotation(RotationEqualization):
         self.supported_sinks = (nn.Linear)
 
     def apply(self, model: nn.Module) -> nn.Module:
+        regions: List[Region] = []
+        rewriters: List[Transform] = []
 
         blacklist_orphan_layers = self.blacklist_layers + self.layers_to_expand
-        regions: List[Region] = []
         self.find_module(model, regions, blacklist_layers=blacklist_orphan_layers)
         expanded_regions = []
         self.find_module_by_name(model, expanded_regions)
@@ -2124,5 +2126,6 @@ class LayerwiseActivationRotation(RotationEqualization):
         if len(expanded_regions) > 0:
             regions.extend(expanded_regions)
         if len(regions) > 0:
-            _compute_rotations(model, regions, expansion_step=self.expansion_step)
+            rewriters.extend(_compute_rotations(model, regions, expansion_step=self.expansion_step))
+        model = self.transform_model(model, rewriters, delay_rewriters=False)
         return model

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -335,9 +335,11 @@ def quantize_llm(args, extra_args=None):
         model = eq.apply(model)
         remove_hooks(model)
     elif args.rotation == 'layerwise':
+        model = offload_model(model)
         eq = LayerwiseActivationRotation(
             layers_to_expand=layers_to_expand, expansion_step=args.expansion_step)
         model = eq.apply(model)
+        remove_hooks(model)
     elif args.rotation == 'fused_no_fx':
         fused_rotation_no_fx(model, calibration_loader, args)
 

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -333,6 +333,14 @@ class LLMQuantLayerTypeCases:
                 "model.layers.0.self_attn.q_proj.layer":
                     "<class 'brevitas.nn.quant_linear.QuantLinear'>",},},
         {
+            "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
+            "rotation": "layerwise",
+            "exp_layer_types": {
+                "model.layers.0.self_attn.q_proj":
+                    "<class 'brevitas.nn.equalized_layer.RotatedModule'>",
+                "model.layers.0.self_attn.q_proj.layer":
+                    "<class 'brevitas.nn.quant_linear.QuantLinear'>",},},
+        {
             "model": "hf-internal-testing/tiny-random-MistralForCausalLM",
             "quantize_last_layer": True,
             "exp_layer_types": {
@@ -360,6 +368,7 @@ class LLMQuantLayerTypeCases:
             "mistral-fp8_fnuz",
             "llama-mxfp8",
             "llama-int8-act_equalization=layerwise",
+            "llama-int8-rotation=layerwise",
             "mistral-int8-quant-last-layer",
             "llama-int8-svd_quant",
             "opt-quant-sdpa",],)


### PR DESCRIPTION
## Reason for this PR

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

Fixes the issue https://github.com/Xilinx/brevitas/issues/1412. This degradation was introduced in [1382](https://github.com/Xilinx/brevitas/pull/1382) and affects the setting `rotation=layerwise`, since `LayerwiseActivationRotation` was turned into a no-op, as rewriters are not applied.

## Changes Made in this PR

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

Added call to `transform_model` to apply the rewriters within `LayerwiseActivationRotation.apply`. 

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

Added test to verify that a given layer is wrapped with a `RotatedModule`.

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
