### PR TITLE
Fix (src/brevitas/quant_tensor/base_quant_tensor.py): Added `torch.float64` to dict of tolerances.

### DIFF
--- a/src/brevitas/quant_tensor/base_quant_tensor.py
+++ b/src/brevitas/quant_tensor/base_quant_tensor.py
@@ -12,7 +12,7 @@ from torch import Tensor
 from brevitas.function.ops_ste import round_ste
 from brevitas.utils.torch_utils import float_internal_scale
 
-TOLERANCE = {torch.float32: 2e-1, torch.float16: 0.5, torch.bfloat16: 0.5}
+TOLERANCE = {torch.float64: 1e-1, torch.float32: 2e-1, torch.float16: 0.5, torch.bfloat16: 0.5}
 
 
 # Base class for all QuantTensor.


### PR DESCRIPTION
## Reason for this PR
I was unable to run `layer.quant_weight().int()` for `brevitas.nn.QuantLinear` layers instantiated with `dtype=torch.float64`.
Code to reproduce the error:
```python
import brevitas.nn as qnn
import torch
layer = qnn.QuantLinear(10, 10, dtype=torch.float64)
layer.quant_weight().int()
```
Error message:
```
>>> layer.quant_weight().int()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jgarciaa/scale/brevitas/src/brevitas/quant_tensor/base_quant_tensor.py", line 203, in int
    if self.is_valid:
       ^^^^^^^^^^^^^
  File "/home/jgarciaa/scale/brevitas/src/brevitas/quant_tensor/base_quant_tensor.py", line 184, in is_valid
    atol = TOLERANCE[self.value.dtype]
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: torch.float64
```
<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR
Added the `(key, value)` pair `(torch.float64, 1e-1)` to the dictionary `TOLERANCES` at the beginning of the file `src/brevitas/quant_tensor/base_quant_tensor.py` to solve the above mentioned issue.

The tolerance `1e-1` was chosen for `float64` as it is `1/2` of the current tolerance for `float32` which is itself ~`1/2` of the tolerance for `float16`.
<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary
Tested locally that the change fixes the issue.
<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

