### PR TITLE
Feat (core): module for runtime computation of exp bias

### DIFF
--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -91,6 +91,17 @@ class StaticExponentBias(torch.nn.Module):
 
 
 class ComputeExponentBias(torch.nn.Module):
+    """
+    Module that returns a runtime-computed exponent bias value.
+
+    Args:
+        exponent_bit_width_impl: Module that returns the exponent bit width
+
+    Examples:
+        >>> exp_bias = ComputeExponentBias(4.)
+        >>> exp_bias()
+        tensor(7.)
+    """
 
     def __init__(self, exponent_bit_width_impl):
         super().__init__()

--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -88,3 +88,13 @@ class StaticExponentBias(torch.nn.Module):
 
     def forward(self):
         return self.exponent_bias()
+
+
+class ComputeExponentBias(torch.nn.Module):
+
+    def __init__(self, exponent_bit_width_impl):
+        super().__init__()
+        self.exponent_bit_width_impl = exponent_bit_width_impl
+
+    def forward(self):
+        return 2 ** (self.exponent_bit_width_impl() - 1) - 1

--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -81,7 +81,8 @@ class StaticExponentBias(torch.nn.Module):
         a checkpoint but will be properly handled during device transfers and dtype conversions.
     """
 
-    def __init__(self, exponent_bias, device=None, dtype=None):
+    def __init__(
+            self, exponent_bias: float, device: torch.device = None, dtype: torch.dtype = None):
         super().__init__()
         self.exponent_bias = StatelessBuffer(
             torch.tensor(float(exponent_bias), device=device, dtype=dtype))
@@ -103,7 +104,7 @@ class ComputeExponentBias(torch.nn.Module):
         tensor(7.)
     """
 
-    def __init__(self, exponent_bit_width_impl):
+    def __init__(self, exponent_bit_width_impl: torch.nn.Module):
         super().__init__()
         self.exponent_bit_width_impl = exponent_bit_width_impl
 


### PR DESCRIPTION
## Reason for this PR

Exponent bias is current its own class but we don't have any utility to compute it at runtime based on the current value of exponent bit width
