### PR TITLE
Fix (proxy): preserve training state after tensor_quant re-init

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1679,15 +1679,11 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                 if parametrize.is_parametrized(module) and tensor_name in module.parametrizations:
                     # Check if the module has any quantization-related children
                     state_dict = None
-                    training_state = None
-                    device = None
                     for submodule in module.modules():
                         if isinstance(
                                 submodule,
                             (WeightQuantProxyFromInjectorBase, BiasQuantProxyFromInjectorBase)):
                             state_dict = submodule.state_dict()
-                            training_state = submodule.training
-                            device = next(iter(submodule.parameters())).device
                             break
                     # The rotated tensor is saved by setting leave_parametrized=True
                     parametrize.remove_parametrizations(
@@ -1696,9 +1692,6 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                     # when registering the parametrized parameter
                     if state_dict is not None:
                         submodule.load_state_dict(state_dict)
-                    if training_state is not None:
-                        submodule.train(training_state)
-                    submodule.to(device=device)
     return model
 
 

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1679,11 +1679,15 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                 if parametrize.is_parametrized(module) and tensor_name in module.parametrizations:
                     # Check if the module has any quantization-related children
                     state_dict = None
+                    training_state = None
+                    device = None
                     for submodule in module.modules():
                         if isinstance(
                                 submodule,
                             (WeightQuantProxyFromInjectorBase, BiasQuantProxyFromInjectorBase)):
                             state_dict = submodule.state_dict()
+                            training_state = submodule.training
+                            device = next(iter(submodule.parameters())).device
                             break
                     # The rotated tensor is saved by setting leave_parametrized=True
                     parametrize.remove_parametrizations(
@@ -1692,6 +1696,9 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                     # when registering the parametrized parameter
                     if state_dict is not None:
                         submodule.load_state_dict(state_dict)
+                    if training_state is not None:
+                        submodule.train(training_state)
+                    submodule.to(device=device)
     return model
 
 

--- a/src/brevitas/nn/mixin/parameter.py
+++ b/src/brevitas/nn/mixin/parameter.py
@@ -84,7 +84,13 @@ class QuantWeightMixin(QuantProxyMixin):
     def register_parameter(self, name, value):
         super(QuantWeightMixin, self).register_parameter(name, value)
         if hasattr(self, 'weight_quant') and name == 'weight':
+            # When tensor_quant is init, we might lose information about the state (train vs eval)
+            # and the device. We keep track of them and restore them post initialization.
+            training_state = self.training
+            device = self.weight.device
             self.weight_quant.init_tensor_quant()
+            self.weight_quant.train(training_state)
+            self.weight_quant.to(device=device)
 
 
 class QuantBiasMixin(QuantProxyMixin):
@@ -113,5 +119,10 @@ class QuantBiasMixin(QuantProxyMixin):
     def register_parameter(self, name, value):
         super(QuantBiasMixin, self).register_parameter(name, value)
         if hasattr(self, 'bias_quant') and name == 'bias':
+            # When tensor_quant is init, we might lose information about the state (train vs eval)
+            # and the device. We keep track of them and restore them post initialization.
+            training_state = self.training
+            device = self.bias.device
             self.bias_quant.init_tensor_quant()
-            self.bias_quant.to(self.bias.device)
+            self.bias_quant.train(training_state)
+            self.bias_quant.to(device=device)

--- a/src/brevitas/nn/mixin/parameter.py
+++ b/src/brevitas/nn/mixin/parameter.py
@@ -85,7 +85,7 @@ class QuantWeightMixin(QuantProxyMixin):
         super(QuantWeightMixin, self).register_parameter(name, value)
         if hasattr(self, 'weight_quant') and name == 'weight':
             # When tensor_quant is init, we might lose information about the state (train vs eval)
-            # and the device. We keep track of them and restore them post initialization.
+            # We keep track of them and restore them post initialization.
             training_state = self.training
             self.weight_quant.init_tensor_quant()
             self.weight_quant.train(training_state)
@@ -118,7 +118,7 @@ class QuantBiasMixin(QuantProxyMixin):
         super(QuantBiasMixin, self).register_parameter(name, value)
         if hasattr(self, 'bias_quant') and name == 'bias':
             # When tensor_quant is init, we might lose information about the state (train vs eval)
-            # and the device. We keep track of them and restore them post initialization.
+            # We keep track of them and restore them post initialization.
             training_state = self.training
             self.bias_quant.init_tensor_quant()
             self.bias_quant.train(training_state)

--- a/src/brevitas/nn/mixin/parameter.py
+++ b/src/brevitas/nn/mixin/parameter.py
@@ -87,10 +87,8 @@ class QuantWeightMixin(QuantProxyMixin):
             # When tensor_quant is init, we might lose information about the state (train vs eval)
             # and the device. We keep track of them and restore them post initialization.
             training_state = self.training
-            device = self.weight.device
             self.weight_quant.init_tensor_quant()
             self.weight_quant.train(training_state)
-            self.weight_quant.to(device=device)
 
 
 class QuantBiasMixin(QuantProxyMixin):
@@ -122,7 +120,5 @@ class QuantBiasMixin(QuantProxyMixin):
             # When tensor_quant is init, we might lose information about the state (train vs eval)
             # and the device. We keep track of them and restore them post initialization.
             training_state = self.training
-            device = self.bias.device
             self.bias_quant.init_tensor_quant()
             self.bias_quant.train(training_state)
-            self.bias_quant.to(device=device)

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -144,8 +144,8 @@ class QuantProxyFromInjector(ExportMixin, nn.Module, QuantProxyProtocol):
             next_param = next(iter(self.parameters()), None)
             device = next_param.device if next_param is not None else None
             self.init_tensor_quant()
-            self.weight_quant.train(training_state)
-            self.weight_quant.to(device=device)
+            self.train(training_state)
+            self.to(device=device)
 
         # for retrocompatibility with when it wasn't removed
         zero_hw_sentinel_key = prefix + 'zero_hw_sentinel'

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -140,7 +140,9 @@ class QuantProxyFromInjector(ExportMixin, nn.Module, QuantProxyProtocol):
             # When tensor_quant is init, we might lose information about the state (train vs eval)
             # and the device. We keep track of them and restore them post initialization.
             training_state = self.training
-            device = self.weight.device
+            # Potentially get the first parameters, if there are any
+            next_param = next(iter(self.parameters()), None)
+            device = next_param.device if next_param is not None else None
             self.init_tensor_quant()
             self.weight_quant.train(training_state)
             self.weight_quant.to(device=device)

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -140,13 +140,8 @@ class QuantProxyFromInjector(ExportMixin, nn.Module, QuantProxyProtocol):
             # When tensor_quant is init, we might lose information about the state (train vs eval)
             # and the device. We keep track of them and restore them post initialization.
             training_state = self.training
-            # Potentially get the first parameters, if there are any
-            next_param = next(iter(self.parameters()), None)
-            device = next_param.device if next_param is not None else None
-            device = device if 'meta' not in str(device) else None
             self.init_tensor_quant()
             self.train(training_state)
-            self.to(device=device)
 
         # for retrocompatibility with when it wasn't removed
         zero_hw_sentinel_key = prefix + 'zero_hw_sentinel'

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -138,7 +138,7 @@ class QuantProxyFromInjector(ExportMixin, nn.Module, QuantProxyProtocol):
         # for the parameter already, it's not overwritten
         if config.REINIT_ON_STATE_DICT_LOAD:
             # When tensor_quant is init, we might lose information about the state (train vs eval)
-            # and the device. We keep track of them and restore them post initialization.
+            # We keep track of them and restore them post initialization.
             training_state = self.training
             self.init_tensor_quant()
             self.train(training_state)

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -137,7 +137,14 @@ class QuantProxyFromInjector(ExportMixin, nn.Module, QuantProxyProtocol):
         # but before the state_dict of tensor_quant is loaded, so in case e.g. there is a value
         # for the parameter already, it's not overwritten
         if config.REINIT_ON_STATE_DICT_LOAD:
+            # When tensor_quant is init, we might lose information about the state (train vs eval)
+            # and the device. We keep track of them and restore them post initialization.
+            training_state = self.training
+            device = self.weight.device
             self.init_tensor_quant()
+            self.weight_quant.train(training_state)
+            self.weight_quant.to(device=device)
+
         # for retrocompatibility with when it wasn't removed
         zero_hw_sentinel_key = prefix + 'zero_hw_sentinel'
         if zero_hw_sentinel_key in unexpected_keys:

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -143,6 +143,7 @@ class QuantProxyFromInjector(ExportMixin, nn.Module, QuantProxyProtocol):
             # Potentially get the first parameters, if there are any
             next_param = next(iter(self.parameters()), None)
             device = next_param.device if next_param is not None else None
+            device = device if 'meta' not in str(device) else None
             self.init_tensor_quant()
             self.train(training_state)
             self.to(device=device)

--- a/tests/brevitas/proxy/test_proxy.py
+++ b/tests/brevitas/proxy/test_proxy.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
+import torch
 
 from brevitas.nn import QuantLinear
 from brevitas.nn.quant_activation import QuantReLU
@@ -83,3 +84,12 @@ class TestProxy:
 
         model.act_quant.disable_quant = True
         assert model.act_quant.bit_width() is None
+
+    def test_training_state(self):
+        quant_layer = QuantLinear(10, 5, weight_quant=Int8WeightPerTensorFloat)
+        quant_layer.eval()
+
+        # Setting new weights will re-init the quant tensor
+        quant_layer.weight = torch.nn.Parameter(torch.randn_like(quant_layer.weight))
+
+        assert quant_layer.weight_quant.tensor_quant.training == False


### PR DESCRIPTION
## Reason for this PR

When merging rotations, the state and device of the quantizers might be lost.

## Changes Made in this PR

Preserve and restore device and training state.


## Testing Summary

TBD