### PR TITLE
Fix (brevitas_examples/imagenet/ptq): DataLoader fix 

### DIFF
--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from argparse import Namespace
+import gc
 import os
 import random
 import sys
@@ -270,6 +271,10 @@ def quantize_ptq_imagenet(args: Namespace, extra_args: Optional[List[str]] = Non
     if args.bias_corr:
         print("Applying bias correction:")
         apply_bias_correction(calib_loader, quant_model)
+        
+    # Free calibration dataloader from memory
+    del calib_loader
+    gc.collect()
 
     # Validate the quant_model on the validation dataloader
     print("Starting validation:")

--- a/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
+++ b/src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py
@@ -271,7 +271,7 @@ def quantize_ptq_imagenet(args: Namespace, extra_args: Optional[List[str]] = Non
     if args.bias_corr:
         print("Applying bias correction:")
         apply_bias_correction(calib_loader, quant_model)
-        
+
     # Free calibration dataloader from memory
     del calib_loader
     gc.collect()

--- a/src/brevitas_examples/imagenet_classification/utils.py
+++ b/src/brevitas_examples/imagenet_classification/utils.py
@@ -125,6 +125,10 @@ def generate_dataloader(
     if subset_size is not None:
         dataset = torch.utils.data.Subset(dataset, list(range(subset_size)))
     loader = torch.utils.data.DataLoader(
-        dataset, batch_size=batch_size, num_workers=num_workers, pin_memory=True, persistent_workers=True)
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        pin_memory=True,
+        persistent_workers=True)
 
     return loader

--- a/src/brevitas_examples/imagenet_classification/utils.py
+++ b/src/brevitas_examples/imagenet_classification/utils.py
@@ -125,6 +125,6 @@ def generate_dataloader(
     if subset_size is not None:
         dataset = torch.utils.data.Subset(dataset, list(range(subset_size)))
     loader = torch.utils.data.DataLoader(
-        dataset, batch_size=batch_size, num_workers=num_workers, pin_memory=True)
+        dataset, batch_size=batch_size, num_workers=num_workers, pin_memory=True, persistent_workers=True)
 
     return loader


### PR DESCRIPTION
## Reason for this PR

[ptq_evaluate.py](src/brevitas_examples/imagenet_classification/ptq/ptq_evaluate.py) was running too slowly on the GPU. It was caused by repeatedly loading the dataset into memory. This was mostly noticeable with enabled: GPTQ, GPFQ...

## Changes Made in this PR

Increased speed of calibration by preserving the dataset in memory and avoiding unnecessary loading by adding `persistent_workers=True` to DataLoader.
Also added code to free the calibration dataset from memory before validation.

## Testing Summary

Pre:

Starting activation calibration:
100%|█████| 16/16 [00:41<00:00,  2.59s/it]

Performing GPTQ:
100%|█████| 21/21 [11:50<00:00, 33.82s/it]

Applying bias correction:
100%|█████| 16/16 [00:34<00:00,  2.15s/it]

Starting validation:
100%|█████| 196/196 [00:56<00:00,  3.49it/s]
Total:Avg acc@1 63.724

Post:

Starting activation calibration:
100%|█████| 16/16 [00:10<00:00,  1.58it/s]

Performing GPTQ:
100%|█████| 21/21 [00:45<00:00,  2.16s/it]

Applying bias correction:
100%|█████| 16/16 [00:01<00:00,  9.43it/s]

Starting validation:
100%|█████| 196/196 [00:53<00:00,  3.67it/s]
Total:Avg acc@1 63.724

(tested on windows, default_template.yaml+ GPTQ + GPU)


## Risk Highlight

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [X] Code comments added to any hard-to-understand areas, if applicable.
- [X] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [X] No conflicts with destination `dev` branch.
- [X] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
