### PR TITLE
deps (ex/llm): Fixed `perf<0.18` to be compatible with `transformers==4.50.0`

### DIFF
--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -8,6 +8,9 @@ onnx
 onnxruntime<1.21
 optimum[onnxruntime]
 pandas
+# TODO (nf): Remove when unpinning `transformers`
+# peft>0.18 is incompatible with the transformers==4.50.0 version
+peft<0.18
 # TODO (pml): Remove when unpinning `transformers`, as `lighteval>=0.10.0`
 # requires this dependency explicitely.
 # See https://github.com/huggingface/lighteval/commit/2651750480d9a23ab0153f8ed3ef1d3331a2ea88.

--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -9,7 +9,7 @@ onnxruntime<1.21
 optimum[onnxruntime]
 pandas
 # TODO (nf): Remove when unpinning `transformers`
-# peft>0.18 is incompatible with the transformers==4.50.0 version
+# peft>=0.18 is incompatible with transformers==4.50.0
 peft<0.18
 # TODO (pml): Remove when unpinning `transformers`, as `lighteval>=0.10.0`
 # requires this dependency explicitely.


### PR DESCRIPTION
Workaround to fix the CI. New versions of perf(`>=0.18.0`) are not compatible with our pinned version of transformers (`4.50.0`)