### PR TITLE
fix (core): import scaling before zero point to prevent circular import

### DIFF
--- a/src/brevitas/core/__init__.py
+++ b/src/brevitas/core/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Prevent circular import: https://github.com/Xilinx/brevitas/pull/1410
+from .scaling import SCALING_STATS_REDUCE_DIM as _SCALING_STATS_REDUCE_DIM


### PR DESCRIPTION
Superseeds #1410. `brevitas.core.scaling` needs to be imported before `brevitas.core.zero_point` - we ensure that this always occurs by adding an import of `scaling` to `brevitas.core`.

We should revisit this if we get any other import issues under `brevitas.core.x`.