### PR TITLE
Test (brevitas_examples/llm): added test of lighteval with rotation

### DIFF
--- a/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
+++ b/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import inspect
+
 import torch
 import torch.nn.functional as F
 from transformers.integrations.executorch import TorchExportableModuleForDecoderOnlyLM
@@ -80,8 +82,18 @@ class make_dynamo_compatible:
         # but then we can unwrap it immediately.
         # We need to specify batch_size and max_cache_len. The latter is not important since we disable
         # cache anyway while we trace the model.
+
+        kwargs = dict()
+        if 'batch_size' in inspect.signature(TorchExportableModuleForDecoderOnlyLM).parameters:
+            kwargs['batch_size'] = 1
+        elif 'max_batch_size' in inspect.signature(
+                TorchExportableModuleForDecoderOnlyLM).parameters:
+            kwargs['max_batch_size'] = 1
+        else:
+            raise RuntimeError("Interface not recognized")
+
         self.model = TorchExportableModuleForDecoderOnlyLM(
-            self.model, batch_size=1, max_cache_len=1).model.model
+            self.model, max_cache_len=1, batch_size=1).model.model
         # Caching should be disabled to make it work with dynamo
         # The other alternative is to use static_cache
         self.model.config.use_cache = False

--- a/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
+++ b/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
@@ -82,18 +82,8 @@ class make_dynamo_compatible:
         # but then we can unwrap it immediately.
         # We need to specify batch_size and max_cache_len. The latter is not important since we disable
         # cache anyway while we trace the model.
-
-        kwargs = dict()
-        if 'batch_size' in inspect.signature(TorchExportableModuleForDecoderOnlyLM).parameters:
-            kwargs['batch_size'] = 1
-        elif 'max_batch_size' in inspect.signature(
-                TorchExportableModuleForDecoderOnlyLM).parameters:
-            kwargs['max_batch_size'] = 1
-        else:
-            raise RuntimeError("Interface not recognized")
-
         self.model = TorchExportableModuleForDecoderOnlyLM(
-            self.model, max_cache_len=1, batch_size=1).model.model
+            self.model, batch_size=1, max_cache_len=1).model.model
         # Caching should be disabled to make it work with dynamo
         # The other alternative is to use static_cache
         self.model.config.use_cache = False

--- a/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
+++ b/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import inspect
-
 import torch
 import torch.nn.functional as F
 from transformers.integrations.executorch import TorchExportableModuleForDecoderOnlyLM

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -373,11 +373,27 @@ def test_parse_yaml_trainer_arguments(caplog, kwargs):
 
 
 @pytest_cases.fixture(
-    ids=["lighteval"],
+    ids=["lighteval", "lighteval_rotations"],
     params=[
         {
             "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
             "no_quantize": True,
+            "eval": False,
+            "few_shot_eval": "lighteval",
+            "few_shot_override_batch_size": 16,
+            "few_shot_tasks": [
+                "arc:challenge|0",
+                "winogrande|0",
+                "arc:easy|0",
+                "hellaswag|0",],
+            "few_shot_zeroshot": True,
+            "imports": ["lighteval"],
+            "all_acc": 0.375,},
+        {
+            "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
+            "no_quantize": True,
+            "rotation": "fused_no_fx",
+            "replace_rmsnorm": True,
             "eval": False,
             "few_shot_eval": "lighteval",
             "few_shot_override_batch_size": 16,


### PR DESCRIPTION
## Reason for this PR

We updated the interface to get an FX representation of LLM models, but this requires the most recent versions of transformers.

Considering there might be incompatibilities with other transformers packages (e.g., lighteval), we want to check that everything works when combining FX + zero-shot tasks.

## Changes Made in this PR

Added tests for few_shot (lighteval) with FX
