### PR TITLE
Fix (brevitas_examples/llm): better compile with merged rotations

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1750,7 +1750,6 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                             (WeightQuantProxyFromInjectorBase, BiasQuantProxyFromInjectorBase)):
                             state_dict = submodule.state_dict()
                             # Currently there is no better way to detect if a module is compiled
-                            is_module_compiled = 'OptimizedModule' in str(type(submodule))
                             break
                     # The rotated tensor is saved by setting leave_parametrized=True
                     parametrize.remove_parametrizations(
@@ -1759,7 +1758,7 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                     # when registering the parametrized parameter
                     if state_dict is not None:
                         submodule.load_state_dict(state_dict)
-                    if is_module_compiled:
+                    if submodule.is_proxy_compiled:
                         submodule.compile_quant()
     return model
 

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1749,6 +1749,8 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                                 submodule,
                             (WeightQuantProxyFromInjectorBase, BiasQuantProxyFromInjectorBase)):
                             state_dict = submodule.state_dict()
+                            # Currently there is no better way to detect if a module is compiled
+                            is_module_compiled = 'OptimizedModule' in str(type(submodule))
                             break
                     # The rotated tensor is saved by setting leave_parametrized=True
                     parametrize.remove_parametrizations(
@@ -1757,6 +1759,8 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                     # when registering the parametrized parameter
                     if state_dict is not None:
                         submodule.load_state_dict(state_dict)
+                    if is_module_compiled:
+                        submodule.compile_quant()
     return model
 
 

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1749,7 +1749,6 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                                 submodule,
                             (WeightQuantProxyFromInjectorBase, BiasQuantProxyFromInjectorBase)):
                             state_dict = submodule.state_dict()
-                            # Currently there is no better way to detect if a module is compiled
                             break
                     # The rotated tensor is saved by setting leave_parametrized=True
                     parametrize.remove_parametrizations(

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1744,11 +1744,13 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                 if parametrize.is_parametrized(module) and tensor_name in module.parametrizations:
                     # Check if the module has any quantization-related children
                     state_dict = None
+                    is_proxy_compiled = False
                     for submodule in module.modules():
                         if isinstance(
                                 submodule,
                             (WeightQuantProxyFromInjectorBase, BiasQuantProxyFromInjectorBase)):
                             state_dict = submodule.state_dict()
+                            is_proxy_compiled = submodule.is_proxy_compiled
                             break
                     # The rotated tensor is saved by setting leave_parametrized=True
                     parametrize.remove_parametrizations(
@@ -1757,7 +1759,7 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
                     # when registering the parametrized parameter
                     if state_dict is not None:
                         submodule.load_state_dict(state_dict)
-                    if submodule.is_proxy_compiled:
+                    if is_proxy_compiled:
                         submodule.compile_quant()
     return model
 

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -110,6 +110,10 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
             self.tensor_quant = torch.compile(self.tensor_quant, dynamic=True, fullgraph=fullgraph)
 
     @property
+    def is_proxy_compiled(self):
+        return 'OptimizedModule' in str(type(self.tensor_quant))
+
+    @property
     def input_view_impl(self):
         if self.tensor_quant is not None:
             return self.tensor_quant.int_quant.input_view_impl
@@ -186,6 +190,10 @@ class BiasQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector, BiasQuantP
     @property
     def tracked_parameter_list(self):
         return [m.bias for m in self.tracked_module_list if m.bias is not None]
+
+    @property
+    def is_proxy_compiled(self):
+        return False
 
     def get_cached(self, attr):
         if self._cached_bias is None:

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -191,10 +191,6 @@ class BiasQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector, BiasQuantP
     def tracked_parameter_list(self):
         return [m.bias for m in self.tracked_module_list if m.bias is not None]
 
-    @property
-    def is_proxy_compiled(self):
-        return False
-
     def get_cached(self, attr):
         if self._cached_bias is None:
             if not is_dynamo_compiling():

--- a/src/brevitas/proxy/quant_proxy.py
+++ b/src/brevitas/proxy/quant_proxy.py
@@ -102,6 +102,10 @@ class QuantProxyFromInjector(ExportMixin, nn.Module, QuantProxyProtocol):
         return not self.disable_quant and self.tensor_quant is not None
 
     @property
+    def is_proxy_compiled(self):
+        return False
+
+    @property
     def is_groupwise(self):
         return _is_groupwise(self.quant_injector)
 

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -113,6 +113,10 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
                 self.fused_activation_quant_proxy.tensor_quant, dynamic=True, fullgraph=fullgraph)
 
     @property
+    def is_proxy_compiled(self):
+        return 'OptimizedModule' in str(type(self.fused_activation_quant_proxy.tensor_quant))
+
+    @property
     def input_view_impl(self):
         if self.fused_activation_quant_proxy.tensor_quant is not None and not isinstance(
                 self.fused_activation_quant_proxy.tensor_quant, _TensorQuantDisabledIdentity):


### PR DESCRIPTION
## Reason for this PR

After merging the rotations, the compiled module is destroyed

## Changes Made in this PR

If we detect that there is a compiled module before rotations, we re-compile after merging the rotations.

## Testing Summary

TBD