### PR TITLE
Fix (brevitas_examples/llm): correct batch size for lm_eval

### DIFF
--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -654,11 +654,11 @@ def quantize_llm(args, extra_args=None):
             from lm_eval.models.huggingface import HFLM
             with torch.no_grad(), quant_inference_mode(model, compile=args.compile_eval):
                 model(**calibration_loader[0])
+                batch_size = 'auto' if args.few_shot_override_batch_size is None else args.few_shot_override_batch_size
 
                 wrapped_model = HFLM(
-                    pretrained=model,
-                    add_bos_token=True,
-                    batch_size=args.few_shot_override_batch_size)  # need to wrap for LLM eval
+                    pretrained=model, add_bos_token=True,
+                    batch_size=batch_size)  # need to wrap for LLM eval
                 few_shot_eval_results = evaluator.simple_evaluate(
                     model=wrapped_model,
                     model_args=None,

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -656,7 +656,9 @@ def quantize_llm(args, extra_args=None):
                 model(**calibration_loader[0])
 
                 wrapped_model = HFLM(
-                    pretrained=model, add_bos_token=True)  # need to wrap for LLM eval
+                    pretrained=model,
+                    add_bos_token=True,
+                    batch_size=args.few_shot_override_batch_size)  # need to wrap for LLM eval
                 few_shot_eval_results = evaluator.simple_evaluate(
                     model=wrapped_model,
                     model_args=None,


### PR DESCRIPTION
## Reason for this PR

lm_eval test was incredibly slow, mostly due to the fact that batch size was not handled properly

## Changes Made in this PR

Now we pass the batch size to the model, which speeds up the computation considerably.

Passing the batch size to the evaluator does not produce any effect, mostly because we pass a torch.nn.Module to the evaluator, which means that a lot of the evaluator args/kwargs are ignored.

## Testing Summary

N/A as lm_eval is an option al dependency.
Do we want any?
@nickfraser @pablomlago 
