### PR TITLE
Feat (brevitas_examples/common): support for mse scale for weights quantized to float formats

### DIFF
--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -70,6 +70,7 @@ from brevitas_examples.common.generative.quantizers import FP8e4m3OCPDynamicActP
 from brevitas_examples.common.generative.quantizers import Fp8e4m3OCPWeightPerChannelFixedPointMSE
 from brevitas_examples.common.generative.quantizers import Fp8e4m3OCPWeightPerChannelFloatMSE
 from brevitas_examples.common.generative.quantizers import Fp8e4m3OCPWeightSymmetricGroupQuant
+from brevitas_examples.common.generative.quantizers import Fp8e4m3WeightPerChannelFloatMSE
 from brevitas_examples.common.generative.quantizers import Fp8e4m3WeightSymmetricGroupQuant
 from brevitas_examples.common.generative.quantizers import Int8DynamicActPerGroupFloat
 from brevitas_examples.common.generative.quantizers import Int8DynamicActPerRowFixedPoint
@@ -131,7 +132,10 @@ WEIGHT_QUANT_MAP = {
                 'per_channel': {
                     'sym': Fp8e4m3WeightPerChannelFloat},
                 'per_group': {
-                    'sym': Fp8e4m3WeightSymmetricGroupQuant}}}},
+                    'sym': Fp8e4m3WeightSymmetricGroupQuant}},
+            'mse': {
+                'per_channel': {
+                    'sym': Fp8e4m3WeightPerChannelFloatMSE}}}},
     'float_ocp': {
         'float_scale': {
             'stats': {

--- a/src/brevitas_examples/common/generative/quantizers.py
+++ b/src/brevitas_examples/common/generative/quantizers.py
@@ -213,3 +213,7 @@ class FP8e4m3FNUZDynamicActPerRowFloat(Fp8e4m3FNUZActPerTensorFloat):
     scaling_stats_op = 'min_max'
     scaling_per_output_channel = True
     proxy_class = DynamicActFloatQuantProxyFromInjector
+
+
+class Fp8e4m3WeightPerChannelFloatMSE(MSESymmetricScale, Fp8e4m3WeightPerChannelFloat):
+    pass

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import pytest
 import pytest_cases
+from brevitas import config
 
 from tests.brevitas_examples.common import process_args_and_metrics
 
@@ -87,6 +89,8 @@ class LLMRunCases:
             "float_e2m1_and_mse"
         ],)
     def case_small_models_toggle_args(self, run_dict, default_run_args, request):
+        if config.JIT_ENABLED and run_dict.get("weight_param_method") == "mse":
+            pytest.skip(reason=f'MSE as weight_param_method requires JIT to be disabled')(f)
         yield process_args_and_metrics(default_run_args, run_dict)
 
 class LLMPerplexityCases:

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -60,7 +60,10 @@ class LLMRunCases:
                 "learned_round": "linear_round",
                 "learned_round_iters": 1,
                 "gpxq_block_name": "model.layers",
-            },
+            },{
+                "weight_quant_format": "float_e2m1",
+                "weight_param_method": "mse",
+            }
         ],
         ids=[
             "defaults",
@@ -81,6 +84,7 @@ class LLMRunCases:
             "quant_sdpa_functional_per_row",
             "functional_sdpa_quant=True,rotation=fused_no_fx",
             "per_group_w_padding,learned_round=linear_round",
+            "float_e2m1_and_mse"
         ],)
     def case_small_models_toggle_args(self, run_dict, default_run_args, request):
         yield process_args_and_metrics(default_run_args, run_dict)

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -3,8 +3,8 @@
 
 import pytest
 import pytest_cases
-from brevitas import config
 
+from brevitas import config
 from tests.brevitas_examples.common import process_args_and_metrics
 
 

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -90,7 +90,7 @@ class LLMRunCases:
         ],)
     def case_small_models_toggle_args(self, run_dict, default_run_args, request):
         if config.JIT_ENABLED and run_dict.get("weight_param_method") == "mse":
-            pytest.skip(reason=f'MSE as weight_param_method requires JIT to be disabled')(f)
+            pytest.skip(reason=f'MSE as weight_param_method requires JIT to be disabled')
         yield process_args_and_metrics(default_run_args, run_dict)
 
 class LLMPerplexityCases:


### PR DESCRIPTION
## Reason for this PR

It was not possible to run the LLM Examples with a configuration using `weight_quant_format: float_eXmY` and `weight_param_method: mse`. That is, if a "regular" (no OCP) float was being used to quantize the weights, then it was not possible to use mean squared error to choose the scale. I need to use this configuration for some of my experiments.
## Changes Made in this PR
- In `src/brevitas_examples/common/generative/quantizers.py`, I added the class `Fp8e4m3WeightPerChannelFloatMSE` that inherits from `MSESymmetricScale` and `Fp8e4m3WeightPerChannelFloat`. This was done following the same pattern used to support mse scale for Float OCP per-channel weights which was already available.
- In `src/brevitas_examples/common/generative/quantize.py`, I added the entry 
```
'mse': {
                'per_channel': {
                    'sym': Fp8e4m3WeightPerChannelFloatMSE}}}},
```
for `float`, `float_scale` in the dictionary `WEIGHT_QUANT_MAP`. This is how it is currently done for other data types (i.e. Float OCP).


## Testing Summary
- Added a new test in `tests/brevitas_examples/test_llm_cases.py` to ensure that the combination of `weight_quant_format: float_e2m1` with `weight_param_method: mse` runs.
  - In the second commit a small change was done to the tests to skip the new added test when JIT is enabled as this does not support `weight_param_method: mse`.
- Tested locally
