### PR TITLE
Feat (brevitas_examples/llm): better RMSNorm replacement

### DIFF
--- a/src/brevitas/graph/base.py
+++ b/src/brevitas/graph/base.py
@@ -435,18 +435,18 @@ class ModuleToModuleByClass(ModuleToModule):
     def __init__(self, old_module_class, new_module_class, **kwargs):
         super().__init__(new_module_class, **kwargs)
         self.old_module_class = old_module_class
+        self.old_new_module_dict = {}
 
     def apply(self, model: GraphModule) -> GraphModule:
-        old_new_module_dict = {}
         for old_module in model.modules():
             # check for equality, not inheritance
             if type(old_module) == self.old_module_class:
                 # init the new module based on the old one
                 new_module = self.init_new_module(old_module)
                 # register modules pair to be replaced
-                old_new_module_dict[old_module] = new_module
+                self.old_new_module_dict[old_module] = new_module
         # replace all pairs registered
-        for old_module, new_module in old_new_module_dict.items():
+        for old_module, new_module in self.old_new_module_dict.items():
             replace_module(model, old_module, new_module)
         return model
 

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1866,7 +1866,8 @@ class GraphRotationEqualization(RotationEqualization):
             layers_to_expand: Optional[List[str]] = None,
             expansion_step: int = None,
             delay_rewriters: bool = False,
-            return_rewriters: bool = False) -> None:
+            return_rewriters: bool = False,
+            extra_rmsnorm_classes: Optional[Tuple] = None) -> None:
         super(GraphRotationEqualization, self).__init__(blacklist_layers, layers_to_expand)
 
         self.supported_srcs = (nn.Linear, nn.Embedding)
@@ -1875,6 +1876,8 @@ class GraphRotationEqualization(RotationEqualization):
         common_scale_invariant.remove(torch.nn.ReLU)
         common_scale_invariant.remove(torch.nn.LeakyReLU)
         self.scale_invariant_layers = tuple(common_scale_invariant) + (RMSNorm,)
+        if extra_rmsnorm_classes is not None:
+            self.scale_invariant_layers = self.scale_invariant_layers + extra_rmsnorm_classes
         self.scale_invariant_function = ()
         self.orphan_sink = orphan_sink
         self.rotate_matmul = rotate_matmul
@@ -2143,9 +2146,11 @@ class LayerNormToRMS(GraphTransform):
 
 class MergeLnAffine(GraphTransform):
 
-    def __init__(self) -> None:
+    def __init__(self, extra_rmsnorm_classes: Optional[Tuple] = None) -> None:
         super(MergeLnAffine, self).__init__()
         self.supported_srcs = (RMSNorm, nn.LayerNorm)
+        if extra_rmsnorm_classes is not None:
+            self.supported_srcs = self.supported_srcs + extra_rmsnorm_classes
         self.supported_sinks = (nn.Linear)
 
     def apply(self, graph_model: GraphModule) -> GraphModule:

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1885,7 +1885,7 @@ class RotationEqualization(GraphTransform):
             return apply_rewriters(model, rewriters)
 
 
-class GraphRotationEqualization(RotationEqualization, StateMixin):
+class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
 
     def __init__(
             self,
@@ -1911,7 +1911,7 @@ class GraphRotationEqualization(RotationEqualization, StateMixin):
             'supported_sinks': (nn.Linear,),
             'scale_invariant_layers': tuple(common_scale_invariant) + (RMSNorm,),
             'scale_invariant_functions': ()}
-        StateMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
+        RegionWalkMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
 
         self.orphan_sink = orphan_sink
         self.rotate_matmul = rotate_matmul
@@ -2130,7 +2130,7 @@ def apply_rewriters(
     return model
 
 
-class LayerNormToRMS(GraphTransform, StateMixin):
+class LayerNormToRMS(GraphTransform, RegionWalkMixin):
 
     def __init__(
             self,
@@ -2140,7 +2140,7 @@ class LayerNormToRMS(GraphTransform, StateMixin):
 
         base_state_kwargs = {
             'supported_srcs': (nn.Linear, nn.Embedding), 'supported_sinks': (nn.LayerNorm,)}
-        StateMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
+        RegionWalkMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
 
         self.return_rewriters = return_rewriters
         assert RMSNorm is not object, 'Update your Pytorch version to 2.4+'
@@ -2179,14 +2179,14 @@ class LayerNormToRMS(GraphTransform, StateMixin):
             return graph_model
 
 
-class MergeLnAffine(GraphTransform, StateMixin):
+class MergeLnAffine(GraphTransform, RegionWalkMixin):
 
     def __init__(self, extra_state_kwargs: Optional[Dict[str, Tuple]] = None) -> None:
         GraphTransform.__init__(self)
         self.supported_srcs = (RMSNorm, nn.LayerNorm)
         base_state_kwargs = {
             'supported_srcs': (RMSNorm, nn.LayerNorm), 'supported_sinks': (nn.Linear,)}
-        StateMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
+        RegionWalkMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
 
     def apply(self, graph_model: GraphModule) -> GraphModule:
         regions = _extract_regions(graph_model, state_impl_kwargs=self.full_state_kwargs)

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -2204,8 +2204,6 @@ class LayerwiseActivationRotation(RotationEqualization):
         self.expansion_step = expansion_step
         self.block_rotation_dim = block_rotation_dim
         self.supported_sinks = (nn.Linear,)
-        # base_state_kwargs = {'supported_sinks': (nn.Linear,)}
-        # StateMixin.__init__(self, base_state_kwargs, extra_state_kwargs)
 
     def apply(self, model: nn.Module) -> nn.Module:
         regions: List[Region] = []

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1785,10 +1785,23 @@ def _merge_ln(layer_norm, next_module, scale_bias_by_weight):
         _replace_bias(next_module, new_bias)
 
 
+class StateMixin:
+
+    def __init__(self, base_state_kwargs, extra_state_kwargs=None):
+
+        self.full_state_kwargs = dict()
+        extra_state_kwargs = dict() if extra_state_kwargs is None else extra_state_kwargs
+
+        for d in (base_state_kwargs, extra_state_kwargs):
+            for key, value in d.items():
+                current_value = self.full_state_kwargs.get(key, ())
+                current_value = current_value + value
+                self.full_state_kwargs[key] = current_value
+
+
 class RotationEqualization(GraphTransform):
 
     def __init__(self, blacklist_layers, layers_to_expand) -> None:
-        super(RotationEqualization, self).__init__()
         if blacklist_layers is not None:
             self.blacklist_layers = blacklist_layers
         else:
@@ -1797,19 +1810,19 @@ class RotationEqualization(GraphTransform):
             self.layers_to_expand = layers_to_expand
         else:
             self.layers_to_expand = []
-        self.supported_sinks = ()
 
     def find_module(
             self,
             model: nn.Module,
             regions: List[Region],
+            supported_sinks: tuple,
             prefix: str = '',
             blacklist_layers: Optional[List[str]] = None):
         """
         Iterate through the model looking at immediate children of every module to look for supported modules.
         This allows us to stop the search when we meet a top-level module that is supported.
         """
-        if isinstance(model, self.supported_sinks):
+        if isinstance(model, supported_sinks):
             if prefix in blacklist_layers:
                 return
             weight = get_weight_sink(model)
@@ -1820,7 +1833,7 @@ class RotationEqualization(GraphTransform):
         else:
             for name, module in model.named_children():
                 full_name = prefix + '.' + name if prefix != '' else name
-                self.find_module(module, regions, full_name, blacklist_layers)
+                self.find_module(module, regions, supported_sinks, full_name, blacklist_layers)
 
     def find_module_by_name(self, model: nn.Module, regions: List[Region], prefix: str = ''):
         """
@@ -1852,7 +1865,7 @@ class RotationEqualization(GraphTransform):
             return apply_rewriters(model, rewriters)
 
 
-class GraphRotationEqualization(RotationEqualization):
+class GraphRotationEqualization(RotationEqualization, StateMixin):
 
     def __init__(
             self,
@@ -1867,18 +1880,19 @@ class GraphRotationEqualization(RotationEqualization):
             expansion_step: int = None,
             delay_rewriters: bool = False,
             return_rewriters: bool = False,
-            extra_rmsnorm_classes: Optional[Tuple] = None) -> None:
-        super(GraphRotationEqualization, self).__init__(blacklist_layers, layers_to_expand)
+            extra_state_kwargs: Optional[Dict[str, Tuple]] = None) -> None:
+        RotationEqualization.__init__(self, blacklist_layers, layers_to_expand)
 
-        self.supported_srcs = (nn.Linear, nn.Embedding)
-        self.supported_sinks = (nn.Linear)
         common_scale_invariant = list(_scale_invariant_layers)
         common_scale_invariant.remove(torch.nn.ReLU)
         common_scale_invariant.remove(torch.nn.LeakyReLU)
-        self.scale_invariant_layers = tuple(common_scale_invariant) + (RMSNorm,)
-        if extra_rmsnorm_classes is not None:
-            self.scale_invariant_layers = self.scale_invariant_layers + extra_rmsnorm_classes
-        self.scale_invariant_function = ()
+        base_state_kwargs = {
+            'supported_srcs': (nn.Linear, nn.Embedding),
+            'supported_sinks': (nn.Linear,),
+            'scale_invariant_layers': tuple(common_scale_invariant) + (RMSNorm,),
+            'scale_invariant_function': ()}
+        StateMixin.__init__(self, base_state_kwargs, extra_state_kwargs)
+
         self.orphan_sink = orphan_sink
         self.rotate_matmul = rotate_matmul
         self.full_rotation_method = full_rotation_method
@@ -1995,13 +2009,7 @@ class GraphRotationEqualization(RotationEqualization):
     def apply(self,
               graph_model: GraphModule) -> Union[Tuple[GraphModule, List[Transform]], GraphModule]:
         rewriters = []
-        regions = _extract_regions(
-            graph_model,
-            state_impl_kwargs={
-                'supported_srcs': self.supported_srcs,
-                'supported_sinks': self.supported_sinks,
-                'scale_invariant_layers': self.scale_invariant_layers,
-                'scale_invariant_function': self.scale_invariant_function})
+        regions = _extract_regions(graph_model, state_impl_kwargs=self.full_state_kwargs)
 
         expanded_regions = []
         self.find_module_by_name(graph_model, expanded_regions)
@@ -2010,7 +2018,11 @@ class GraphRotationEqualization(RotationEqualization):
 
         if self.orphan_sink:
             blacklist_orphan_layers = self.blacklist_layers + self.layers_to_expand
-            self.find_module(graph_model, orphan_regions, blacklist_layers=blacklist_orphan_layers)
+            self.find_module(
+                graph_model,
+                orphan_regions,
+                self.full_state_kwargs['supported_sinks'],
+                blacklist_layers=blacklist_orphan_layers)
 
         if len(expanded_regions) > 0:
             parameter_number_pre = 0
@@ -2098,20 +2110,23 @@ def apply_rewriters(
     return model
 
 
-class LayerNormToRMS(GraphTransform):
+class LayerNormToRMS(GraphTransform, StateMixin):
 
-    def __init__(self, return_rewriters=False) -> None:
-        super(LayerNormToRMS, self).__init__()
-        self.supported_srcs = (nn.Linear, nn.Embedding)
-        self.supported_sinks = (nn.LayerNorm)
+    def __init__(
+            self,
+            return_rewriters: bool = False,
+            extra_state_kwargs: Optional[Dict[str, Tuple]] = None) -> None:
+        GraphTransform.__init__(self)
+
+        base_state_kwargs = {
+            'supported_srcs': (nn.Linear, nn.Embedding), 'supported_sinks': (nn.LayerNorm,)}
+        StateMixin.__init__(self, base_state_kwargs, extra_state_kwargs)
+
         self.return_rewriters = return_rewriters
         assert RMSNorm is not object, 'Update your Pytorch version to 2.4+'
 
     def apply(self, graph_model: GraphModule) -> GraphModule:
-        regions = _extract_regions(
-            graph_model,
-            state_impl_kwargs={
-                'supported_srcs': self.supported_srcs, 'supported_sinks': self.supported_sinks})
+        regions = _extract_regions(graph_model, state_impl_kwargs=self.full_state_kwargs)
 
         rewriters = []
         if len(regions) > 0:
@@ -2144,20 +2159,17 @@ class LayerNormToRMS(GraphTransform):
             return graph_model
 
 
-class MergeLnAffine(GraphTransform):
+class MergeLnAffine(GraphTransform, StateMixin):
 
-    def __init__(self, extra_rmsnorm_classes: Optional[Tuple] = None) -> None:
-        super(MergeLnAffine, self).__init__()
+    def __init__(self, extra_state_kwargs: Optional[Dict[str, Tuple]] = None) -> None:
+        GraphTransform.__init__(self)
         self.supported_srcs = (RMSNorm, nn.LayerNorm)
-        if extra_rmsnorm_classes is not None:
-            self.supported_srcs = self.supported_srcs + extra_rmsnorm_classes
-        self.supported_sinks = (nn.Linear)
+        base_state_kwargs = {
+            'supported_srcs': (RMSNorm, nn.LayerNorm), 'supported_sinks': (nn.Linear,)}
+        StateMixin.__init__(self, base_state_kwargs, extra_state_kwargs)
 
     def apply(self, graph_model: GraphModule) -> GraphModule:
-        regions = _extract_regions(
-            graph_model,
-            state_impl_kwargs={
-                'supported_srcs': self.supported_srcs, 'supported_sinks': self.supported_sinks})
+        regions = _extract_regions(graph_model, state_impl_kwargs=self.full_state_kwargs)
 
         if len(regions) > 0:
             scaled_biases = set()
@@ -2185,18 +2197,23 @@ class LayerwiseActivationRotation(RotationEqualization):
             blacklist_layer: Optional[List] = None,
             layers_to_expand: Optional[List] = None,
             expansion_step: int = 0,
-            block_rotation_dim: Optional[int] = None):
-        super().__init__(blacklist_layer, layers_to_expand)
+            block_rotation_dim: Optional[int] = None,
+            extra_state_kwargs: Optional[Dict[str, Tuple]] = None):
+
+        RotationEqualization.__init__(self, blacklist_layer, layers_to_expand)
         self.expansion_step = expansion_step
-        self.supported_sinks = (nn.Linear)
         self.block_rotation_dim = block_rotation_dim
+        self.supported_sinks = (nn.Linear,)
+        # base_state_kwargs = {'supported_sinks': (nn.Linear,)}
+        # StateMixin.__init__(self, base_state_kwargs, extra_state_kwargs)
 
     def apply(self, model: nn.Module) -> nn.Module:
         regions: List[Region] = []
         rewriters: List[Transform] = []
 
         blacklist_orphan_layers = self.blacklist_layers + self.layers_to_expand
-        self.find_module(model, regions, blacklist_layers=blacklist_orphan_layers)
+        self.find_module(
+            model, regions, self.supported_sinks, blacklist_layers=blacklist_orphan_layers)
         expanded_regions = []
         self.find_module_by_name(model, expanded_regions)
 

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -293,7 +293,7 @@ class WalkRegionState:
 
     supported_srcs: set = _supported_layers
     supported_sinks: set = _supported_layers
-    scale_invariant_function: set = _scale_invariant_op
+    scale_invariant_functions: set = _scale_invariant_op
     scale_invariant_layers: set = _scale_invariant_layers
     residual_fns: set = _residual_fns
     residual_methods: set = _residual_methods
@@ -1027,7 +1027,7 @@ def find_srcs_channel_dim(state, model, inp_node):
         return total_channels
     elif _is_scale_invariant_module(model, inp_node,
                                     state.scale_invariant_layers) or _is_scale_invariant_function(
-                                        inp_node, state.scale_invariant_function):
+                                        inp_node, state.scale_invariant_functions):
         return find_srcs_channel_dim(state, model, inp_node.all_input_nodes[0])
     else:
         return _UNSUPPORTED_OP
@@ -1078,7 +1078,7 @@ def find_srcs(graph_model: GraphModule, starting_node: Node,
                 0]
         elif _is_scale_invariant_module(
                 graph_model, node, state.scale_invariant_layers) or _is_scale_invariant_function(
-                    node, state.scale_invariant_function):
+                    node, state.scale_invariant_functions):
             find_sinks(graph_model, node, state)
             find_srcs(graph_model, node, state)
         elif _is_add(node, state.residual_fns, state.residual_methods):
@@ -1126,7 +1126,7 @@ def find_sinks(graph_model: GraphModule, starting_node: Node,
 
         elif _is_scale_invariant_module(
                 graph_model, node, state.scale_invariant_layers) or _is_scale_invariant_function(
-                    node, state.scale_invariant_function):
+                    node, state.scale_invariant_functions):
             find_sinks(graph_model, node, state)
         elif _is_add(node, state.residual_fns, state.residual_methods):
             state.update_offset = False
@@ -1787,16 +1787,37 @@ def _merge_ln(layer_norm, next_module, scale_bias_by_weight):
 
 class StateMixin:
 
-    def __init__(self, base_state_kwargs, extra_state_kwargs=None):
+    def __init__(
+            self,
+            supported_srcs: Tuple[nn.Module] = _supported_layers,
+            supported_sinks: Tuple[nn.Module] = _supported_layers,
+            scale_invariant_layers: Tuple[nn.Module] = _scale_invariant_layers,
+            scale_invariant_functions: Tuple[nn.Module] = _scale_invariant_op,
+            residual_fns: Tuple[nn.Module] = _residual_fns,
+            residual_methods: Tuple[nn.Module] = _residual_methods,
+            extra_state_kwargs=None):
+        self.supported_srcs = supported_srcs
+        self.supported_sinks = supported_sinks
+        self.scale_invariant_layers = scale_invariant_layers
+        self.scale_invariant_functions = scale_invariant_functions
+        self.residual_fns = residual_fns
+        self.residual_methods = residual_methods
 
-        self.full_state_kwargs = dict()
-        extra_state_kwargs = dict() if extra_state_kwargs is None else extra_state_kwargs
+        if extra_state_kwargs is not None:
+            for attr_name in extra_state_kwargs:
+                value = extra_state_kwargs[attr_name]
+                combined_value = value + getattr(self, attr_name)
+                setattr(self, attr_name, combined_value)
 
-        for d in (base_state_kwargs, extra_state_kwargs):
-            for key, value in d.items():
-                current_value = self.full_state_kwargs.get(key, ())
-                current_value = current_value + value
-                self.full_state_kwargs[key] = current_value
+    @property
+    def full_state_kwargs(self):
+        return {
+            'supported_srcs': self.supported_srcs,
+            'supported_sinks': self.supported_sinks,
+            'scale_invariant_layers': self.scale_invariant_layers,
+            'scale_invariant_functions': self.scale_invariant_functions,
+            'residual_fns': self.residual_fns,
+            'residual_methods': self.residual_methods}
 
 
 class RotationEqualization(GraphTransform):
@@ -1890,8 +1911,8 @@ class GraphRotationEqualization(RotationEqualization, StateMixin):
             'supported_srcs': (nn.Linear, nn.Embedding),
             'supported_sinks': (nn.Linear,),
             'scale_invariant_layers': tuple(common_scale_invariant) + (RMSNorm,),
-            'scale_invariant_function': ()}
-        StateMixin.__init__(self, base_state_kwargs, extra_state_kwargs)
+            'scale_invariant_functions': ()}
+        StateMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
 
         self.orphan_sink = orphan_sink
         self.rotate_matmul = rotate_matmul
@@ -2120,7 +2141,7 @@ class LayerNormToRMS(GraphTransform, StateMixin):
 
         base_state_kwargs = {
             'supported_srcs': (nn.Linear, nn.Embedding), 'supported_sinks': (nn.LayerNorm,)}
-        StateMixin.__init__(self, base_state_kwargs, extra_state_kwargs)
+        StateMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
 
         self.return_rewriters = return_rewriters
         assert RMSNorm is not object, 'Update your Pytorch version to 2.4+'
@@ -2166,7 +2187,7 @@ class MergeLnAffine(GraphTransform, StateMixin):
         self.supported_srcs = (RMSNorm, nn.LayerNorm)
         base_state_kwargs = {
             'supported_srcs': (RMSNorm, nn.LayerNorm), 'supported_sinks': (nn.Linear,)}
-        StateMixin.__init__(self, base_state_kwargs, extra_state_kwargs)
+        StateMixin.__init__(self, **base_state_kwargs, extra_state_kwargs=extra_state_kwargs)
 
     def apply(self, graph_model: GraphModule) -> GraphModule:
         regions = _extract_regions(graph_model, state_impl_kwargs=self.full_state_kwargs)

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1785,17 +1785,17 @@ def _merge_ln(layer_norm, next_module, scale_bias_by_weight):
         _replace_bias(next_module, new_bias)
 
 
-class StateMixin:
+class RegionWalkMixin:
 
     def __init__(
             self,
-            supported_srcs: Tuple[nn.Module] = _supported_layers,
-            supported_sinks: Tuple[nn.Module] = _supported_layers,
-            scale_invariant_layers: Tuple[nn.Module] = _scale_invariant_layers,
-            scale_invariant_functions: Tuple[nn.Module] = _scale_invariant_op,
-            residual_fns: Tuple[nn.Module] = _residual_fns,
-            residual_methods: Tuple[nn.Module] = _residual_methods,
-            extra_state_kwargs=None):
+            supported_srcs: Tuple[Type[nn.Module]] = _supported_layers,
+            supported_sinks: Tuple[Type[nn.Module]] = _supported_layers,
+            scale_invariant_layers: Tuple[Type[nn.Module]] = _scale_invariant_layers,
+            scale_invariant_functions: Tuple[Callable] = _scale_invariant_op,
+            residual_fns: Tuple[Callable] = _residual_fns,
+            residual_methods: Tuple[str] = _residual_methods,
+            extra_state_kwargs: Optional[Dict[str, Tuple[Type[nn.Module]]]] = None):
         self.supported_srcs = supported_srcs
         self.supported_sinks = supported_sinks
         self.scale_invariant_layers = scale_invariant_layers
@@ -1804,13 +1804,12 @@ class StateMixin:
         self.residual_methods = residual_methods
 
         if extra_state_kwargs is not None:
-            for attr_name in extra_state_kwargs:
-                value = extra_state_kwargs[attr_name]
+            for attr_name, value in extra_state_kwargs.items():
                 combined_value = value + getattr(self, attr_name)
                 setattr(self, attr_name, combined_value)
 
     @property
-    def full_state_kwargs(self):
+    def full_state_kwargs(self) -> Dict[str, Tuple[Type[nn.Module]]]:
         return {
             'supported_srcs': self.supported_srcs,
             'supported_sinks': self.supported_sinks,
@@ -1836,7 +1835,7 @@ class RotationEqualization(GraphTransform):
             self,
             model: nn.Module,
             regions: List[Region],
-            supported_sinks: tuple,
+            supported_sinks: Tuple[nn.Module],
             prefix: str = '',
             blacklist_layers: Optional[List[str]] = None):
         """

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -23,8 +23,7 @@ class rmsnorm_patch:
     def __init__(self, model, config, enabled=True):
         self.model = model
         self.config = config
-        self.enabled = enabled
-        if self.enabled:
+        if enabled:
             self.rmsnorm_classes = tuple(
                 set(type(x) for x in model.modules() if 'RMS' in type(x).__name__))
         else:

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -3,38 +3,67 @@ Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 SPDX-License-Identifier: MIT
 """
 
+from inspect import signature
+
 from packaging import version
 import torch
 from torch import nn
 
 from brevitas import torch_version
-from brevitas.graph import ModuleInstanceToModuleInstance
+from brevitas.graph import ModuleToModuleByClass
 from brevitas.graph.equalize import _is_scale_invariant_module
 from brevitas.graph.equalize import LayerNormToRMS
 from brevitas.graph.equalize import MergeLnAffine
 from brevitas.graph.utils import get_module
 
 
-def replace_rmsnorm_with_torch(model, config):
-    assert torch_version >= version.parse('2.4'), "torch.nn.RMSNorm requires torch 2.4 or greater"
-    set_of_layers = set(type(x) for x in model.modules() if 'RMS' in type(x).__name__)
-    first_norm = next(iter(set_of_layers))
-    dtype = next(model.parameters()).dtype
-    rewriters = []
+class rmsnorm_patch:
 
-    for n, m in model.named_modules():
-        if 'RMS' in type(m).__name__:
-            new_class = type(f"NewRMSNorm", (first_norm, torch.nn.RMSNorm), {})
-            new_instance = new_class.__new__(new_class)
-            new_instance.__dict__ = m.__dict__.copy()
-            rewriter = ModuleInstanceToModuleInstance(m, new_instance)
+    def __init__(self, model, config, enabled=True):
+        self.model = model
+        self.config = config
+        self.enabled = enabled
+        if self.enabled:
+            self.rmsnorm_classes = tuple(
+                set(type(x) for x in model.modules() if 'RMS' in type(x).__name__))
+        else:
+            self.rmsnorm_class = tuple()
+
+    def __enter__(self):
+        assert torch_version >= version.parse('2.4'), "torch.nn.RMSNorm requires torch 2.4 or greater"
+
+        dtype = next(self.model.parameters()).dtype
+        device = next(self.model.parameters()).device
+        rewriters = [
+            ModuleToModuleByClass(
+                rms_cls,
+                torch.nn.RMSNorm,
+                normalized_shape=lambda module: module.weight.shape[0],
+                eps=self.config.rms_norm_eps,
+                dtype=dtype,
+                device=device) for rms_cls in self.rmsnorm_classes]
+        dtype = next(iter(self.model.parameters())).dtype
+        for r in rewriters:
+            self.model = r.apply(self.model)
+
+        self.model = self.model.to(dtype)
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        rewriters = []
+        dtype = next(self.model.parameters()).dtype
+        device = next(self.model.parameters()).device
+        for rms_class in self.rmsnorm_classes:
+            hidden_dim, eps = list(signature(rms_class).parameters.keys())
+            kwargs = {
+                hidden_dim: lambda module: module.normalized_shape, eps: lambda module: module.eps}
+            rewriter = ModuleToModuleByClass(torch.nn.RMSNorm, rms_class, **kwargs)
             rewriters.append(rewriter)
 
-    for r in rewriters:
-        r.apply(model)
+        for r in rewriters:
+            self.model = r.apply(self.model)
 
-    model = model.to(dtype)
-    return model
+        self.model = self.model.to(dtype)
 
 
 def replace_bias(next_module, new_bias):
@@ -108,8 +137,8 @@ def merge_layernorm_affine_params(graph_model):
 
 
 @torch.no_grad()
-def apply_layernorm_affine_merge(graph_model):
-    eq = MergeLnAffine()
+def apply_layernorm_affine_merge(graph_model, rmsnorm_classes):
+    eq = MergeLnAffine(extra_rmsnorm_classes=rmsnorm_classes)
     graph_model = eq.apply(graph_model)
     return graph_model
 

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -57,7 +57,7 @@ class rmsnorm_patch:
         rewriters = []
         dtype = next(self.model.parameters()).dtype
 
-        for old_module, new_module in self.mapping:
+        for old_module, new_module in self.mapping.items():
             rewriter = ModuleInstanceToModuleInstance(old_module, new_module)
             rewriters.append(rewriter)
 

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -10,6 +10,7 @@ import torch
 from torch import nn
 
 from brevitas import torch_version
+from brevitas.graph import ModuleInstanceToModuleInstance
 from brevitas.graph import ModuleToModuleByClass
 from brevitas.graph.equalize import _is_scale_invariant_module
 from brevitas.graph.equalize import LayerNormToRMS
@@ -28,12 +29,14 @@ class rmsnorm_patch:
                 set(type(x) for x in model.modules() if 'RMS' in type(x).__name__))
         else:
             self.rmsnorm_classes = tuple()
+        self.mapping = dict()
 
     def __enter__(self):
         assert torch_version >= version.parse('2.4'), "torch.nn.RMSNorm requires torch 2.4 or greater"
 
         dtype = next(self.model.parameters()).dtype
         device = next(self.model.parameters()).device
+
         rewriters = [
             ModuleToModuleByClass(
                 rms_cls,
@@ -42,9 +45,10 @@ class rmsnorm_patch:
                 eps=self.config.rms_norm_eps,
                 dtype=dtype,
                 device=device) for rms_cls in self.rmsnorm_classes]
-        dtype = next(iter(self.model.parameters())).dtype
+
         for r in rewriters:
             self.model = r.apply(self.model)
+            self.mapping.update(r.old_new_module_dict)
 
         self.model = self.model.to(dtype)
         return self
@@ -52,12 +56,9 @@ class rmsnorm_patch:
     def __exit__(self, *args, **kwargs):
         rewriters = []
         dtype = next(self.model.parameters()).dtype
-        device = next(self.model.parameters()).device
-        for rms_class in self.rmsnorm_classes:
-            hidden_dim, eps = list(signature(rms_class).parameters.keys())
-            kwargs = {
-                hidden_dim: lambda module: module.normalized_shape, eps: lambda module: module.eps}
-            rewriter = ModuleToModuleByClass(torch.nn.RMSNorm, rms_class, **kwargs)
+
+        for old_module, new_module in self.mapping:
+            rewriter = ModuleInstanceToModuleInstance(old_module, new_module)
             rewriters.append(rewriter)
 
         for r in rewriters:

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -139,7 +139,7 @@ def merge_layernorm_affine_params(graph_model):
 
 @torch.no_grad()
 def apply_layernorm_affine_merge(graph_model, rmsnorm_classes):
-    eq = MergeLnAffine(extra_rmsnorm_classes=rmsnorm_classes)
+    eq = MergeLnAffine(extra_state_kwargs={'scale_invariant_layers': rmsnorm_classes})
     graph_model = eq.apply(graph_model)
     return graph_model
 

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -27,7 +27,7 @@ class rmsnorm_patch:
             self.rmsnorm_classes = tuple(
                 set(type(x) for x in model.modules() if 'RMS' in type(x).__name__))
         else:
-            self.rmsnorm_class = tuple()
+            self.rmsnorm_classes = tuple()
 
     def __enter__(self):
         assert torch_version >= version.parse('2.4'), "torch.nn.RMSNorm requires torch 2.4 or greater"

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -59,7 +59,6 @@ class rmsnorm_patch:
             rewriter = ModuleInstanceToModuleInstance(old_module, new_module)
             self.model = rewriter.apply(self.model)
 
-
         self.model = self.model.to(dtype)
 
 

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -18,6 +18,9 @@ from brevitas.graph.utils import get_module
 def replace_rmsnorm_with_torch(model, config):
     assert torch_version >= version.parse('2.4'), "torch.nn.RMSNorm requires torch 2.4 or greater"
     set_of_layers = set(type(x) for x in model.modules() if 'RMS' in type(x).__name__)
+    first_norm = next(iter(set_of_layers))
+    is_gemma = 'Gemma' in first_norm.__name__
+
     dtype = next(model.parameters()).dtype
     device = next(model.parameters()).device
     rewriters = [
@@ -31,6 +34,12 @@ def replace_rmsnorm_with_torch(model, config):
     dtype = next(iter(model.parameters())).dtype
     for r in rewriters:
         model = r.apply(model)
+
+    # In Gemma, there is a `+ 1` factor to account for, and we can do that by changing the weights
+    if is_gemma:
+        for m in model.modules():
+            if isinstance(m, torch.nn.RMSNorm):
+                m.weight.data = m.weight.data + 1
     model = model.to(dtype)
     return model
 

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -8,7 +8,7 @@ import torch
 from torch import nn
 
 from brevitas import torch_version
-from brevitas.graph.base import ModuleToModuleByClass
+from brevitas.graph import ModuleInstanceToModuleInstance
 from brevitas.graph.equalize import _is_scale_invariant_module
 from brevitas.graph.equalize import LayerNormToRMS
 from brevitas.graph.equalize import MergeLnAffine
@@ -19,27 +19,20 @@ def replace_rmsnorm_with_torch(model, config):
     assert torch_version >= version.parse('2.4'), "torch.nn.RMSNorm requires torch 2.4 or greater"
     set_of_layers = set(type(x) for x in model.modules() if 'RMS' in type(x).__name__)
     first_norm = next(iter(set_of_layers))
-    is_gemma = 'Gemma' in first_norm.__name__
-
     dtype = next(model.parameters()).dtype
-    device = next(model.parameters()).device
-    rewriters = [
-        ModuleToModuleByClass(
-            rms_cls,
-            torch.nn.RMSNorm,
-            normalized_shape=lambda module: module.weight.shape[0],
-            eps=config.rms_norm_eps,
-            dtype=dtype,
-            device=device) for rms_cls in set_of_layers]
-    dtype = next(iter(model.parameters())).dtype
-    for r in rewriters:
-        model = r.apply(model)
+    rewriters = []
 
-    # In Gemma, there is a `+ 1` factor to account for, and we can do that by changing the weights
-    if is_gemma:
-        for m in model.modules():
-            if isinstance(m, torch.nn.RMSNorm):
-                m.weight.data = m.weight.data + 1
+    for n, m in model.named_modules():
+        if 'RMS' in type(m).__name__:
+            new_class = type(f"NewRMSNorm", (first_norm, torch.nn.RMSNorm), {})
+            new_instance = new_class.__new__(new_class)
+            new_instance.__dict__ = m.__dict__.copy()
+            rewriter = ModuleInstanceToModuleInstance(m, new_instance)
+            rewriters.append(rewriter)
+
+    for r in rewriters:
+        r.apply(model)
+
     model = model.to(dtype)
     return model
 

--- a/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
+++ b/src/brevitas_examples/llm/llm_quant/ln_affine_merge.py
@@ -53,15 +53,12 @@ class rmsnorm_patch:
         return self
 
     def __exit__(self, *args, **kwargs):
-        rewriters = []
         dtype = next(self.model.parameters()).dtype
 
         for old_module, new_module in self.mapping.items():
             rewriter = ModuleInstanceToModuleInstance(old_module, new_module)
-            rewriters.append(rewriter)
+            self.model = rewriter.apply(self.model)
 
-        for r in rewriters:
-            self.model = r.apply(self.model)
 
         self.model = self.model.to(dtype)
 

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -126,7 +126,7 @@ def fused_rotation_no_fx(model, calibration_loader, args):
         expansion_step=args.expansion_step,
         layers_to_expand=layers_to_expand,
         block_rotation_dim=args.block_rotation_dim,
-        extra_rmsnorm_classes=rmsnorm_classes)
+        extra_state_kwargs={'scale_invariant_layers': rmsnorm_classes})
     fx_model, rewriters = eq.apply(fx_model)
 
     model = offload_model(model)
@@ -285,11 +285,8 @@ def quantize_llm(args, extra_args=None):
         remove_hooks(model)
         print(f"Float perplexity ({args.dataset}): {float_ppl:.3f}")
 
-    # if args.replace_rmsnorm:
-    #     rmsnorm_layers = return_rmsnorm_type(model, model.config)
-
+    rmsnorm_classes = ()
     if require_fx:
-
         with torch.no_grad(), rmsnorm_patch(model, model.config, enabled=args.replace_rmsnorm) as patcher:
             rmsnorm_classes = patcher.rmsnorm_classes
             with make_dynamo_compatible(model) as dynamo_comp:
@@ -342,7 +339,7 @@ def quantize_llm(args, extra_args=None):
             expansion_step=args.expansion_step,
             layers_to_expand=layers_to_expand,
             block_rotation_dim=args.block_rotation_dim,
-            extra_rmsnorm_classes=rmsnorm_classes)
+            extra_state_kwargs={'scale_invariant_layers': rmsnorm_classes})
         model = eq.apply(model)
         remove_hooks(model)
     elif args.rotation == 'layerwise':

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -56,7 +56,7 @@ from brevitas_examples.llm.llm_quant.gpxq import apply_qronos
 from brevitas_examples.llm.llm_quant.learned_round_utils import apply_learned_round
 from brevitas_examples.llm.llm_quant.ln_affine_merge import apply_layernorm_affine_merge
 from brevitas_examples.llm.llm_quant.ln_affine_merge import apply_layernorm_to_rmsnorm
-from brevitas_examples.llm.llm_quant.ln_affine_merge import replace_rmsnorm_with_torch
+from brevitas_examples.llm.llm_quant.ln_affine_merge import rmsnorm_patch
 from brevitas_examples.llm.llm_quant.prepare_for_quantize import add_zero_bias_to_linear
 from brevitas_examples.llm.llm_quant.prepare_for_quantize import make_dynamo_compatible
 from brevitas_examples.llm.llm_quant.prepare_for_quantize import \
@@ -89,7 +89,8 @@ def filter_results(results, tasks):
 
 
 def fused_rotation_no_fx(model, calibration_loader, args):
-    with torch.no_grad():
+    with torch.no_grad(), rmsnorm_patch(model, model.config) as patcher:
+        rmsnorm_classes = patcher.rmsnorm_classes
         with make_dynamo_compatible(model) as dynamo_comp:
             fx_model, guards = torch._dynamo.export(dynamo_comp.model)(**calibration_loader[0])
     if hasattr(model, str(torch.nn.functional.scaled_dot_product_attention)):
@@ -102,7 +103,7 @@ def fused_rotation_no_fx(model, calibration_loader, args):
             if any(map(lambda x: x in name, args.rotation_layers_to_expand)):
                 layers_to_expand.append(name)
 
-    apply_layernorm_affine_merge(fx_model)
+    apply_layernorm_affine_merge(fx_model, rmsnorm_classes)
     # NOTE: This call breaks ties between the the lm_head and the embedding layer
     fx_model, rewriters = apply_layernorm_to_rmsnorm(fx_model, return_rewriters=True)
     rewriters = fix_rewriter(rewriters, model, 'weight')
@@ -124,7 +125,8 @@ def fused_rotation_no_fx(model, calibration_loader, args):
         delay_rewriters=delay_rewriters,
         expansion_step=args.expansion_step,
         layers_to_expand=layers_to_expand,
-        block_rotation_dim=args.block_rotation_dim)
+        block_rotation_dim=args.block_rotation_dim,
+        extra_rmsnorm_classes=rmsnorm_classes)
     fx_model, rewriters = eq.apply(fx_model)
 
     model = offload_model(model)
@@ -283,11 +285,13 @@ def quantize_llm(args, extra_args=None):
         remove_hooks(model)
         print(f"Float perplexity ({args.dataset}): {float_ppl:.3f}")
 
-    if args.replace_rmsnorm:
-        model = replace_rmsnorm_with_torch(model, model.config)
+    # if args.replace_rmsnorm:
+    #     rmsnorm_layers = return_rmsnorm_type(model, model.config)
 
     if require_fx:
-        with torch.no_grad():
+
+        with torch.no_grad(), rmsnorm_patch(model, model.config, enabled=args.replace_rmsnorm) as patcher:
+            rmsnorm_classes = patcher.rmsnorm_classes
             with make_dynamo_compatible(model) as dynamo_comp:
                 model, guards = torch._dynamo.export(dynamo_comp.model)(**calibration_loader[0])
         # Blockwise optimization does not work with FX at the moment
@@ -298,7 +302,7 @@ def quantize_llm(args, extra_args=None):
     # since currently there is support only for merging into Linear
     if args.ln_affine_merge:
         print("Apply LN affine merge...")
-        apply_layernorm_affine_merge(model)
+        apply_layernorm_affine_merge(model, rmsnorm_classes)
         print("LN affine merge applied.")
 
     if args.convert_layernorm_to_rmsnorm:
@@ -337,7 +341,8 @@ def quantize_llm(args, extra_args=None):
             use_parametrized_rotations=args.optimize_rotations,
             expansion_step=args.expansion_step,
             layers_to_expand=layers_to_expand,
-            block_rotation_dim=args.block_rotation_dim)
+            block_rotation_dim=args.block_rotation_dim,
+            extra_rmsnorm_classes=rmsnorm_classes)
         model = eq.apply(model)
         remove_hooks(model)
     elif args.rotation == 'layerwise':


### PR DESCRIPTION
## Reason for this PR

Some models have weird forward passes for RMSNorm, like gemma that uses `(1 + weight) * input` instead of `(weight) * input`.

Similarly, we were not handling correctly the fact that llama/gemma and maybe other models cast up to float32 and then back to (b)float16 during the forward pass.


## Changes Made in this PR

~~We dynamically create a new class type that inherits from torch.nn.RMSNorm and from whatever RMSNorm class the LLM is using.~~

~~Then we initialize the internal dict manually (a bit scary but it works).~~

~~Finally we replace the newly created Frankestein instance with the old one.~~

~~Importantly, the new instance passes the check `isinstance(module, torch.nn.RMSNorm)`, which we use to apply rotations.~~

All of the above does not work because dynamo cannot trace through custom classes.
Instead what we do now is that we replace just for dynamo to pick up the OG torch.nn.RMSNorm, and then we put back whatever RMSNorm class was originally intended.

Side effect, we need to carry around these classes types for some of our algorithms.

## Testing Summary

All existing, hopefully I didn't break too many.
