### PR TITLE
Feat (graph/gptq): Expose lambda as an argument

### DIFF
--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -44,14 +44,16 @@ class GPTQ(GPxQ):
 
     def __init__(
             self,
-            layer,
-            name,
-            act_order,
-            len_parallel_layers,
-            create_weight_orig,
-            num_blocks,
-            device='cpu',
-            dtype=torch.float32) -> None:
+            layer: torch.nn.Module,
+            name: str,
+            act_order: bool,
+            len_parallel_layers: int,
+            create_weight_orig: bool,
+            num_blocks: int,
+            device: str = 'cpu',
+            percdamp: float = .01,
+            dtype: torch.dtype = torch.float32) -> None:
+
         super().__init__(
             layer, name, act_order, len_parallel_layers, create_weight_orig, device, dtype)
 
@@ -69,7 +71,7 @@ class GPTQ(GPxQ):
                                  device=self.device,
                                  dtype=self.dtype)
         self.nsamples = 0
-
+        self.percdamp = percdamp
         assert torch_version >= version.parse('1.10'), "GPTQ requires torch 1.10 or higher"
 
     def compute_iterative_covariance(self, module, input, current_layer):
@@ -103,7 +105,7 @@ class GPTQ(GPxQ):
             current_layer.forward_count = 0
             raise StopFwdException
 
-    def single_layer_update(self, percdamp=.01, c=1e4):
+    def single_layer_update(self, c=1e4):
         assert not self.layer.weight_quant.requires_quant_input, "Error: GPTQ does not support weight quantizers that require quantized inputs."
         if hasattr(self.layer, 'allocate_params'):
             self.layer.allocate_params(self.layer)
@@ -151,7 +153,7 @@ class GPTQ(GPxQ):
         # Try/Except in case the inverse Hessian cannot be computed
         try:
             for i in range(self.groups):
-                damp = percdamp * torch.mean(torch.diag(self.H[i, :, :]))
+                damp = self.percdamp * torch.mean(torch.diag(self.H[i, :, :]))
                 diag = torch.arange(self.columns, device=self.device)
                 self.H[i, diag, diag] += damp
                 self.H[i, :, :] = torch.linalg.cholesky(self.H[i, :, :])
@@ -219,6 +221,7 @@ class gptq_mode(gpxq_mode):
         gptq_class (GPTQ): The uninitialized class to perform GPTQ. Default: `brevitas.graph.gptq.GPTQ`
         device (str): Device the buffers are stored on. Default: cpu
         dtype (torch.dtype): Datatype the buffers are stored in. Default: torch.float32
+        percdamp (float): Lambda parameter from GPTQ paper. Fraction of the average diagonal added to the diagonal of H. Default: .01
 
     Example:
         >>> with torch.no_grad():
@@ -243,7 +246,8 @@ class gptq_mode(gpxq_mode):
             act_order: bool = False,
             gptq_class: GPTQ = GPTQ,
             device: str = 'cpu',
-            dtype: torch.dtype = torch.float32) -> None:
+            dtype: torch.dtype = torch.float32,
+            percdamp: float = .01) -> None:
         if not inplace:
             model = deepcopy(model)
         super().__init__(
@@ -260,6 +264,7 @@ class gptq_mode(gpxq_mode):
         # How many subblock to use during GPTQ for each layer
         self.num_blocks = num_blocks
         self.gptq_class = gptq_class
+        self.percdamp = percdamp
 
     def catch_stopfwd(self, *args, **kwargs):
         try:
@@ -285,4 +290,5 @@ class gptq_mode(gpxq_mode):
             create_weight_orig=create_weight_orig,
             num_blocks=self.num_blocks,
             device=self.device,
-            dtype=self.dtype)
+            dtype=self.dtype,
+            percdamp=self.percdamp)

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -246,8 +246,7 @@ class gptq_mode(gpxq_mode):
             act_order: bool = False,
             gptq_class: GPTQ = GPTQ,
             device: str = 'cpu',
-            dtype: torch.dtype = torch.float32,
-            percdamp: float = .01) -> None:
+            dtype: torch.dtype = torch.float32) -> None:
         if not inplace:
             model = deepcopy(model)
         super().__init__(
@@ -264,7 +263,6 @@ class gptq_mode(gpxq_mode):
         # How many subblock to use during GPTQ for each layer
         self.num_blocks = num_blocks
         self.gptq_class = gptq_class
-        self.percdamp = percdamp
 
     def catch_stopfwd(self, *args, **kwargs):
         try:
@@ -290,5 +288,4 @@ class gptq_mode(gpxq_mode):
             create_weight_orig=create_weight_orig,
             num_blocks=self.num_blocks,
             device=self.device,
-            dtype=self.dtype,
-            percdamp=self.percdamp)
+            dtype=self.dtype)

--- a/src/brevitas_examples/common/axe.py
+++ b/src/brevitas_examples/common/axe.py
@@ -178,16 +178,18 @@ class A2GPTQ(_AXE, GPTQ):
             max_accumulator_bit_width,
             max_accumulator_tile_size,
             device='cpu',
+            percdamp: float = .01,
             dtype=torch.float32) -> None:
         super().__init__(
-            layer,
-            name,
-            act_order,
-            len_parallel_layers,
-            create_weight_orig,
-            num_blocks,
-            device,
-            dtype)
+            layer=layer,
+            name=name,
+            act_order=act_order,
+            len_parallel_layers=len_parallel_layers,
+            create_weight_orig=create_weight_orig,
+            num_blocks=num_blocks,
+            device=device,
+            percdamp=percdamp,
+            dtype=dtype)
         assert max_accumulator_bit_width is not None, \
             "Error: max_accumulator_bit_width is not specified."
         if not isinstance(max_accumulator_bit_width, Tensor):
@@ -201,7 +203,7 @@ class A2GPTQ(_AXE, GPTQ):
         assert self.max_accumulator_bit_width > 2, \
             "Error: accumulator bit width needs to be bigger than 2."
 
-    def single_layer_update(self, percdamp=0.01, c=1e4):
+    def single_layer_update(self, c=1e4):
         assert not self.layer.weight_quant.requires_quant_input, \
             "Error: GPTQ does not support weight quantizers that require quantized inputs."
         if self.quant_metadata is None:
@@ -266,7 +268,7 @@ class A2GPTQ(_AXE, GPTQ):
         # Try/Except in case the inverse Hessian cannot be computed
         try:
             for i in range(self.groups):
-                damp = percdamp * torch.mean(torch.diag(self.H[i, :, :]))
+                damp = self.percdamp * torch.mean(torch.diag(self.H[i, :, :]))
                 diag = torch.arange(self.columns, device=self.device)
                 self.H[i, diag, diag] += damp
                 self.H[i, :, :] = torch.linalg.cholesky(self.H[i, :, :])

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -267,6 +267,13 @@ def create_args_parser() -> ArgumentParser:
     parser.add_argument(
         '--qronos-alpha', default=1e-6, type=float, help='Alpha for Qronos. Default: 1e-6')
     parser.add_argument('--gptq', action='store_true', help='Apply GPTQ.')
+    parser.add_argument(
+        '--gptq-lambda',
+        default=.01,
+        type=float,
+        help=
+        'Lambda parameter for GPTQ. Fraction of the average diagonal added to the diagonal of H. (default: %(default)s).'
+    )
     parser.add_argument('--gpfq', action='store_true', help='Apply GPFQ.')
     parser.add_argument(
         '--gpxq-act-order', action='store_true', help='Apply GPxQ activation ordering.')

--- a/src/brevitas_examples/llm/llm_quant/gpxq.py
+++ b/src/brevitas_examples/llm/llm_quant/gpxq.py
@@ -120,7 +120,8 @@ def apply_gptq(
         max_accumulator_bit_width=None,
         max_accumulator_tile_size=None,
         buffer_device='cpu',
-        buffer_dtype=torch.float32):
+        buffer_dtype=torch.float32,
+        percdamp: float = .01):
     if max_accumulator_bit_width is not None:
         # Use accumulator-aware extension (AXE) framework
         print(f"Using AXE to target {max_accumulator_bit_width}-bit accumulation...")
@@ -138,7 +139,8 @@ def apply_gptq(
             'use_quant_activations': use_quant_activations,
             'gptq_class': gptq_class,
             'device': buffer_device,
-            'dtype': buffer_dtype}
+            'dtype': buffer_dtype,
+            'percdamp': percdamp}
         block_optimization(model, dataloader, block_name, gptq_mode, context_manager_kwargs)
     else:
         with gptq_mode(model,
@@ -148,7 +150,8 @@ def apply_gptq(
                        create_weight_orig=create_weight_orig,
                        gptq_class=gptq_class,
                        device=buffer_device,
-                       dtype=buffer_dtype) as gptq:
+                       dtype=buffer_dtype,
+                       percdamp=percdamp) as gptq:
             gptq_model = gptq.model
             for _ in tqdm(range(gptq.num_layers)):
                 for inps in dataloader:

--- a/src/brevitas_examples/llm/llm_quant/gpxq.py
+++ b/src/brevitas_examples/llm/llm_quant/gpxq.py
@@ -131,6 +131,10 @@ def apply_gptq(
             max_accumulator_tile_size=max_accumulator_tile_size)
     else:
         gptq_class = GPTQ
+
+    # Set percdam parameter for any of the two classes
+    gptq_class = partial(gptq_class, percdamp=percdamp)
+
     if block_name is not None:
         context_manager_kwargs = {
             'act_order': act_order,
@@ -139,8 +143,7 @@ def apply_gptq(
             'use_quant_activations': use_quant_activations,
             'gptq_class': gptq_class,
             'device': buffer_device,
-            'dtype': buffer_dtype,
-            'percdamp': percdamp}
+            'dtype': buffer_dtype}
         block_optimization(model, dataloader, block_name, gptq_mode, context_manager_kwargs)
     else:
         with gptq_mode(model,
@@ -150,8 +153,7 @@ def apply_gptq(
                        create_weight_orig=create_weight_orig,
                        gptq_class=gptq_class,
                        device=buffer_device,
-                       dtype=buffer_dtype,
-                       percdamp=percdamp) as gptq:
+                       dtype=buffer_dtype) as gptq:
             gptq_model = gptq.model
             for _ in tqdm(range(gptq.num_layers)):
                 for inps in dataloader:

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -603,7 +603,8 @@ def quantize_llm(args, extra_args=None):
                 block_name=args.gpxq_block_name,
                 buffer_device=args.gpxq_buffer_device,
                 max_accumulator_bit_width=args.gpxq_max_accumulator_bit_width,
-                max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
+                max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size,
+                percdamp=args.gptq_lambda)
             print("GPTQ applied.")
 
         if args.gpfq and not args.load_checkpoint:

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -61,6 +61,7 @@ class LLMRunCases:
                 "learned_round_iters": 1,
                 "gpxq_block_name": "model.layers",
             },
+            {"gptq": True, "gptq_lambda": 0.5},
         ],
         ids=[
             "defaults",
@@ -81,6 +82,7 @@ class LLMRunCases:
             "quant_sdpa_functional_per_row",
             "functional_sdpa_quant=True,rotation=fused_no_fx",
             "per_group_w_padding,learned_round=linear_round",
+            "gptq_lambda",
         ],)
     def case_small_models_toggle_args(self, run_dict, default_run_args, request):
         yield process_args_and_metrics(default_run_args, run_dict)


### PR DESCRIPTION
## Reason for this PR
This PR allows users to set a custom lambda parameter for GPTQ. Lambda is a hyperparameter of the GPTQ algorithm but currently it always takes a default value (variable `percdamp` in `GPTQ.single_layer_update()`). Therefore, this change gives users more freedom to run GPTQ with different "configurations".

## Changes Made in this PR
- Added a new argument named `gptq_lambda` to `src/brevitas_examples/llm/llm_args.py`. The default value is 0.01 which is the previous default value. The name `gptq_lambda` was chosen instead of `percdamp` to make the argument name more informative for the users.
- The method `apply_gptq` from `src/brevitas_examples/llm/llm_quant/gpxq.py` now takes the argument `percdamp` which is propagated to  the `gptq_class` (`GPTQ` or `A2GPTQ`) using `partial` to make it available in `single_layer_update()`. It was chosen to keep the name `percdamp` internally as this was the one already in use in the GPTQ implementation. Following the review comments and private discussions, it was chosen to use `partial` to keep the parameter `percdamp` decoupled from the context manager `gptq_mode`.

## Testing Summary
- A new test has been added to `LLMRunCases` in `tests/brevitas_examples/test_llm_cases.py` to ensure that the code runs when `gptq_lambda`  is set in the configuration.
- Python debugger has been used to check that the value of  `percdamp` does indeed take the value set with the argument `gptq_lambda`.
- Tests were ran locally.
The following values were achieved for GPTQ used to quantize `meta-llama/Llama-3.2-1B` to int4 with weight only quantization, per channel quantization, and 512 samples from `wikitext2` for calibration:

| `gptq_lambda` | Quantized Perplexity |
| -------- | ------- | 
| 0.005|  10.438| 
| 0.01 (default)| 10.438|
| 0.5| 15.87| 


