### PR TITLE
Feat (equalize): option to disable fused block rotations

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1590,8 +1590,26 @@ def _compute_rotations(
             assert not region.expand_region, "Orthogonal rotation not compatible with expansion"
             assert block_rotation_dim is None, "Orthogonal rotation not compatible with blockwise rotation"
 
-        # Initialize variables
+        # Initialize hidden_dim to the max shape of the sinks
         hidden_dim = region.max_shape_sinks
+
+        # If block_rotation_dim is specified, then we will apply block rotations
+        apply_block_rotation = block_rotation_dim is not None
+
+        # insert_rotation_module is True for orphan sinks (aka online rotations). Sometimes we want to use
+        # block rotations only for online rotations and full-vector for fused rotations.
+        if not insert_rotation_module and disable_block_rotation_for_fused:
+            apply_block_rotation = False
+
+        if apply_block_rotation:
+            # Check block_rotation is compatible with the current shape
+            if (hidden_dim // block_rotation_dim > 1) and (hidden_dim % block_rotation_dim == 0):
+                hidden_dim = block_rotation_dim
+            else:
+                logging.info(
+                    f"Block rotation shape is not compatible with hidden_dim={hidden_dim}."
+                    " Falling back to full-vector rotation.")
+
         expanded_hidden_dim, expanded_rot_mat, expanded_K = None, None, None
         if not insert_rotation_module and full_rotation_method == 'ort':
             rot_mat = random_orthogonal_matrix(hidden_dim)
@@ -1619,22 +1637,6 @@ def _compute_rotations(
                 else:
                     logging.info("Skipping region")
                     continue
-
-        hidden_dim = hidden_dim if not region.expand_region else expanded_hidden_dim
-        # Sometimes we want to use block rotation only for online rotations and full-vector for fused rotations
-        # In this case, we use block rotations only for online rotations and skip fused rotations
-        skip_block_rotation = disable_block_rotation_for_fused and fuse_rotations and not insert_rotation_module
-        if block_rotation_dim is not None and not skip_block_rotation:
-            # Check if we are doing block_rotation and if it is compatible with the current shape
-            if (hidden_dim // block_rotation_dim > 1) and (hidden_dim % block_rotation_dim == 0):
-                hidden_dim = block_rotation_dim
-                rot_mat, K = get_hadK(block_rotation_dim)
-                if region.expand_region:
-                    expanded_rot_mat, expanded_K = rot_mat, K
-            else:
-                warnings.warn(
-                    "Block rotation shape is not compatible with the shape of this region. "
-                    f"Performing normal rotations with hidden_dim={hidden_dim}.")
 
         if region.expand_region:
             rot_mat, K = expanded_rot_mat, expanded_K

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1570,7 +1570,8 @@ def _compute_rotations(
         full_rotation_method='had',
         fuse_rotations: bool = True,
         expansion_step: int = 1,
-        block_rotation_dim: Optional[int] = None):
+        block_rotation_dim: Optional[int] = None,
+        disable_block_rotation_for_fused: bool = False):
 
     rewriters = []
     # First, rotations on orphan sinks are applied so the order in which rotations are
@@ -1620,17 +1621,20 @@ def _compute_rotations(
                     continue
 
         hidden_dim = hidden_dim if not region.expand_region else expanded_hidden_dim
-        # Check if we are doing block_rotation and if it is compatible with the current shape
-        if block_rotation_dim is not None:
-            if hidden_dim // block_rotation_dim > 1 and hidden_dim % block_rotation_dim == 0:
+        # Sometimes we want to use block rotation only for online rotations and full-vector for fused rotations
+        # In this case, we use block rotations only for online rotations and skip fused rotations
+        skip_block_rotation = disable_block_rotation_for_fused and fuse_rotations and not insert_rotation_module
+        if block_rotation_dim is not None and not skip_block_rotation:
+            # Check if we are doing block_rotation and if it is compatible with the current shape
+            if (hidden_dim // block_rotation_dim > 1) and (hidden_dim % block_rotation_dim == 0):
                 hidden_dim = block_rotation_dim
                 rot_mat, K = get_hadK(block_rotation_dim)
                 if region.expand_region:
                     expanded_rot_mat, expanded_K = rot_mat, K
             else:
-                logging.info(
-                    "Block rotation shape is not compatible with the region shape, perfoming normal rotations"
-                )
+                warnings.warn(
+                    "Block rotation shape is not compatible with the shape of this region. "
+                    f"Performing normal rotations with hidden_dim={hidden_dim}.")
 
         if region.expand_region:
             rot_mat, K = expanded_rot_mat, expanded_K
@@ -1896,6 +1900,7 @@ class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
             use_parametrized_rotations: bool = False,
             full_rotation_method: str = 'had',
             block_rotation_dim: Optional[int] = None,
+            disable_block_rotation_for_fused: bool = False,
             layers_to_expand: Optional[List[str]] = None,
             expansion_step: int = None,
             delay_rewriters: bool = False,
@@ -1921,6 +1926,7 @@ class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
         self.expansion_step = expansion_step
         self.delay_rewriters = delay_rewriters
         self.block_rotation_dim = block_rotation_dim
+        self.disable_block_rotation_for_fused = disable_block_rotation_for_fused
 
         if self.delay_rewriters:
             assert return_rewriters, "If `delay_rewriters=True`, rewriters are not applied immediately. Therefore, these must be returned, by setting `return_rewriters=True`, to be applied at a later stage."
@@ -2098,7 +2104,8 @@ class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
                     self.full_rotation_method,
                     fuse_rotations=not self.use_parametrized_rotations,
                     expansion_step=first_exp_step,
-                    block_rotation_dim=self.block_rotation_dim))
+                    block_rotation_dim=self.block_rotation_dim,
+                    disable_block_rotation_for_fused=self.disable_block_rotation_for_fused))
             rewriters.extend(
                 _compute_rotations(
                     graph_model,
@@ -2106,7 +2113,8 @@ class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
                     self.full_rotation_method,
                     fuse_rotations=not self.use_parametrized_rotations,
                     expansion_step=second_exp_step,
-                    block_rotation_dim=self.block_rotation_dim))
+                    block_rotation_dim=self.block_rotation_dim,
+                    disable_block_rotation_for_fused=self.disable_block_rotation_for_fused))
             if len(expanded_regions) > 0:
                 parameter_number_post = 0
                 for m in graph_model.parameters():

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1564,6 +1564,49 @@ def random_orthogonal_matrix(size):
     return q
 
 
+def _compute_hidden_dim(
+        region: Region,
+        block_rotation_dim: Optional[int] = None,
+        insert_rotation_module: bool = False,
+        disable_block_rotation_for_fused: bool = False) -> int:
+    """
+    Compute the hidden dimension for rotation per region.
+
+    Since each region may have a different shape and block rotation compatibility,
+    this calculation must be performed on a per-region basis.
+
+    Args:
+        region: The region for which to compute hidden dimension.
+        block_rotation_dim: Optional block rotation dimension for block-wise rotations.
+        insert_rotation_module: Whether this region is an orphan sink (online rotation).
+        disable_block_rotation_for_fused: Whether to disable block rotation for fused rotations.
+
+    Returns:
+        The computed hidden dimension for the region.
+    """
+    # Initialize hidden_dim to the max shape of the sinks
+    hidden_dim = region.max_shape_sinks
+
+    # If block_rotation_dim is specified, then we will apply block rotations
+    apply_block_rotation = block_rotation_dim is not None
+
+    # insert_rotation_module is True for orphan sinks (aka online rotations). Sometimes we want to use
+    # block rotations only for online rotations and full-vector for fused rotations.
+    if not insert_rotation_module and disable_block_rotation_for_fused:
+        apply_block_rotation = False
+
+    if apply_block_rotation:
+        # Check block_rotation is compatible with the current shape
+        if (hidden_dim // block_rotation_dim > 1) and (hidden_dim % block_rotation_dim == 0):
+            hidden_dim = block_rotation_dim
+        else:
+            logging.info(
+                f"Block rotation shape is not compatible with hidden_dim={hidden_dim}."
+                " Falling back to full-vector rotation.")
+
+    return hidden_dim
+
+
 def _compute_rotations(
         model: nn.Module,
         regions: List[Region],
@@ -1590,25 +1633,12 @@ def _compute_rotations(
             assert not region.expand_region, "Orthogonal rotation not compatible with expansion"
             assert block_rotation_dim is None, "Orthogonal rotation not compatible with blockwise rotation"
 
-        # Initialize hidden_dim to the max shape of the sinks
-        hidden_dim = region.max_shape_sinks
-
-        # If block_rotation_dim is specified, then we will apply block rotations
-        apply_block_rotation = block_rotation_dim is not None
-
-        # insert_rotation_module is True for orphan sinks (aka online rotations). Sometimes we want to use
-        # block rotations only for online rotations and full-vector for fused rotations.
-        if not insert_rotation_module and disable_block_rotation_for_fused:
-            apply_block_rotation = False
-
-        if apply_block_rotation:
-            # Check block_rotation is compatible with the current shape
-            if (hidden_dim // block_rotation_dim > 1) and (hidden_dim % block_rotation_dim == 0):
-                hidden_dim = block_rotation_dim
-            else:
-                logging.info(
-                    f"Block rotation shape is not compatible with hidden_dim={hidden_dim}."
-                    " Falling back to full-vector rotation.")
+        # Compute hidden_dim per region
+        hidden_dim = _compute_hidden_dim(
+            region=region,
+            block_rotation_dim=block_rotation_dim,
+            insert_rotation_module=insert_rotation_module,
+            disable_block_rotation_for_fused=disable_block_rotation_for_fused)
 
         expanded_hidden_dim, expanded_rot_mat, expanded_K = None, None, None
         if not insert_rotation_module and full_rotation_method == 'ort':

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1640,6 +1640,12 @@ def _compute_rotations(
             assert not region.expand_region, "Orthogonal rotation not compatible with expansion"
             assert block_rotation_dim is None, "Orthogonal rotation not compatible with blockwise rotation"
 
+        # Compute expanded_hidden_dim for weight padding (if applicable)
+        expanded_hidden_dim = None
+        if region.expand_region and expansion_step > 1:
+            expanded_hidden_dim = find_closest_hadamard_number(
+                region.max_shape_sinks, steps=expansion_step)
+
         # Compute hidden_dim per region (includes expansion if applicable)
         hidden_dim = _compute_hidden_dim(
             region=region,
@@ -1703,10 +1709,10 @@ def _compute_rotations(
 
             if region.expand_region:
                 assert isinstance(module, nn.Linear), "Currently only Linear layers support expanded hadamard"
-                new_weights = pad_to_dim(module.weight.data, weight_axis, hidden_dim)
+                new_weights = pad_to_dim(module.weight.data, weight_axis, expanded_hidden_dim)
                 # Modify the weights in-place
                 setattr(module, 'weight', torch.nn.Parameter(new_weights))
-                module.in_features = int(hidden_dim)
+                module.in_features = int(expanded_hidden_dim)
 
             # Only "weight" is rotated
             # If rotations are fused or if the module is an orphan sink, transform is applied directly onto the tensor

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1591,7 +1591,7 @@ def _compute_hidden_dim(
     hidden_dim = region.max_shape_sinks
 
     # Step 2: Expand if region requires expansion
-    if region.expand_region and expansion_step > 1:
+    if region.expand_region:
         hidden_dim = find_closest_hadamard_number(hidden_dim, steps=expansion_step)
 
     # Step 3: Apply block rotation if applicable
@@ -1648,6 +1648,11 @@ def _compute_rotations(
             disable_block_rotation_for_fused=disable_block_rotation_for_fused,
             expansion_step=expansion_step)
 
+        # Compute expanded_hidden_dim for weight padding (if applicable)
+        if region.expand_region:
+            expanded_hidden_dim = find_closest_hadamard_number(
+                region.max_shape_sinks, steps=expansion_step)
+
         if not insert_rotation_module and full_rotation_method == 'ort':
             rot_mat = random_orthogonal_matrix(hidden_dim)
             rot_func = _apply_ort_device
@@ -1703,9 +1708,6 @@ def _compute_rotations(
 
             if region.expand_region:
                 assert isinstance(module, nn.Linear), "Currently only Linear layers support expanded hadamard"
-                # Compute expanded_hidden_dim for weight padding
-                expanded_hidden_dim = find_closest_hadamard_number(
-                    region.max_shape_sinks, steps=expansion_step)
                 new_weights = pad_to_dim(module.weight.data, weight_axis, expanded_hidden_dim)
                 # Modify the weights in-place
                 setattr(module, 'weight', torch.nn.Parameter(new_weights))

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1640,12 +1640,6 @@ def _compute_rotations(
             assert not region.expand_region, "Orthogonal rotation not compatible with expansion"
             assert block_rotation_dim is None, "Orthogonal rotation not compatible with blockwise rotation"
 
-        # Compute expanded_hidden_dim for weight padding (if applicable)
-        expanded_hidden_dim = None
-        if region.expand_region and expansion_step > 1:
-            expanded_hidden_dim = find_closest_hadamard_number(
-                region.max_shape_sinks, steps=expansion_step)
-
         # Compute hidden_dim per region (includes expansion if applicable)
         hidden_dim = _compute_hidden_dim(
             region=region,
@@ -1709,6 +1703,9 @@ def _compute_rotations(
 
             if region.expand_region:
                 assert isinstance(module, nn.Linear), "Currently only Linear layers support expanded hadamard"
+                # Compute expanded_hidden_dim for weight padding
+                expanded_hidden_dim = find_closest_hadamard_number(
+                    region.max_shape_sinks, steps=expansion_step)
                 new_weights = pad_to_dim(module.weight.data, weight_axis, expanded_hidden_dim)
                 # Modify the weights in-place
                 setattr(module, 'weight', torch.nn.Parameter(new_weights))

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1648,7 +1648,10 @@ def _compute_rotations(
             disable_block_rotation_for_fused=disable_block_rotation_for_fused,
             expansion_step=expansion_step)
 
-        # Compute expanded_hidden_dim for weight padding (if applicable)
+        # NOTE: We need to compute expanded_hidden_dim separately for weight padding in expansion
+        # regions. This is required for proper interop of block rotations and expansion: the weight
+        # must be padded to the expanded dimension before block reduction, but hidden_dim may have
+        # been reduced by block rotation for the parametrizations and rotation matrices.
         if region.expand_region:
             expanded_hidden_dim = find_closest_hadamard_number(
                 region.max_shape_sinks, steps=expansion_step)

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1568,26 +1568,33 @@ def _compute_hidden_dim(
         region: Region,
         block_rotation_dim: Optional[int] = None,
         insert_rotation_module: bool = False,
-        disable_block_rotation_for_fused: bool = False) -> int:
+        disable_block_rotation_for_fused: bool = False,
+        expansion_step: int = 1) -> int:
     """
     Compute the hidden dimension for rotation per region.
 
     Since each region may have a different shape and block rotation compatibility,
-    this calculation must be performed on a per-region basis.
+    this calculation must be performed on a per-region basis. The order of operations
+    is: (1) initialize from region, (2) expand if needed, (3) apply block rotation.
 
     Args:
         region: The region for which to compute hidden dimension.
         block_rotation_dim: Optional block rotation dimension for block-wise rotations.
         insert_rotation_module: Whether this region is an orphan sink (online rotation).
         disable_block_rotation_for_fused: Whether to disable block rotation for fused rotations.
+        expansion_step: Number of steps for finding closest hadamard number (used for expansion).
 
     Returns:
         The computed hidden dimension for the region.
     """
-    # Initialize hidden_dim to the max shape of the sinks
+    # Step 1: Initialize hidden_dim to the max shape of the sinks
     hidden_dim = region.max_shape_sinks
 
-    # If block_rotation_dim is specified, then we will apply block rotations
+    # Step 2: Expand if region requires expansion
+    if region.expand_region and expansion_step > 1:
+        hidden_dim = find_closest_hadamard_number(hidden_dim, steps=expansion_step)
+
+    # Step 3: Apply block rotation if applicable
     apply_block_rotation = block_rotation_dim is not None
 
     # insert_rotation_module is True for orphan sinks (aka online rotations). Sometimes we want to use
@@ -1633,14 +1640,14 @@ def _compute_rotations(
             assert not region.expand_region, "Orthogonal rotation not compatible with expansion"
             assert block_rotation_dim is None, "Orthogonal rotation not compatible with blockwise rotation"
 
-        # Compute hidden_dim per region
+        # Compute hidden_dim per region (includes expansion if applicable)
         hidden_dim = _compute_hidden_dim(
             region=region,
             block_rotation_dim=block_rotation_dim,
             insert_rotation_module=insert_rotation_module,
-            disable_block_rotation_for_fused=disable_block_rotation_for_fused)
+            disable_block_rotation_for_fused=disable_block_rotation_for_fused,
+            expansion_step=expansion_step)
 
-        expanded_hidden_dim, expanded_rot_mat, expanded_K = None, None, None
         if not insert_rotation_module and full_rotation_method == 'ort':
             rot_mat = random_orthogonal_matrix(hidden_dim)
             rot_func = _apply_ort_device
@@ -1655,8 +1662,6 @@ def _compute_rotations(
             try:
                 # Build hadamard rotation matrix
                 rot_mat, K = get_hadK(hidden_dim)
-                expanded_hidden_dim = find_closest_hadamard_number(hidden_dim, steps=expansion_step)
-                expanded_rot_mat, expanded_K = get_hadK(int(expanded_hidden_dim))
                 rot_func = _apply_had_device
             except AssertionError as e:
                 logging.info(f"Incompatible dim {hidden_dim} for hadamard rotation")
@@ -1667,9 +1672,6 @@ def _compute_rotations(
                 else:
                     logging.info("Skipping region")
                     continue
-
-        if region.expand_region:
-            rot_mat, K = expanded_rot_mat, expanded_K
 
         # Cast rotation matrix to the weight dtype
         if rot_mat is not None:
@@ -1701,10 +1703,10 @@ def _compute_rotations(
 
             if region.expand_region:
                 assert isinstance(module, nn.Linear), "Currently only Linear layers support expanded hadamard"
-                new_weights = pad_to_dim(module.weight.data, weight_axis, expanded_hidden_dim)
+                new_weights = pad_to_dim(module.weight.data, weight_axis, hidden_dim)
                 # Modify the weights in-place
                 setattr(module, 'weight', torch.nn.Parameter(new_weights))
-                module.in_features = int(expanded_hidden_dim)
+                module.in_features = int(hidden_dim)
 
             # Only "weight" is rotated
             # If rotations are fused or if the module is an orphan sink, transform is applied directly onto the tensor

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -365,6 +365,10 @@ def create_args_parser() -> ArgumentParser:
         type=int,
         default=None,
         help='Perform blockwise rotations when possible. Default: %(default)s')
+    parser.add_argument(
+        '--disable-block-rotation-for-fused',
+        action='store_true',
+        help='Disable block rotations when using fused rotations. Default: %(default)s')
     parser.add_argument('--svd-quant', action='store_true', help='Apply SVDQuant.')
     parser.add_argument(
         '--svd-quant-rank',

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -129,6 +129,7 @@ def fused_rotation_no_fx(model, calibration_loader, args):
         expansion_step=args.expansion_step,
         layers_to_expand=layers_to_expand,
         block_rotation_dim=args.block_rotation_dim,
+        disable_block_rotation_for_fused=args.disable_block_rotation_for_fused,
         extra_state_kwargs={'scale_invariant_layers': rmsnorm_classes})
     fx_model, rewriters = eq.apply(fx_model)
 
@@ -350,6 +351,7 @@ def quantize_llm(args, extra_args=None):
             expansion_step=args.expansion_step,
             layers_to_expand=layers_to_expand,
             block_rotation_dim=args.block_rotation_dim,
+            disable_block_rotation_for_fused=args.disable_block_rotation_for_fused,
             extra_state_kwargs={'scale_invariant_layers': rmsnorm_classes})
         model = eq.apply(model)
         remove_hooks(model)

--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -435,6 +435,7 @@ def compare_model_weights(model_fused, model_unfused, classes_to_compare=(nn.Lin
 @pytest_cases.parametrize('use_fx', [True, False], ids=["fx", "no-fx"])
 @pytest_cases.parametrize('expansion_step', [3, 0], ids=["expansion", "no-expansion"])
 @pytest_cases.parametrize('block_rotation_dim', [12, None])
+@pytest_cases.parametrize('disable_block_rotation_for_fused', [True, False])
 def test_compute_rotations(
         rotation_model,
         mask,
@@ -443,7 +444,8 @@ def test_compute_rotations(
         fuse_rotations,
         use_fx,
         expansion_step,
-        block_rotation_dim):
+        block_rotation_dim,
+        disable_block_rotation_for_fused):
     if expansion_step > 0 and full_rotation_method == 'ort':
         pytest.skip("Expansion is not compatible with orthogonal rotations")
     if block_rotation_dim is not None and full_rotation_method == 'ort':
@@ -518,7 +520,8 @@ def test_compute_rotations(
                 full_rotation_method=full_rotation_method,
                 fuse_rotations=False,
                 expansion_step=expansion_step,
-                block_rotation_dim=block_rotation_dim)
+                block_rotation_dim=block_rotation_dim,
+                disable_block_rotation_for_fused=disable_block_rotation_for_fused)
     elif full_rotation_method == 'ort':
         with patch('brevitas.graph.equalize.random_orthogonal_matrix',
                    partial(_random_orthogonal_matrix, generator=generator)):
@@ -528,7 +531,8 @@ def test_compute_rotations(
                 full_rotation_method=full_rotation_method,
                 fuse_rotations=False,
                 expansion_step=expansion_step,
-                block_rotation_dim=block_rotation_dim)
+                block_rotation_dim=block_rotation_dim,
+                disable_block_rotation_for_fused=disable_block_rotation_for_fused)
 
     apply_rewriters(rotated_model_unfused, rewriters)
 
@@ -545,7 +549,8 @@ def test_compute_rotations(
             full_rotation_method=full_rotation_method,
             fuse_rotations=True,
             expansion_step=expansion_step,
-            block_rotation_dim=block_rotation_dim)
+            block_rotation_dim=block_rotation_dim,
+            disable_block_rotation_for_fused=disable_block_rotation_for_fused)
         apply_rewriters(rotated_model_fused, r)
 
     # Compute outputs for each model


### PR DESCRIPTION
## Reason for this PR

The current implementation applies block rotations uniformly to both online and fused rotation matrices when `block_rotation_dim` is specified. However, there are scenarios where it's beneficial to apply block rotations only to online matrices while keeping fused rotations as full-vector Hadamard matrices. This PR addresses the need for control over such rotation strategies, allowing users to selectively disable block rotations for fused rotations while maintaining them for online rotations.


<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

- Added `disable_block_rotation_for_fused` to control block rotations in `_compute_rotations`
- Packaged `hidden_dim` logic into `_compute_hidden_dim`
- Added CLI flag `--disable-block-rotation-for-fused` to the argument parser
- Modified the rotation equalization logic to conditionally apply block rotations


<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

Extended the `test_equalization.py` test cases to include `disable_block_rotation_for_fused`

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
