### PR TITLE
Fix (graph/qronos): Normalize contribution to H and G when buffer is disabled

### DIFF
--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -62,25 +62,24 @@ class Qronos(GPFQ):
         if not is_quant_enabled:
             # Computing the normalized G matrix
             self.G *= (self.nsamples - batch_size) / self.nsamples
+            inp_processed /= math.sqrt(
+                self.nsamples)  # NOTE: quant_input is normalized before, in the H update
             if self.use_intermediate_buffer:
-                self.B.copy_((inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
-                    self.quant_input.transpose(2, 1) * (1 / math.sqrt(self.nsamples))))
+                self.B.copy_(inp_processed.bmm(self.quant_input.transpose(2, 1)))
                 self.G += self.B
             else:
-                self.G += (inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
-                    self.quant_input.transpose(2, 1) * (1 / math.sqrt(self.nsamples)))
+                self.G += inp_processed.bmm(self.quant_input.transpose(2, 1))
             self.quant_input = None  # NOTE: set back to None now that we've used it
         else:
             # Computing the normalized H matrix
             self.nsamples += batch_size  # NOTE: only increment with quant inputs
             self.H *= (self.nsamples - batch_size) / self.nsamples
+            inp_processed /= math.sqrt(self.nsamples)
             if self.use_intermediate_buffer:
-                self.B.copy_((inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
-                    inp_processed.transpose(2, 1) * (1 / math.sqrt(self.nsamples))))
+                self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
                 self.H += self.B
             else:
-                self.H += (inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
-                    inp_processed.transpose(2, 1) * (1 / math.sqrt(self.nsamples)))
+                self.H += inp_processed.bmm(inp_processed.transpose(2, 1))
             # store the quantized input for computing the H matrix
             assert self.quant_input is None
             self.quant_input = inp_processed

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -66,7 +66,8 @@ class Qronos(GPFQ):
                 self.B.copy_(inp_processed.bmm(self.quant_input.transpose(2, 1)))
                 self.G += (self.B / self.nsamples)
             else:
-                self.G += inp_processed.bmm(self.quant_input.transpose(2, 1))
+                self.G += (inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
+                    self.quant_input.transpose(2, 1) * (1 / math.sqrt(self.nsamples)))
             self.quant_input = None  # NOTE: set back to None now that we've used it
         else:
             # Computing the normalized H matrix
@@ -76,7 +77,8 @@ class Qronos(GPFQ):
                 self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
                 self.H += (self.B / self.nsamples)
             else:
-                self.H += inp_processed.bmm(inp_processed.transpose(2, 1))
+                self.H += (inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
+                    inp_processed.transpose(2, 1) * (1 / math.sqrt(self.nsamples)))
             # store the quantized input for computing the H matrix
             assert self.quant_input is None
             self.quant_input = inp_processed

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -63,8 +63,9 @@ class Qronos(GPFQ):
             # Computing the normalized G matrix
             self.G *= (self.nsamples - batch_size) / self.nsamples
             if self.use_intermediate_buffer:
-                self.B.copy_(inp_processed.bmm(self.quant_input.transpose(2, 1)))
-                self.G += (self.B / self.nsamples)
+                self.B.copy_((inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
+                    self.quant_input.transpose(2, 1) * (1 / math.sqrt(self.nsamples))))
+                self.G += self.B
             else:
                 self.G += (inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
                     self.quant_input.transpose(2, 1) * (1 / math.sqrt(self.nsamples)))
@@ -74,8 +75,9 @@ class Qronos(GPFQ):
             self.nsamples += batch_size  # NOTE: only increment with quant inputs
             self.H *= (self.nsamples - batch_size) / self.nsamples
             if self.use_intermediate_buffer:
-                self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
-                self.H += (self.B / self.nsamples)
+                self.B.copy_((inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
+                    inp_processed.transpose(2, 1) * (1 / math.sqrt(self.nsamples))))
+                self.H += self.B
             else:
                 self.H += (inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
                     inp_processed.transpose(2, 1) * (1 / math.sqrt(self.nsamples)))


### PR DESCRIPTION
## Reason for this PR

In  the method `Qronos().update_batch()` (in the file `src/brevitas/graph/qronos.py`), in the case where `self._use_intermediate_buffer`  is `False`, the contribution from the current samples that is being added to the matrices `H` or `G`  is not normalized. However, the current ("pre-update") value of `G` or `H`  is normalized (multiplied by the number of samples and divided by the number of samples plus the number of "incoming" samples).

This is a bug as it causes the contribution from samples from the later updates to weight more on the final `H` and `G` matrices than the contribution of the earlier samples. However, the order of the samples is not relevant and they should all be equally weighted, as it is done in the case where `self._use_intermediate_buffer` is `True` or also in `GPTQ` (only for `H` in this case as `G` is not needed there).

## Changes Made in this PR

In the file `src/brevitas/graph/qronos.py` the line `self.G += inp_processed.bmm(self.quant_input.transpose(2, 1))` inside `Qronos().update_batch()` has been updated so that the incoming contribution is normalized. The new line is 
```python
self.G += (inp_processed * (1 / math.sqrt(self.nsamples))).bmm(
                    self.quant_input.transpose(2, 1) * (1 / math.sqrt(self.nsamples)))
```
The analogous change was done to normalize the contribution to `self.H`.

## Testing Summary

- Tests run locally.
- Ran the code before and after the fix to quantize a Llama 1B. When quantizing to int4 the perplexity result wasn't affected by the bug/the fix. When quantizing to int2 the quantized perplexity before the fix was 1032 and after fixing this bug it went down to 804.
