### PR TITLE
Feat (brevitas_examples/llm): share quantizers across layers

### DIFF
--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -2,15 +2,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from argparse import ArgumentParser
+from argparse import ArgumentTypeError
 from argparse import Namespace
 from typing import List
 from typing import Optional
 from warnings import warn
 
-import torch
-
 from brevitas_examples.common.parse_utils import create_entrypoint_args_parser
 from brevitas_examples.common.parse_utils import quant_format_validator
+
+
+def list_of_layers(s):
+    try:
+        list_of_layers = list(map(str, s.split(',')))
+        return list_of_layers
+    except:
+        raise ArgumentTypeError("Layer lists must be in the format x,y u,z")
 
 
 def create_args_parser() -> ArgumentParser:
@@ -19,6 +26,11 @@ def create_args_parser() -> ArgumentParser:
         '--model',
         type=str,
         default="facebook/opt-125m",
+        help='HF model name. Default: facebook/opt-125m.')
+    parser.add_argument(
+        '--shared-quantizers',
+        type=list_of_layers,
+        nargs='*',
         help='HF model name. Default: facebook/opt-125m.')
     parser.add_argument(
         '--dtype',

--- a/src/brevitas_examples/llm/llm_quant/run_utils.py
+++ b/src/brevitas_examples/llm/llm_quant/run_utils.py
@@ -20,6 +20,7 @@ limitations under the License.
 """
 
 from contextlib import contextmanager
+from typing import List
 
 from optimum.utils.normalized_config import NormalizedConfigManager
 import torch
@@ -28,6 +29,7 @@ from torch.utils._pytree import tree_map
 from transformers import AutoConfig
 
 from brevitas.fx.value_tracer import ValueProxy
+from brevitas.graph.utils import get_module
 
 
 def modify_dataloader(model_name_or_path, data, dtype):
@@ -103,3 +105,29 @@ def fix_rewriter(rewriters, old_model_ref, tensor_name):
             if hasattr(m, tensor_name) and id(m.weight) == tensor_id]
         r.old_module_instance = module[0]
     return rewriters
+
+
+def share_quantizer(model: torch.nn.Module, shared_quantizers: List[List[str]]) -> torch.nn.Module:
+    name_list = [name for (name, _) in model.named_modules()]
+    # We first iterate through all the group of layers that share quantization
+    for layers_to_share in shared_quantizers:
+        # We keep track of the quantizers name we want to share
+        # In LLM entrypoint, we only create these quantizers
+        quantizers_reference = {'input_quant': None, 'weight_quant': None, 'act_quant': None}
+        # We iterate through the model to find the shared layers
+        matching_layers = [
+            name for name in name_list if any(map(lambda x: name.endswith(x), layers_to_share))]
+        for name in matching_layers:
+            module = get_module(model, name)
+
+            # We replace all the relevant quantizers
+            for quant_name, quantizer in quantizers_reference.items():
+
+                # We check for which quantizer to replace
+                if hasattr(module, quant_name):
+                    # If the reference was not set, we set it up, otherwise we use
+                    # the reference for all the subsequent quantizers
+                    if quantizer is None:
+                        quantizer = getattr(module, quant_name)
+                    setattr(module, quant_name, quantizer)
+    return model

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -68,6 +68,7 @@ from brevitas_examples.llm.llm_quant.prepare_for_quantize import \
 from brevitas_examples.llm.llm_quant.rotation_optimization import apply_rotation_optimization
 from brevitas_examples.llm.llm_quant.rotation_optimization import parse_rotation_optimization_args
 from brevitas_examples.llm.llm_quant.run_utils import fix_rewriter
+from brevitas_examples.llm.llm_quant.run_utils import share_quantizer
 from brevitas_examples.llm.llm_quant.svd_quant import apply_svd_quant
 
 logging = setup_logger(__name__)
@@ -213,6 +214,7 @@ def find_equalized_layer(layer):
 def quantize_llm(args, extra_args=None):
     validate(args, extra_args)
     set_seed(args.seed)
+
     if args.export_prefix is None:
         args.export_prefix = f"{args.model.replace('/', '--')}"
 
@@ -477,6 +479,9 @@ def quantize_llm(args, extra_args=None):
 
         model = layerwise_quantize(
             model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
+
+        if args.shared_quantizers is not None and len(args.shared_quantizers) > 0:
+            model = share_quantizer(model, args.shared_quantizers)
 
         # Just to be sure
         model.eval()


### PR DESCRIPTION
## Reason for this PR
Some layers have shared inputs and they are merged in some frameworks like vLLM. This means their input quantizers should be shared

## Changes Made in this PR

Implement input quantization sharing by allowing the user to specify a list of list with the layers to share the quantizers across.

--shared-quantizers q_proj,k_proj,v_proj up_proj,down_proj

Will share the input quant for Q/K/V and separately for Up/Down proj.