### PR TITLE
Feat (optim): decoupling dtype of CayleySGD from params

### DIFF
--- a/src/brevitas/optim/cailey_sgd.py
+++ b/src/brevitas/optim/cailey_sgd.py
@@ -94,7 +94,7 @@ class CaileySGD(Optimizer):
         stiefel: bool = False,
         iters: int = 5,
         grad_clip=None,
-        dtype=torch.float32,
+        dtype=None,
     ) -> None:
         defaults = dict(
             lr=lr,
@@ -140,7 +140,7 @@ class CaileySGD(Optimizer):
                 param = p.data
                 param_state = self.state[p]
                 # Store a copy of weights in desired dtype if it is different from param dtype
-                if self.dtype != param.dtype:
+                if self.dtype is not None and self.dtype != param.dtype:
                     if "weight_buffer" not in param_state:
                         param_state["weight_buffer"] = param.clone().to(self.dtype)
                     param = param_state["weight_buffer"]
@@ -154,7 +154,8 @@ class CaileySGD(Optimizer):
                         unity = qr_retraction(unity)
 
                     g = p.grad.data.view(p.size()[0], -1)
-                    g = g.to(self.dtype)
+                    if self.dtype is not None:
+                        g = g.to(self.dtype)
 
                     lr = group["lr"]
 

--- a/src/brevitas/optim/cailey_sgd.py
+++ b/src/brevitas/optim/cailey_sgd.py
@@ -93,8 +93,8 @@ class CaileySGD(Optimizer):
         nesterov: bool = False,
         stiefel: bool = False,
         iters: int = 5,
-        grad_clip=None,
-        dtype=None,
+        grad_clip: bool = None,
+        dtype: str = None,
     ) -> None:
         defaults = dict(
             lr=lr,
@@ -110,7 +110,7 @@ class CaileySGD(Optimizer):
         if nesterov and (momentum <= 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
         super(CaileySGD, self).__init__(params, defaults)
-        self.dtype = dtype
+        self.dtype = getattr(torch, dtype) if dtype is not None else dtype
 
     def __setstate__(self, state) -> None:
         super(CaileySGD, self).__setstate__(state)

--- a/src/brevitas/optim/cailey_sgd.py
+++ b/src/brevitas/optim/cailey_sgd.py
@@ -31,17 +31,14 @@ def matrix_norm_one(W):
     return out
 
 
-def Cayley_loop(X, W, tan_vec, t):  #
-    [n, p] = X.size()
+def cayley_loop(X, W, tan_vec, t, iters=5):
     Y = X + t * tan_vec
-    for i in range(5):
+    for _ in range(iters):
         Y = X + t * torch.matmul(W, 0.5 * (X + Y))
-
     return Y.t()
 
 
-def qr_retraction(tan_vec):  # tan_vec, p-by-n, p <= n
-    [p, n] = tan_vec.size()
+def qr_retraction(tan_vec):
     tan_vec.t_()
     dtype = tan_vec.dtype
     # torch.linalg.qr is not implemented for 'Half'
@@ -51,11 +48,10 @@ def qr_retraction(tan_vec):  # tan_vec, p-by-n, p <= n
     ph = d.sign()
     q *= ph.expand_as(q)
     q.t_()
-
     return q
 
 
-episilon = 1e-8
+epsilon = 1e-8
 
 
 class CaileySGD(Optimizer):
@@ -96,8 +92,9 @@ class CaileySGD(Optimizer):
         weight_decay: int = 0,
         nesterov: bool = False,
         stiefel: bool = False,
-        omega: int = 0,
+        iters: int = 5,
         grad_clip=None,
+        dtype=torch.float32,
     ) -> None:
         defaults = dict(
             lr=lr,
@@ -107,11 +104,13 @@ class CaileySGD(Optimizer):
             nesterov=nesterov,
             stiefel=stiefel,
             omega=0,
+            iters=iters,
             grad_clip=grad_clip,
         )
         if nesterov and (momentum <= 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
         super(CaileySGD, self).__init__(params, defaults)
+        self.dtype = dtype
 
     def __setstate__(self, state) -> None:
         super(CaileySGD, self).__setstate__(state)
@@ -132,46 +131,61 @@ class CaileySGD(Optimizer):
         for group in self.param_groups:
             momentum = group["momentum"]
             stiefel = group["stiefel"]
+            iters = group["iters"]
 
             for p in group["params"]:
                 if p.grad is None:
                     continue
 
-                unity, _ = unit(p.data.view(p.size()[0], -1))
+                param = p.data
+                param_state = self.state[p]
+                # Store a copy of weights in desired dtype if it is different from param dtype
+                if self.dtype != param.dtype:
+                    if "weight_buffer" not in param_state:
+                        param_state["weight_buffer"] = param.clone().to(self.dtype)
+                    param = param_state["weight_buffer"]
+
+                unity = param.view(p.size()[0], -1)
+                unity, _ = unit(unity)
                 if stiefel and unity.size()[0] <= unity.size()[1]:
-                    weight_decay = group["weight_decay"]
-                    dampening = group["dampening"]
-                    nesterov = group["nesterov"]
 
                     rand_num = random.randint(1, 101)
                     if rand_num == 1:
                         unity = qr_retraction(unity)
 
                     g = p.grad.data.view(p.size()[0], -1)
+                    g = g.to(self.dtype)
 
                     lr = group["lr"]
 
-                    param_state = self.state[p]
-                    if "momentum_buffer" not in param_state:
-                        param_state["momentum_buffer"] = torch.zeros_like(g.t())
+                    # if momentum is used, initialize the momentum buffer
+                    V = 0.
+                    if momentum != 0:
+                        if "momentum_buffer" not in param_state:
+                            param_state["momentum_buffer"] = torch.zeros_like(g.t())
+                        V = param_state["momentum_buffer"]
 
-                    V = param_state["momentum_buffer"]
                     V = momentum * V - g.t()
                     MX = torch.mm(V, unity)
                     XMX = torch.mm(unity, MX)
                     XXMX = torch.mm(unity.t(), XMX)
                     W_hat = MX - 0.5 * XXMX
                     W = W_hat - W_hat.t()
-                    t = 0.5 * 2 / (matrix_norm_one(W) + episilon)
+                    t = 1. / (matrix_norm_one(W) + epsilon)
                     alpha = min(t, lr)
 
-                    p_new = Cayley_loop(unity.t(), W, V, alpha)
-                    V_new = torch.mm(W, unity.t())  # n-by-p
-                    #                     check_identity(p_new.t())
-                    p.data.copy_(p_new.view(p.size()))
-                    V.copy_(V_new)
+                    p_new = cayley_loop(unity.t(), W, V, alpha, iters)
+                    param.copy_(p_new)  # update shadow weights
+                    p.data.copy_(p_new.view(p.size()).to(p.data.dtype))  # update param.data
+                    # update momentum buffer if momentum is used
+                    if momentum != 0:
+                        V.copy_(torch.mm(W, unity.t()))  # n-by-p
 
                 else:
+
+                    weight_decay = group["weight_decay"]
+                    dampening = group["dampening"]
+                    nesterov = group["nesterov"]
                     d_p = p.grad.data
                     #  defined.
                     try:

--- a/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
+++ b/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
@@ -147,20 +147,6 @@ def _prepare_train_dataset(train_dataset: DatasetToDevice) -> Dataset:
         device=None)
 
 
-def _parse_optimizer_dtype(dtype_str: Optional[str]) -> Optional[torch.dtype]:
-    """Convert string dtype to torch.dtype."""
-    if dtype_str is None:
-        return None
-    dtype_map = {
-        'float32': torch.float32,
-        'float16': torch.float16,
-        'bfloat16': torch.bfloat16,}
-    if dtype_str not in dtype_map:
-        raise ValueError(
-            f"Invalid optimizer_dtype: {dtype_str}. Valid values: {list(dtype_map.keys())}")
-    return dtype_map[dtype_str]
-
-
 def _prepare_model(model: torch.nn.Module) -> torch.nn.Module:
     # For a PretrainedModel, the Trainer in accelerate calls save_pretrained after
     # finishing the optimization. However, this method no longer works after
@@ -201,9 +187,11 @@ def apply_rotation_optimization(
     trainable_rotations = extract_trainable_rotation_matrices(model)
     for rot_mat in trainable_rotations:
         rot_mat.requires_grad = True
-    optimizer_dtype = _parse_optimizer_dtype(training_args.optimizer_dtype)
     optimizer = CaileySGD(
-        trainable_rotations, lr=training_args.learning_rate, stiefel=True, dtype=optimizer_dtype)
+        trainable_rotations,
+        lr=training_args.learning_rate,
+        stiefel=True,
+        dtype=training_args.optimizer_dtype)
     trainer = GeneralizedTrainer(
         model=model,
         tokenizer=tokenizer,

--- a/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
+++ b/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
@@ -34,6 +34,14 @@ class TrainingArguments(transformers.TrainingArguments):
     # from a checkpoint, so related files are not save by default
     save_strategy: Optional[str] = field(default="no")
 
+    ### Optimizer args
+    optimizer_dtype: Optional[str] = field(
+        default=None,
+        metadata={
+            "help":
+                "Data type for CaileySGD optimizer computations. None means use parameter dtype. "
+                "Valid values: 'float32', 'float16', 'bfloat16'."})
+
     ### Distillation Loss args
     use_distillation_loss: bool = field(
         default=False, metadata={"help": "Whether to compute the distillation loss."})
@@ -139,6 +147,20 @@ def _prepare_train_dataset(train_dataset: DatasetToDevice) -> Dataset:
         device=None)
 
 
+def _parse_optimizer_dtype(dtype_str: Optional[str]) -> Optional[torch.dtype]:
+    """Convert string dtype to torch.dtype."""
+    if dtype_str is None:
+        return None
+    dtype_map = {
+        'float32': torch.float32,
+        'float16': torch.float16,
+        'bfloat16': torch.bfloat16,}
+    if dtype_str not in dtype_map:
+        raise ValueError(
+            f"Invalid optimizer_dtype: {dtype_str}. Valid values: {list(dtype_map.keys())}")
+    return dtype_map[dtype_str]
+
+
 def _prepare_model(model: torch.nn.Module) -> torch.nn.Module:
     # For a PretrainedModel, the Trainer in accelerate calls save_pretrained after
     # finishing the optimization. However, this method no longer works after
@@ -179,7 +201,9 @@ def apply_rotation_optimization(
     trainable_rotations = extract_trainable_rotation_matrices(model)
     for rot_mat in trainable_rotations:
         rot_mat.requires_grad = True
-    optimizer = CaileySGD(trainable_rotations, lr=training_args.learning_rate, stiefel=True)
+    optimizer_dtype = _parse_optimizer_dtype(training_args.optimizer_dtype)
+    optimizer = CaileySGD(
+        trainable_rotations, lr=training_args.learning_rate, stiefel=True, dtype=optimizer_dtype)
     trainer = GeneralizedTrainer(
         model=model,
         tokenizer=tokenizer,

--- a/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
+++ b/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
@@ -39,8 +39,7 @@ class TrainingArguments(transformers.TrainingArguments):
         default=None,
         metadata={
             "help":
-                "Data type for CaileySGD optimizer computations. None means use parameter dtype. "
-                "Valid values: 'float32', 'float16', 'bfloat16'."})
+                "Data type for CaileySGD optimizer computations. None means use parameter dtype."})
 
     ### Distillation Loss args
     use_distillation_loss: bool = field(


### PR DESCRIPTION
## Reason for this PR

When training with mixed precision or low-precision weights, it can be beneficial to maintain optimizer state and perform gradient updates in higher precision to preserve numerical stability, while keeping model weights in lower precision for memory efficiency. This PR adds dtype flexibility to the `CayleySGD` optimizer, allowing optimizer computations to be performed in a different precision than the model parameters (e.g., running optimizer math in float32 while parameters are in float16/bfloat16).

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

- __New `dtype` parameter__: Specify the dtype for optimizer computations (default: `torch.float32`)
- __New `iters` parameter__: Make Cayley loop iterations configurable (default: 5)
- __Code cleanup__: PEP 8 naming, typo fixes, simplified calculations, and conditional momentum buffer handling


<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
