### PR TITLE
Setup: support for python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you like this project please consider ⭐ this repo, as it is the simplest an
 
 ## Requirements
 
-* Python >= 3.10, <3.13
+* Python >= 3.10, <3.14
 * [Pytorch](https://pytorch.org) >= 1.12, <= 2.9.1 (more recent versions would be untested).
 * Windows, Linux or macOS.
 * GPU training-time acceleration (*Optional* but recommended).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you like this project please consider ⭐ this repo, as it is the simplest an
 
 ## Requirements
 
-* Python >= 3.9, <3.13
+* Python >= 3.9, <3.14
 * [Pytorch](https://pytorch.org) >= 1.12, <= 2.8 (more recent versions would be untested).
 * Windows, Linux or macOS.
 * GPU training-time acceleration (*Optional* but recommended).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you like this project please consider ⭐ this repo, as it is the simplest an
 
 ## Requirements
 
-* Python >= 3.10, <3.14
+* Python >= 3.10
 * [Pytorch](https://pytorch.org) >= 1.12, <= 2.9.1 (more recent versions would be untested).
 * Windows, Linux or macOS.
 * GPU training-time acceleration (*Optional* but recommended).

--- a/docsrc/source/setup.rst
+++ b/docsrc/source/setup.rst
@@ -8,7 +8,7 @@ Requirements
 Installation Requirements
 '''''''''''''''''''''''''
 
--  Python >= 3.10, <3.13.
+-  Python >= 3.10
 -  `Pytorch`_ >= 1.9.1, <= 2.9.1 (more recent versions would be untested).
 -  Windows, Linux or macOS.
 -  GPU training-time acceleration (*optional* but recommended).

--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,3 +1,7 @@
+# Recent versions of onnxruntime are not compatible with python < 3.13
+# Latest version of onnx is not compatible with older version of onnxruntime
+# For python < 3.13, we will automatically install older versions of onnxruntime
+# and we need to pin a slightly old version of ONNX
 onnx==1.17.0 ; python_version < "3.13"
 onnx ; python_version >= "3.13"
 onnxoptimizer

--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,4 +1,5 @@
-onnx
+onnx==1.17.0 ; python_version < 3.13
+onnx ; python_version >= 3.13
 onnxoptimizer
 onnxscript
 qonnx

--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,5 +1,5 @@
-onnx==1.17.0 ; python_version < 3.13
-onnx ; python_version >= 3.13
+onnx==1.17.0 ; python_version < "3.13"
+onnx ; python_version >= "3.13"
 onnxoptimizer
 onnxscript
 qonnx

--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,4 +1,4 @@
-onnx==1.17.0
+onnx
 onnxoptimizer
 onnxscript
 qonnx

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -1,6 +1,6 @@
 bitstring
-onnx==1.17.0 ; python_version < 3.13
-onnx ; python_version >= 3.13
+onnx==1.17.0 ; python_version < "3.13"
+onnx ; python_version >= "3.13"
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
 onnxscript

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -1,5 +1,6 @@
 bitstring
-onnx
+onnx==1.17.0 ; python_version < 3.13
+onnx ; python_version >= 3.13
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
 onnxscript

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -1,5 +1,5 @@
 bitstring
-onnx==1.17.0
+onnx
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
 onnxscript

--- a/requirements/requirements-numpy.txt
+++ b/requirements/requirements-numpy.txt
@@ -1,1 +1,2 @@
-numpy<=1.26.4
+numpy < 2.0 ; python_version < "3.13"
+numpy ; python_version >= "3.13"

--- a/requirements/requirements-numpy.txt
+++ b/requirements/requirements-numpy.txt
@@ -1,2 +1,6 @@
+# The most recent versions of packages that are compatible with 3.13 (e.g., ml_dtypes) require latest
+# version of numpy.
+# Packages not compatible with latest numpy (e.g., older pytorch versions) are also not compatible
+# with python 3.13
 numpy < 2.0 ; python_version < "3.13"
 numpy ; python_version >= "3.13"

--- a/requirements/requirements-ort-integration.txt
+++ b/requirements/requirements-ort-integration.txt
@@ -1,4 +1,4 @@
-onnx==1.17.0
+onnx
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
 onnxscript

--- a/requirements/requirements-ort-integration.txt
+++ b/requirements/requirements-ort-integration.txt
@@ -1,5 +1,5 @@
-onnx==1.17.0 ; python_version < 3.13
-onnx ; python_version >= 3.13
+onnx==1.17.0 ; python_version < "3.13"
+onnx ; python_version >= "3.13"
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
 onnxscript

--- a/requirements/requirements-ort-integration.txt
+++ b/requirements/requirements-ort-integration.txt
@@ -1,4 +1,5 @@
-onnx
+onnx==1.17.0 ; python_version < 3.13
+onnx ; python_version >= 3.13
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
 onnxscript

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="AMD Research and Advanced Development",
     author_email="brevitas-external@amd.com",
     url="https://github.com/Xilinx/brevitas",
-    python_requires=">=3.9, <3.13",
+    python_requires=">=3.9, <3.14",
     install_requires=read_requirements('requirements.txt'),
     extras_require={
         "numpy": read_requirements('requirements-numpy.txt'),

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="AMD Research and Advanced Development",
     author_email="brevitas-external@amd.com",
     url="https://github.com/Xilinx/brevitas",
-    python_requires=">=3.10, <3.13",
+    python_requires=">=3.10, <3.14",
     install_requires=read_requirements('requirements.txt'),
     extras_require={
         "numpy": read_requirements('requirements-numpy.txt'),

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="AMD Research and Advanced Development",
     author_email="brevitas-external@amd.com",
     url="https://github.com/Xilinx/brevitas",
-    python_requires=">=3.10, <3.14",
+    python_requires=">=3.10",
     install_requires=read_requirements('requirements.txt'),
     extras_require={
         "numpy": read_requirements('requirements-numpy.txt'),

--- a/src/brevitas/inject/__init__.py
+++ b/src/brevitas/inject/__init__.py
@@ -79,7 +79,13 @@ class _ExtendedInjectorType(_InjectorType):
 
         _check_inheritance(bases, (Injector, BaseInjector))
         ns = {}
-        for attr in ("__module__", "__doc__", "__weakref__", "__qualname__"):
+        for attr in ("__module__",
+                     "__doc__",
+                     "__weakref__",
+                     "__qualname__",
+                     "__firstlineno__",
+                     "__static_attributes__",
+                     "__classdictcell__"):
             try:
                 ns[attr] = namespace.pop(attr)
             except KeyError:


### PR DESCRIPTION
## Reason for this PR

New dunder methods have been added in python 3.13, which break compatibility with Dependency Injection

Fixes #1450 

## Changes Made in this PR

Expand the list of whitelisted dunder methods 
We also need to handle the compatibility of certain packages (like onnx) with python 3.13

In particular, latest version of onnxruntime is not compatible with python < 3.13
The latest version of ONNX is compatible with python < 3.13, but not with the penultimate version of onnxruntime.
For this reason, we need to pin ONNX when installing python < 3.13

Similarly, latest ONNX requires latest ml_dtypes, which requires numpy > 2.0
For this reason, we also have a conditional dependency on numpy.
The main issue is that numpy > 2.0 is not compatible with old torch versions, but these are also not compatible with python 3.13, so I guess it's fine?

Dependencies are _hard_


## Testing Summary

Extended test to python 3.13

## Risk Highlight

We need to make sure that adding these methods in the whitelist does not have side effects