### PR TITLE
Feat (stats): Statistics capture

### DIFF
--- a/src/brevitas/graph/gpfq.py
+++ b/src/brevitas/graph/gpfq.py
@@ -107,13 +107,11 @@ class GPFQ(GPxQ):
             current_layer.forward_count = 0
             raise StopFwdException
 
-    def single_layer_update(self):
+    def _single_layer_update(self):
         assert not self.layer.weight_quant.requires_quant_input, \
             "Error: GPFQ does not support weight quantizers that require metadata from input quantizers."
         assert hasattr(self.layer, 'weight_orig'), \
             "Error: GPFQ requires the original weights to be stored, see `create_weight_orig`."
-        if hasattr(self.layer, 'allocate_params'):
-            self.layer.allocate_params(self.layer)
         if self.use_intermediate_buffer:
             del self.B  # free memory
 
@@ -193,9 +191,6 @@ class GPFQ(GPxQ):
                 q_arg = Ds[group_index, t] * weight[group_index, :, i].to(self.dtype) + Lw - Lq
                 assert not torch.isnan(q_arg).any()
                 weight[group_index, :, i] = q_arg.to(dtype)
-
-        if hasattr(self.layer, 'offload_params'):
-            self.layer.offload_params(self.layer)
 
 
 class gpfq_mode(gpxq_mode):

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -212,6 +212,7 @@ class GPTQ(GPxQ):
 
         # Log post-update statistics
         gptq_stats_collector.log("post_update", name=self.name, layer=self.layer, H=H_orig)
+        del H_orig
         # If stats are being collected, print statistics to DEBUG
         if gptq_stats_collector.is_active:
             logger.debug(

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from copy import deepcopy
+import functools
 import math
 from typing import List
 from typing import Optional
@@ -9,6 +10,8 @@ import warnings
 
 from packaging import version
 import torch
+
+from brevitas.utils.stats_utils import StatsCollectorCtx
 
 try:
     from torch.linalg import LinAlgError
@@ -21,6 +24,23 @@ from brevitas.graph.gpxq import gpxq_mode
 from brevitas.graph.gpxq import SUPPORTED_CONV_OP
 from brevitas.graph.utils import is_conv_transposed
 from brevitas.utils.torch_utils import StopFwdException
+
+
+# TODO (pml): Simplify this function
+@torch.no_grad()
+def compute_weight_error(prefix: str, name: str, layer: torch.nn.Module, H: torch.Tensor):
+    quant_weight = layer.quant_weight().value.to(dtype=H.dtype)
+    weight = layer.weight_orig.to(dtype=H.dtype, device=quant_weight.device)
+    H = H.to(device=quant_weight.device).squeeze(0)
+    # Compute relative error between quantized and original weights
+    err = quant_weight - weight
+    weight_rel_err = torch.norm(err) / torch.norm(weight)
+    # Compute relative error weighted by the Hessian, i.e. (w-q)^T H (w-q) / w^T H w
+    out_rel_err = torch.norm(err.T @ H @ err, p='fro') / torch.norm(weight.T @ H @ weight, p='fro')
+    return {
+        name: {
+            f"{prefix}_rel_weight_err": weight_rel_err.item(),
+            f"{prefix}_rel_out_err": out_rel_err.item(),}}
 
 
 class GPTQ(GPxQ):
@@ -112,6 +132,10 @@ class GPTQ(GPxQ):
         weight = self.layer.weight.data
         dev = weight.device
 
+        # Log pre-update statistics
+        gptq_stats_collector = StatsCollectorCtx.get()
+        gptq_stats_collector.log("pre_update", name=self.name, layer=self.layer, H=self.H)
+
         # Store the original dtype of the weights
         # During computation, everything is converted to float32.
         # When the weights are updated, we cast everything back to the original dtype
@@ -167,7 +191,9 @@ class GPTQ(GPxQ):
                 f'Increasing the number of samples might fix this issue')
             return
         finally:
-            del self.H
+            # TODO (pml): Delay Hessian deletion for statistics capture
+            # del self.H
+            pass
 
         for i1 in range(0, self.columns, self.blocksize):
             i2 = min(i1 + self.blocksize, self.columns)
@@ -195,6 +221,10 @@ class GPTQ(GPxQ):
                 weight[group_index, :, perm[i2:]] -= (
                     error_block[group_index].matmul(h_inv[group_index, i1:i2,
                                                           i2:].to(dev))).to(dtype)
+
+        # Log post-update statistics
+        gptq_stats_collector.log("post_update", name=self.name, layer=self.layer, H=self.H)
+
         if hasattr(self.layer, 'offload_params'):
             self.layer.offload_params(self.layer)
 
@@ -260,6 +290,12 @@ class gptq_mode(gpxq_mode):
         # How many subblock to use during GPTQ for each layer
         self.num_blocks = num_blocks
         self.gptq_class = gptq_class
+
+        # Register the statistics to collect during GPTQ
+        gptq_stats_collector = StatsCollectorCtx.get()
+        gptq_stats_collector.on("pre_update", functools.partial(compute_weight_error, prefix="pre"))
+        gptq_stats_collector.on(
+            "post_update", functools.partial(compute_weight_error, prefix="post"))
 
     def catch_stopfwd(self, *args, **kwargs):
         try:

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -11,6 +11,7 @@ import warnings
 from packaging import version
 import torch
 
+from brevitas.utils.logging import setup_logger
 from brevitas.utils.stats_utils import StatsCollectorCtx
 
 try:
@@ -22,25 +23,11 @@ from brevitas import torch_version
 from brevitas.graph.gpxq import GPxQ
 from brevitas.graph.gpxq import gpxq_mode
 from brevitas.graph.gpxq import SUPPORTED_CONV_OP
+from brevitas.graph.utils import gpxq_compute_error_stats
 from brevitas.graph.utils import is_conv_transposed
 from brevitas.utils.torch_utils import StopFwdException
 
-
-# TODO (pml): Simplify this function
-@torch.no_grad()
-def compute_weight_error(prefix: str, name: str, layer: torch.nn.Module, H: torch.Tensor):
-    quant_weight = layer.quant_weight().value.to(dtype=H.dtype)
-    weight = layer.weight_orig.to(dtype=H.dtype, device=quant_weight.device)
-    H = H.to(device=quant_weight.device).squeeze(0)
-    # Compute relative error between quantized and original weights
-    err = quant_weight - weight
-    weight_rel_err = torch.norm(err) / torch.norm(weight)
-    # Compute relative error weighted by the Hessian, i.e. (w-q)^T H (w-q) / w^T H w
-    out_rel_err = torch.norm(err.T @ H @ err, p='fro') / torch.norm(weight.T @ H @ weight, p='fro')
-    return {
-        name: {
-            f"{prefix}_rel_weight_err": weight_rel_err.item(),
-            f"{prefix}_rel_out_err": out_rel_err.item(),}}
+logger = setup_logger(__name__)
 
 
 class GPTQ(GPxQ):
@@ -132,9 +119,12 @@ class GPTQ(GPxQ):
         weight = self.layer.weight.data
         dev = weight.device
 
-        # Log pre-update statistics
         gptq_stats_collector = StatsCollectorCtx.get()
-        gptq_stats_collector.log("pre_update", name=self.name, layer=self.layer, H=self.H)
+        H_orig = None
+        if gptq_stats_collector.is_active:
+            H_orig = deepcopy(self.H)
+        # Log pre-update statistics
+        gptq_stats_collector.log("pre_update", name=self.name, layer=self.layer, H=H_orig)
 
         # Store the original dtype of the weights
         # During computation, everything is converted to float32.
@@ -191,9 +181,7 @@ class GPTQ(GPxQ):
                 f'Increasing the number of samples might fix this issue')
             return
         finally:
-            # TODO (pml): Delay Hessian deletion for statistics capture
-            # del self.H
-            pass
+            del self.H
 
         for i1 in range(0, self.columns, self.blocksize):
             i2 = min(i1 + self.blocksize, self.columns)
@@ -223,7 +211,11 @@ class GPTQ(GPxQ):
                                                           i2:].to(dev))).to(dtype)
 
         # Log post-update statistics
-        gptq_stats_collector.log("post_update", name=self.name, layer=self.layer, H=self.H)
+        gptq_stats_collector.log("post_update", name=self.name, layer=self.layer, H=H_orig)
+        # If stats are being collected, print statistics to DEBUG
+        if gptq_stats_collector.is_active:
+            logger.debug(
+                f"GPTQ statistics for layer {self.name}: {gptq_stats_collector.stats[self.name]}")
 
         if hasattr(self.layer, 'offload_params'):
             self.layer.offload_params(self.layer)
@@ -293,9 +285,10 @@ class gptq_mode(gpxq_mode):
 
         # Register the statistics to collect during GPTQ
         gptq_stats_collector = StatsCollectorCtx.get()
-        gptq_stats_collector.on("pre_update", functools.partial(compute_weight_error, prefix="pre"))
         gptq_stats_collector.on(
-            "post_update", functools.partial(compute_weight_error, prefix="post"))
+            "pre_update", functools.partial(gpxq_compute_error_stats, prefix="pre"))
+        gptq_stats_collector.on(
+            "post_update", functools.partial(gpxq_compute_error_stats, prefix="post"))
 
     def catch_stopfwd(self, *args, **kwargs):
         try:

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from copy import deepcopy
-import functools
 import math
 from typing import List
 from typing import Optional
@@ -12,7 +11,6 @@ from packaging import version
 import torch
 
 from brevitas.utils.logging import setup_logger
-from brevitas.utils.stats_utils import StatsCollectorCtx
 
 try:
     from torch.linalg import LinAlgError
@@ -22,8 +20,8 @@ except:
 from brevitas import torch_version
 from brevitas.graph.gpxq import GPxQ
 from brevitas.graph.gpxq import gpxq_mode
+from brevitas.graph.gpxq import gpxq_stats_wrap
 from brevitas.graph.gpxq import SUPPORTED_CONV_OP
-from brevitas.graph.utils import gpxq_compute_error_stats
 from brevitas.graph.utils import is_conv_transposed
 from brevitas.utils.torch_utils import StopFwdException
 
@@ -110,21 +108,13 @@ class GPTQ(GPxQ):
             current_layer.forward_count = 0
             raise StopFwdException
 
-    def single_layer_update(self, percdamp=.01, c=1e4):
+    @gpxq_stats_wrap
+    def _single_layer_update(self, percdamp=.01, c=1e4):
         assert not self.layer.weight_quant.requires_quant_input, "Error: GPTQ does not support weight quantizers that require quantized inputs."
-        if hasattr(self.layer, 'allocate_params'):
-            self.layer.allocate_params(self.layer)
         if self.use_intermediate_buffer:
             del self.B  # free memory
         weight = self.layer.weight.data
         dev = weight.device
-
-        gptq_stats_collector = StatsCollectorCtx.get()
-        H_orig = None
-        if gptq_stats_collector.is_active:
-            H_orig = deepcopy(self.H)
-        # Log pre-update statistics
-        gptq_stats_collector.log("pre_update", name=self.name, layer=self.layer, H=H_orig)
 
         # Store the original dtype of the weights
         # During computation, everything is converted to float32.
@@ -210,17 +200,6 @@ class GPTQ(GPxQ):
                     error_block[group_index].matmul(h_inv[group_index, i1:i2,
                                                           i2:].to(dev))).to(dtype)
 
-        # Log post-update statistics
-        gptq_stats_collector.log("post_update", name=self.name, layer=self.layer, H=H_orig)
-        del H_orig
-        # If stats are being collected, print statistics to DEBUG
-        if gptq_stats_collector.is_active:
-            logger.debug(
-                f"GPTQ statistics for layer {self.name}: {gptq_stats_collector.stats[self.name]}")
-
-        if hasattr(self.layer, 'offload_params'):
-            self.layer.offload_params(self.layer)
-
 
 class gptq_mode(gpxq_mode):
     """
@@ -283,13 +262,6 @@ class gptq_mode(gpxq_mode):
         # How many subblock to use during GPTQ for each layer
         self.num_blocks = num_blocks
         self.gptq_class = gptq_class
-
-        # Register the statistics to collect during GPTQ
-        gptq_stats_collector = StatsCollectorCtx.get()
-        gptq_stats_collector.on(
-            "pre_update", functools.partial(gpxq_compute_error_stats, prefix="pre"))
-        gptq_stats_collector.on(
-            "post_update", functools.partial(gpxq_compute_error_stats, prefix="post"))
 
     def catch_stopfwd(self, *args, **kwargs):
         try:

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -123,6 +123,11 @@ class gpxq_mode(quantization_status_manager):
             "pre_update", functools.partial(gpxq_compute_error_stats, prefix="pre"))
         gptq_stats_collector.on(
             "post_update", functools.partial(gpxq_compute_error_stats, prefix="post"))
+        # Verify that the original weights are kept when statistics are being collected
+        if gptq_stats_collector.is_active and not create_weight_orig:
+            raise ValueError(
+                "Statistics collection during GPxQ requires keeping original weights. Set `create_weight_orig` to True."
+            )
 
     def _is_module_supported(self, module):
         if is_quant_module(module):

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -118,13 +118,13 @@ class gpxq_mode(quantization_status_manager):
             self.model.forward = self.catch_stopfwd
 
         # Register the statistics to collect during GPTQ
-        gptq_stats_collector = StatsCollectorCtx.get()
-        gptq_stats_collector.on(
+        gpxq_stats_collector = StatsCollectorCtx.get()
+        gpxq_stats_collector.on(
             "pre_update", functools.partial(gpxq_compute_error_stats, prefix="pre"))
-        gptq_stats_collector.on(
+        gpxq_stats_collector.on(
             "post_update", functools.partial(gpxq_compute_error_stats, prefix="post"))
         # Verify that the original weights are kept when statistics are being collected
-        if gptq_stats_collector.is_active and not create_weight_orig:
+        if gpxq_stats_collector.is_active and not create_weight_orig:
             raise ValueError(
                 "Statistics collection during GPxQ requires keeping original weights. Set `create_weight_orig` to True."
             )

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
 from dataclasses import field
+import functools
 from functools import partial
 from operator import attrgetter
 from typing import List
@@ -20,11 +21,17 @@ import unfoldNd
 
 from brevitas.fx import GraphModule
 from brevitas.graph.calibrate import quantization_status_manager
+from brevitas.graph.utils import gpxq_compute_error_stats
 from brevitas.graph.utils import is_conv_transposed
 from brevitas.graph.utils import is_quant_module
 import brevitas.nn as qnn
 from brevitas.quant_tensor import _unpack_quant_tensor
 from brevitas.quant_tensor import QuantTensor
+from brevitas.utils.logging import setup_logger
+from brevitas.utils.stats_utils import DictStatsCollector
+from brevitas.utils.stats_utils import StatsCollectorCtx
+
+logger = setup_logger(__name__)
 
 SUPPORTED_CONV_OP = (
     nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d)
@@ -110,6 +117,13 @@ class gpxq_mode(quantization_status_manager):
         else:
             self.model.forward = self.catch_stopfwd
 
+        # Register the statistics to collect during GPTQ
+        gptq_stats_collector = StatsCollectorCtx.get()
+        gptq_stats_collector.on(
+            "pre_update", functools.partial(gpxq_compute_error_stats, prefix="pre"))
+        gptq_stats_collector.on(
+            "post_update", functools.partial(gpxq_compute_error_stats, prefix="post"))
+
     def _is_module_supported(self, module):
         if is_quant_module(module):
             is_quant_enabled = module.weight_quant.is_quant_enabled
@@ -181,6 +195,29 @@ class gpxq_mode(quantization_status_manager):
     @abstractmethod
     def catch_stopfwd(self, *args, **kwargs):
         pass
+
+
+def gpxq_stats_wrap(layer_update_fn):
+
+    @functools.wraps(layer_update_fn)
+    def wrapper(self: GPxQ, *args, **kwargs):
+        gpxq_stats_collector: DictStatsCollector = StatsCollectorCtx.get()
+        if gpxq_stats_collector.is_active:
+            H = deepcopy(self.H)
+            G = deepcopy(self.G) if hasattr(self, 'G') else None
+            # Log pre-update statistics
+            gpxq_stats_collector.log("pre_update", name=self.name, layer=self.layer, H=H, G=G)
+            # Run the layer update function
+            layer_update_fn(self, *args, **kwargs)
+            # Log post-update statistics
+            gpxq_stats_collector.log("post_update", name=self.name, layer=self.layer, H=H, G=G)
+            # If stats are being collected, print statistics to DEBUG
+            logger.debug(
+                f"GPTQ statistics for layer {self.name}: {gpxq_stats_collector.stats[self.name]}")
+            del H
+            del G
+
+    return wrapper
 
 
 class GPxQ(ABC):
@@ -297,8 +334,17 @@ class GPxQ(ABC):
     def update_batch(self):
         pass
 
-    @abstractmethod
     def single_layer_update(self):
+        if hasattr(self.layer, 'allocate_params'):
+            self.layer.allocate_params(self.layer)
+
+        self._single_layer_update()
+
+        if hasattr(self.layer, 'offload_params'):
+            self.layer.offload_params(self.layer)
+
+    @abstractmethod
+    def _single_layer_update(self):
         pass
 
     def get_quant_weights(self, i, i1, permutation_list, with_quant_history=False):

--- a/src/brevitas/graph/magr.py
+++ b/src/brevitas/graph/magr.py
@@ -110,9 +110,7 @@ class MagR(GPTQ):
         # across GPxQ classes
         self.compute_iterative_covariance(module, input, current_layer)
 
-    def single_layer_update(self):
-        if hasattr(self.layer, 'allocate_params'):
-            self.layer.allocate_params(self.layer)
+    def _single_layer_update(self):
         weight = self.layer.weight.data
         if self.create_weight_orig:
             weight_orig = self.layer.weight_orig.data
@@ -150,8 +148,6 @@ class MagR(GPTQ):
                 weight[group_index] = wk.to(dtype)  # downcast
                 assert torch.isfinite(weight[group_index]).all()
         del self.H  # free memory
-        if hasattr(self.layer, 'offload_params'):
-            self.layer.offload_params(self.layer)
 
 
 class magr_mode(gpxq_mode):

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -92,14 +92,12 @@ class Qronos(GPFQ):
             current_layer.forward_count = 0
             raise StopFwdException
 
-    def single_layer_update(self, beta: int = 1e4):
+    def _single_layer_update(self, beta: int = 1e4):
         from brevitas.graph.magr import _power_iteration
         assert not self.layer.weight_quant.requires_quant_input, \
             "Error: Qronos does not support weight quantizers that require metadata from input quantizers."
         assert hasattr(self.layer, 'weight_orig'), \
             "Error: Qronos requires the original weights to be stored, see `create_weight_orig`."
-        if hasattr(self.layer, 'allocate_params'):
-            self.layer.allocate_params(self.layer)
         if self.use_intermediate_buffer:
             del self.B  # free memory
 
@@ -262,6 +260,3 @@ class Qronos(GPFQ):
                     error_block[group_index].matmul(self.L[group_index, i1 - 1:i2 - 1,
                                                            i2 - 1:])).to(dtype)
         del self.L  # memory management
-
-        if hasattr(self.layer, 'offload_params'):
-            self.layer.offload_params(self.layer)

--- a/src/brevitas/graph/utils.py
+++ b/src/brevitas/graph/utils.py
@@ -5,7 +5,9 @@ from inspect import signature
 from typing import Any
 from typing import Dict
 from typing import Iterable
+from typing import Optional
 from typing import Tuple
+from typing import Union
 
 import torch
 from torch import nn
@@ -189,16 +191,26 @@ def remove_weight_orig(model: nn.Module):
 
 
 @torch.no_grad()
-def gpxq_compute_error_stats(prefix: str, name: str, layer: torch.nn.Module,
-                             H: torch.Tensor) -> Dict[str, float]:
+def gpxq_compute_error_stats(
+        prefix: str,
+        name: str,
+        layer: torch.nn.Module,
+        H: torch.Tensor,
+        G: Optional[torch.Tensor] = None,
+        device: Optional[Union[str, torch.device]] = None) -> Dict[str, float]:
     # This computation only supports nn.Linear, currently
-    assert isinstance(layer, qnn.QuantLinear), "`compute_weight_error` only supports `QuantLinear` layers"
-    quant_weight = layer.quant_weight().value.to(dtype=H.dtype)
-    weight = layer.weight_orig.to(dtype=H.dtype, device=quant_weight.device)
-    H = H.to(device=quant_weight.device).squeeze(0)
+    if not isinstance(layer, (qnn.QuantLinear,)):
+        raise NotImplementedError(
+            f"`compute_weight_error` only supports `QuantLinear` layers, but got {type(layer)}.")
+    device = device if device is not None else layer.weight.device
+    dtype = H.dtype
+    quant_weight = layer.quant_weight().value.to(dtype=dtype, device=device)
+    weight = layer.weight_orig.to(dtype=dtype, device=device)
+    H = H.to(device=device).squeeze(0)
+    G = G.to(device=device).squeeze(0) if G is not None else H
     # Compute relative error between quantized and original weights
     err = quant_weight - weight
-    weight_rel_err = torch.norm(err) / torch.norm(weight)
+    weight_rel_err = torch.norm(err, p='fro') / torch.norm(weight, p='fro')
     # Compute relative error weighted by the Hessian, i.e. (w-q)^T H (w-q) / w^T H w
     out_rel_err = torch.norm(err @ H @ err.T, p='fro') / torch.norm(weight @ H @ weight.T, p='fro')
     return {

--- a/src/brevitas/graph/utils.py
+++ b/src/brevitas/graph/utils.py
@@ -186,3 +186,22 @@ def remove_weight_orig(model: nn.Module):
     for name, module in model.named_modules():
         if hasattr(module, 'weight_orig'):
             del module.weight_orig
+
+
+@torch.no_grad()
+def gpxq_compute_error_stats(prefix: str, name: str, layer: torch.nn.Module,
+                             H: torch.Tensor) -> Dict[str, float]:
+    # This computation only supports nn.Linear, currently
+    assert isinstance(layer, qnn.QuantLinear), "`compute_weight_error` only supports `QuantLinear` layers"
+    quant_weight = layer.quant_weight().value.to(dtype=H.dtype)
+    weight = layer.weight_orig.to(dtype=H.dtype, device=quant_weight.device)
+    H = H.to(device=quant_weight.device).squeeze(0)
+    # Compute relative error between quantized and original weights
+    err = quant_weight - weight
+    weight_rel_err = torch.norm(err) / torch.norm(weight)
+    # Compute relative error weighted by the Hessian, i.e. (w-q)^T H (w-q) / w^T H w
+    out_rel_err = torch.norm(err @ H @ err.T, p='fro') / torch.norm(weight @ H @ weight.T, p='fro')
+    return {
+        name: {
+            f"{prefix}_rel_weight_err": weight_rel_err.item(),
+            f"{prefix}_rel_out_err": out_rel_err.item(),}}

--- a/src/brevitas/utils/stats_utils.py
+++ b/src/brevitas/utils/stats_utils.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from abc import ABC
+from abc import abstractmethod
+from collections.abc import Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+from typing import Dict
+from typing import override
+from typing import Protocol
+
+
+class StatFn(Protocol):
+
+    def __call__(self, **payload) -> Dict[str, Any]:
+        ...
+
+
+class BaseStatsCollector(ABC):
+
+    def __init__(self) -> None:
+        self._stats_fn: Dict[str, StatFn] = {}
+
+    def on(self, key: str, fn: StatFn) -> None:
+        self._stats_fn[key] = fn
+
+    def log(self, event: str, **payload) -> None:
+        if (fn := self._stats_fn.get(event, None)) is not None:
+            self._log(fn, **payload)
+
+    @abstractmethod
+    def _log(self, fn: StatFn, **payload) -> None:
+        pass
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({", ".join(self._stats_fn.keys())})"
+
+
+class NullCollector(BaseStatsCollector):
+
+    @override
+    def on(self, key: str, fn: StatFn) -> None:
+        pass
+
+    def _log(self, fn: StatFn, **payload) -> None:
+        pass
+
+
+def recursive_update(d: Dict, u: Dict) -> Dict:
+    for k, v in u.items():
+        if isinstance(v, Mapping):
+            d[k] = recursive_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
+
+class DictStatsCollector(BaseStatsCollector):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.stats: Dict[str, Any] = {}
+
+    def _log(self, fn: StatFn, **payload) -> None:
+        recursive_update(self.stats, fn(**payload))
+
+
+StatsCollectorCtx: ContextVar[BaseStatsCollector] = ContextVar(
+    "StatsCollector", default=NullCollector())
+
+
+@contextmanager
+def collect_stats(collector: BaseStatsCollector):
+    token = StatsCollectorCtx.set(collector)
+    try:
+        yield
+    finally:
+        StatsCollectorCtx.reset(token)

--- a/src/brevitas/utils/stats_utils.py
+++ b/src/brevitas/utils/stats_utils.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any
 from typing import Dict
-from typing import override
 from typing import Protocol
 
 
@@ -44,7 +43,6 @@ class BaseStatsCollector(ABC):
 
 class NullCollector(BaseStatsCollector):
 
-    @override
     def on(self, key: str, fn: StatFn) -> None:
         pass
 
@@ -52,7 +50,6 @@ class NullCollector(BaseStatsCollector):
         pass
 
     # NullCollector is always inactive, so stats are not collected
-    @override
     @property
     def is_active(self) -> bool:
         return False

--- a/src/brevitas/utils/stats_utils.py
+++ b/src/brevitas/utils/stats_utils.py
@@ -35,7 +35,7 @@ class BaseStatsCollector(ABC):
         pass
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({", ".join(self._stats_fn.keys())})"
+        return f'{self.__class__.__name__}({", ".join(self._stats_fn.keys())})'
 
     @property
     def is_active(self) -> bool:

--- a/src/brevitas/utils/stats_utils.py
+++ b/src/brevitas/utils/stats_utils.py
@@ -37,6 +37,10 @@ class BaseStatsCollector(ABC):
     def __repr__(self):
         return f"{self.__class__.__name__}({", ".join(self._stats_fn.keys())})"
 
+    @property
+    def is_active(self) -> bool:
+        return True
+
 
 class NullCollector(BaseStatsCollector):
 
@@ -46,6 +50,12 @@ class NullCollector(BaseStatsCollector):
 
     def _log(self, fn: StatFn, **payload) -> None:
         pass
+
+    # NullCollector is always inactive, so stats are not collected
+    @override
+    @property
+    def is_active(self) -> bool:
+        return False
 
 
 def recursive_update(d: Dict, u: Dict) -> Dict:

--- a/src/brevitas/utils/stats_utils.py
+++ b/src/brevitas/utils/stats_utils.py
@@ -26,7 +26,7 @@ class BaseStatsCollector(ABC):
         self._stats_fn[key] = fn
 
     def log(self, event: str, **payload) -> None:
-        if (fn := self._stats_fn.get(event, None)) is not None:
+        if (fn := self._stats_fn.get(event)):
             self._log(fn, **payload)
 
     @abstractmethod

--- a/src/brevitas_examples/common/axe.py
+++ b/src/brevitas_examples/common/axe.py
@@ -201,7 +201,7 @@ class A2GPTQ(_AXE, GPTQ):
         assert self.max_accumulator_bit_width > 2, \
             "Error: accumulator bit width needs to be bigger than 2."
 
-    def single_layer_update(self, percdamp=0.01, c=1e4):
+    def _single_layer_update(self, percdamp=0.01, c=1e4):
         assert not self.layer.weight_quant.requires_quant_input, \
             "Error: GPTQ does not support weight quantizers that require quantized inputs."
         if self.quant_metadata is None:
@@ -210,8 +210,6 @@ class A2GPTQ(_AXE, GPTQ):
                 "Make sure that either the input to the model is an IntQuantTensor or the layer has an input quant enabled. "
                 "Also, check if `use_quant_activations=True` in `gptq_mode` when `max_accumulator_bit_width` is specified. "
             )
-        if hasattr(self.layer, "allocate_params"):
-            self.layer.allocate_params(self.layer)
         if self.use_intermediate_buffer:
             del self.B  # free memory
         weight = self.layer.weight.data
@@ -351,9 +349,6 @@ class A2GPTQ(_AXE, GPTQ):
                 weight[group_index, :, perm[i2:]] -= (
                     error_block[group_index].matmul(h_inv[group_index, i1:i2,
                                                           i2:].to(dev))).to(dtype)
-        if hasattr(self.layer, "offload_params"):
-            self.layer.offload_params(self.layer)
-
         del thresholds, scales  # memory management
 
 
@@ -388,7 +383,7 @@ class A2GPFQ(_AXE, GPFQ):
         assert self.max_accumulator_bit_width > 2, \
             "Error: accumulator bit width needs to be bigger than 2."
 
-    def single_layer_update(self):
+    def _single_layer_update(self):
         assert not self.layer.weight_quant.requires_quant_input, \
             "Error: GPFQ does not support weight quantizers that require quantized inputs."
         if self.quant_metadata is None:
@@ -397,8 +392,6 @@ class A2GPFQ(_AXE, GPFQ):
                 "Make sure that either the input to the model is an IntQuantTensor or the layer has an input quant enabled. "
                 "Also, check if `use_quant_activations=True` in `gpfq_mode` when `max_accumulator_bit_width` is specified. "
             )
-        if hasattr(self.layer, "allocate_params"):
-            self.layer.allocate_params(self.layer)
         if self.use_intermediate_buffer:
             del self.B  # free memory
 

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -486,6 +486,13 @@ def create_args_parser() -> ArgumentParser:
         default=1,
         help='Batch size for calibration data loader. (default: %(default)s).')
 
+    parser.add_argument(
+        '--ptq-stats',
+        default=['gptq'],
+        type=str,
+        nargs='*',
+        help='A list of stats to be collected in PTQ algorithms. Default: %(default)s')
+
     return parser
 
 

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -488,7 +488,7 @@ def create_args_parser() -> ArgumentParser:
 
     parser.add_argument(
         '--ptq-stats',
-        default=['gptq'],
+        default=[],
         type=str,
         nargs='*',
         help='A list of stats to be collected in PTQ algorithms. Default: %(default)s')

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -609,7 +609,9 @@ def quantize_llm(args, extra_args=None):
 
         if args.gptq and not args.load_checkpoint:
             print("Applying GPTQ...")
-            with collect_stats(DictStatsCollector()):
+            stats_collector_ctx = collect_stats(
+                DictStatsCollector()) if "gptq" in args.ptq_stats else nullcontext()
+            with stats_collector_ctx:
                 apply_gptq(
                     model,
                     calibration_loader,

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -29,6 +29,8 @@ from brevitas.graph.utils import remove_weight_orig
 from brevitas.nn.quant_sdpa import ScaledDotProductAttention
 from brevitas.utils.logging import setup_logger
 from brevitas.utils.python_utils import hooked_on_a_function
+from brevitas.utils.stats_utils import collect_stats
+from brevitas.utils.stats_utils import DictStatsCollector
 from brevitas_examples.common.accelerate_utils.accelerate import offload_model
 from brevitas_examples.common.accelerate_utils.accelerate import remove_hooks
 from brevitas_examples.common.accelerate_utils.accelerate import update_internal_dict
@@ -607,16 +609,17 @@ def quantize_llm(args, extra_args=None):
 
         if args.gptq and not args.load_checkpoint:
             print("Applying GPTQ...")
-            apply_gptq(
-                model,
-                calibration_loader,
-                act_order=args.gpxq_act_order,
-                use_quant_activations=args.gpxq_use_quant_activations,
-                create_weight_orig=not args.disable_create_weight_orig,
-                block_name=args.gpxq_block_name,
-                buffer_device=args.gpxq_buffer_device,
-                max_accumulator_bit_width=args.gpxq_max_accumulator_bit_width,
-                max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
+            with collect_stats(DictStatsCollector()):
+                apply_gptq(
+                    model,
+                    calibration_loader,
+                    act_order=args.gpxq_act_order,
+                    use_quant_activations=args.gpxq_use_quant_activations,
+                    create_weight_orig=not args.disable_create_weight_orig,
+                    block_name=args.gpxq_block_name,
+                    buffer_device=args.gpxq_buffer_device,
+                    max_accumulator_bit_width=args.gpxq_max_accumulator_bit_width,
+                    max_accumulator_tile_size=args.gpxq_max_accumulator_tile_size)
             print("GPTQ applied.")
 
         if args.gpfq and not args.load_checkpoint:

--- a/tests/brevitas/graph/test_stats_utils.py
+++ b/tests/brevitas/graph/test_stats_utils.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from brevitas.utils.stats_utils import BaseStatsCollector
+from brevitas.utils.stats_utils import collect_stats
+from brevitas.utils.stats_utils import DictStatsCollector
+from brevitas.utils.stats_utils import NullCollector
+from brevitas.utils.stats_utils import StatsCollectorCtx
+
+
+class _SpyCollector(BaseStatsCollector):
+    """Collector for testing BaseStatsCollector semantics."""
+
+    def __init__(self):
+        super().__init__()
+        self.calls = []  # List of (fn, payload)
+
+    def _log(self, fn, **payload) -> None:
+        self.calls.append((fn, payload))
+
+
+def test_collector_dispatches():
+    c = _SpyCollector()
+
+    def fn(**payload):
+        return {"seen": payload}
+
+    c.on("evt", fn)
+    c.log("evt", a=1, b=2)
+
+    assert len(c.calls) == 1
+    called_fn, called_payload = c.calls[0]
+    assert called_fn is fn
+    assert called_payload == {"a": 1, "b": 2}
+
+    # If the key is missing, log() should be a no-op
+    c.log("missing", x=1)
+    assert len(c.calls) == 1
+
+
+def test_repr_keys():
+    c = _SpyCollector()
+
+    c.on("a", lambda **p: {})
+    c.on("b", lambda **p: {})
+    r = repr(c)
+
+    assert r.startswith("_SpyCollector(")
+    assert "a" in r and "b" in r
+
+
+def test_nullcollector_is_inactive():
+    n = NullCollector()
+
+    called = {"count": 0}
+
+    def fn(**payload):
+        called["count"] += 1
+        return {"x": 1}
+
+    # NullCollector should not register handlers or call them
+    n.on("evt", fn)
+    n.log("evt", a=1)
+
+    assert len(n._stats_fn) == 0
+    assert n.is_active is False
+    assert called["count"] == 0
+
+
+def test_dict_collector_merges_stats():
+    c = DictStatsCollector()
+
+    c.on("e1", lambda **p: {"outer": {"a": 1}, "flat": p["v"]})
+    c.on("e2", lambda **p: {"outer": {"b": 2}, "flat": 123})
+
+    c.log("e1", v=5)
+    assert c.stats == {"outer": {"a": 1}, "flat": 5}
+
+    # "e2" deep-merges "outer" and overwrites "flat"
+    c.log("e2")
+    assert c.stats == {"outer": {"a": 1, "b": 2}, "flat": 123}
+
+
+def test_collect_stats_sets_context():
+    default = StatsCollectorCtx.get()
+    assert isinstance(default, NullCollector)
+    assert default.is_active is False
+
+    c = DictStatsCollector()
+    with collect_stats(c):
+        assert StatsCollectorCtx.get() is c
+        assert StatsCollectorCtx.get().is_active is True
+
+    # Back to default after exit
+    after = StatsCollectorCtx.get()
+    assert isinstance(after, NullCollector)
+    assert after.is_active is False


### PR DESCRIPTION
## Reason for this PR

Add opt-in statistics collection for GPTQ/PTQ to quantify and debug per-layer quantization error during calibration, without changing default behavior.

## Changes Made in this PR

### What
- Introduced a generic statistics collection framework (`stats_utils.py`) with a no-op default.
- Instrumented GPTQ to emit `pre_update` and `post_update` events, to compute statistics before/after weight update.
- Added GPTQ error metrics (relative weight error and Hessian-weighted output error).
- Added `--ptq-stats` CLI flag to the LLM entrypoint.

### How
- Used a `ContextVar`-based collector to minimize changes required for statistics collection.
- Decoupled *when* stats are emitted (events) from *what* is computed (handlers).


## Testing Summary

- Manually validated GPTQ runs with and without `--ptq-stats gptq`.


## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
