### PR TITLE
Feat (brevitas_examples/llm): support for fully custom quantizers

### DIFF
--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -468,7 +468,15 @@ def generate_quantizers(
             linear_input_quant = linear_input_quant.let(
                 **{
                     'group_dim': -1, 'group_size': input_group_size})
-    return linear_input_quant, weight_quant, input_quant, q_scaled_quant, k_transposed_quant, v_quant, attn_output_weights_quant
+    output_dict = {
+        'linear_input_quant': linear_input_quant,
+        'weight_quant': weight_quant,
+        'input_quant': input_quant,
+        'q_scaled_quant': q_scaled_quant,
+        'k_transposed_quant': k_transposed_quant,
+        'v_quant': v_quant,
+        'attn_output_weights_quant': attn_output_weights_quant}
+    return output_dict
 
 
 def generate_quant_maps(

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -21,6 +21,13 @@ def create_args_parser() -> ArgumentParser:
         default="facebook/opt-125m",
         help='HF model name. Default: facebook/opt-125m.')
     parser.add_argument(
+        '--custom-quantizers',
+        type=str,
+        default=None,
+        help=
+        'Override the quantization list with custom user defined quantizers. This must be a .py file with a list of seven quantizers. Default: None.'
+    )
+    parser.add_argument(
         '--dtype',
         type=str,
         default="auto",

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -412,7 +412,7 @@ def quantize_llm(args, extra_args=None):
                     'zero_point_affine_rescaling_init': args.weight_quant_rescaling_init}}
         if args.weight_narrow_range:
             weight_kwargs = {**weight_kwargs, **{'narrow_range': args.weight_narrow_range}}
-        linear_input_quant, weight_quant, input_quant, q_scaled_quant, k_transposed_quant, v_quant, attn_output_weights_quant = generate_quantizers(
+        quantization_dict = generate_quantizers(
             weight_bit_width=args.weight_bit_width,
             weight_param_method=args.weight_param_method,
             weight_scale_precision=args.weight_scale_precision,
@@ -450,18 +450,20 @@ def quantize_llm(args, extra_args=None):
                 "custom_quantizers", args.custom_quantizers)
             custom_quantizers = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(custom_quantizers)
-            weight_quant, linear_input_quant, input_quant, q_scaled_quant, k_transposed_quant, v_quant, attn_output_weights_quant = custom_quantizers.quantization_list
+            keys_to_check = [
+                'weight_quant',
+                'linear_input_quant',
+                'input_quant',
+                'q_scaled_quant',
+                'k_transposed_quant',
+                'v_quant',
+                'attn_output_weights_quant']
+            quantization_dict = dict()
+            for k in keys_to_check:
+                quantization_dict[k] = custom_quantizers.quantization_dict.get(k, None)
+
         layer_map = generate_quant_maps(
-            linear_input_quant=linear_input_quant,
-            weight_quant=weight_quant,
-            input_quant=input_quant,
-            q_scaled_quant=q_scaled_quant,
-            k_transposed_quant=k_transposed_quant,
-            v_quant=v_quant,
-            attn_output_weights_quant=attn_output_weights_quant,
-            dtype=dtype,
-            device=device,
-            quantize_embedding=False)
+            **quantization_dict, dtype=dtype, device=device, quantize_embedding=False)
         if not args.quantize_last_layer:
             # Dynamo tracing changes the name of the modules, thus we need this workaround to pick
             # up the last module.

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -4,6 +4,7 @@
 from contextlib import nullcontext
 from copy import deepcopy
 import functools
+import importlib.util
 import os
 import pprint
 import sys
@@ -444,6 +445,12 @@ def quantize_llm(args, extra_args=None):
             quant_attn_mode='sdpa',
             scaling_min_val=args.scaling_min_val,
             weight_kwargs=weight_kwargs)
+        if args.custom_quantizers:
+            spec = importlib.util.spec_from_file_location(
+                "custom_quantizers", args.custom_quantizers)
+            custom_quantizers = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(custom_quantizers)
+            weight_quant, linear_input_quant, input_quant, q_scaled_quant, k_transposed_quant, v_quant, attn_output_weights_quant = custom_quantizers.quantization_list
         layer_map = generate_quant_maps(
             linear_input_quant=linear_input_quant,
             weight_quant=weight_quant,

--- a/src/brevitas_examples/stable_diffusion/main.py
+++ b/src/brevitas_examples/stable_diffusion/main.py
@@ -530,7 +530,7 @@ def quantize_sd(args: Namespace, extra_args: Optional[List[str]] = None):
             input_kwargs=input_kwargs)
 
         layer_map = generate_quant_maps(
-            *quantizers, dtype=dtype, device=args.device, quantize_embedding=False)
+            **quantizers, dtype=dtype, device=args.device, quantize_embedding=False)
 
         linear_qkwargs = layer_map[torch.nn.Linear][1]
         linear_qkwargs[

--- a/tests/brevitas_examples/custom_quant.py
+++ b/tests/brevitas_examples/custom_quant.py
@@ -1,0 +1,5 @@
+from brevitas.quant import Int8ActPerTensorFloat
+from brevitas.quant import Int8WeightPerTensorFloat
+
+quantization_dict = dict()
+quantization_dict['weight_quant'] = Int8WeightPerTensorFloat

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -65,7 +65,8 @@ class LLMRunCases:
             },{
                 "weight_quant_format": "float_e2m1",
                 "weight_param_method": "mse",
-            }
+            },
+            {"custom_quantizers": "custom_quant.py"}
         ],
         ids=[
             "defaults",
@@ -86,7 +87,8 @@ class LLMRunCases:
             "quant_sdpa_functional_per_row",
             "functional_sdpa_quant=True,rotation=fused_no_fx",
             "per_group_w_padding,learned_round=linear_round",
-            "float_e2m1_and_mse"
+            "float_e2m1_and_mse",
+            "custom_quantizer"
         ],)
     def case_small_models_toggle_args(self, run_dict, default_run_args, request):
         if config.JIT_ENABLED and run_dict.get("weight_param_method") == "mse":

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -66,7 +66,7 @@ class LLMRunCases:
                 "weight_quant_format": "float_e2m1",
                 "weight_param_method": "mse",
             },
-            {"custom_quantizers": "custom_quant.py"}
+            {"custom_quantizers": "./tests/brevitas_examples/custom_quant.py"}
         ],
         ids=[
             "defaults",


### PR DESCRIPTION
## Reason for this PR

Currently, every time we need to support a new quantization type, we need to modify our entry-point in several ways (e.g., new args, new option in the dict), and this process does not scale up with more advanced quantization schemes.


## Changes Made in this PR

This PR allows the user to specify a file with custom quantizers to use for our LLM entrypoint.
The user can optionally specify up to seven quantizers:
- `weight_quantizer`
- `input_linear_quantizer`: quantizer used specifically in linear layers
- `input_quant`: for all other layers that are not linear (e.g., if there are conv in the network)
- `q_scaled_quant`, `k_transposed_quant`, `v_quant`: quantizers for QKV in scaled dot product
- `attn_output_weights_quant`: quantization for the output of sigmoid of scaled dot product

These quantizers should be put in a dict, using they specified above.
If any of the keys is not specified, then the quantizer is set to None (equivalent to no quantization)


## Testing Summary

TBD
