### PR TITLE
Setup: test ONNX dynamo export with torch >= 2.7

### DIFF
--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,3 +1,4 @@
 onnx==1.17.0
 onnxoptimizer
+onnxscript
 qonnx

--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,4 +1,5 @@
 onnx==1.17.0
+onnx_ir<0.1.16
 onnxoptimizer
 onnxscript<0.5.4
 qonnx

--- a/requirements/requirements-export.txt
+++ b/requirements/requirements-export.txt
@@ -1,5 +1,3 @@
 onnx==1.17.0
-onnx_ir<0.1.16
 onnxoptimizer
-onnxscript<0.5.4
 qonnx

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -2,5 +2,6 @@ bitstring
 onnx==1.17.0
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
+onnxscript
 qonnx
 toposort

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -1,5 +1,6 @@
 bitstring
 onnx==1.17.0
+onnx_ir<0.1.16
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
 onnxscript<0.5.4

--- a/requirements/requirements-finn-integration.txt
+++ b/requirements/requirements-finn-integration.txt
@@ -1,8 +1,6 @@
 bitstring
 onnx==1.17.0
-onnx_ir<0.1.16
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
-onnxscript<0.5.4
 qonnx
 toposort

--- a/requirements/requirements-ort-integration.txt
+++ b/requirements/requirements-ort-integration.txt
@@ -1,4 +1,5 @@
 onnx==1.17.0
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
+onnxscript
 qonnx

--- a/requirements/requirements-ort-integration.txt
+++ b/requirements/requirements-ort-integration.txt
@@ -1,6 +1,4 @@
 onnx==1.17.0
-onnx_ir<0.1.16
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
-onnxscript<0.5.4
 qonnx

--- a/requirements/requirements-ort-integration.txt
+++ b/requirements/requirements-ort-integration.txt
@@ -1,4 +1,5 @@
 onnx==1.17.0
+onnx_ir<0.1.16
 onnxoptimizer
 onnxruntime>=1.15.0, <1.21
 onnxscript<0.5.4

--- a/tests/brevitas_finn/brevitas_examples/test_bnn_pynq_finn_export.py
+++ b/tests/brevitas_finn/brevitas_examples/test_bnn_pynq_finn_export.py
@@ -14,8 +14,6 @@ from qonnx.transformation.general import RemoveStaticGraphInputs
 from qonnx.transformation.infer_shapes import InferShapes
 import torch
 
-from brevitas import torch_version
-from brevitas.quant_tensor import QuantTensor
 from brevitas_examples.bnn_pynq.models import model_with_cfg
 
 from ...export_fixture import qonnx_export_fn

--- a/tests/export_fixture.py
+++ b/tests/export_fixture.py
@@ -13,7 +13,7 @@ from brevitas.export import export_qonnx
 
 
 def _get_qonnx_export_modes():
-    if parse("2.6") > torch_version:
+    if parse("2.7") > torch_version:
         export_fns = [export_qonnx]
         export_ids = ["torchscript"]
     else:


### PR DESCRIPTION
## Reason for this PR

New version of onnx_ir seems to not be compatible with our pinned version of onnxscript.


## Changes Made in this PR

Test ONNX dynamo export only against torch 2.7 and higher, where there are no issues.
The other solution is to pin both onnxscript _and_ onnx_ir, which is not practical.