### PR TITLE
Feat (common/quantizer): Enable passing custom quantizers

### DIFF
--- a/src/brevitas/utils/python_utils.py
+++ b/src/brevitas/utils/python_utils.py
@@ -4,6 +4,14 @@
 from contextlib import contextmanager
 from enum import Enum
 import functools
+from typing import Callable
+from typing import Dict
+from typing import Generic
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import TypeVar
+from typing import Union
 
 
 class AutoName(str, Enum):
@@ -64,3 +72,43 @@ def hooked_on_a_function(function, prefunction):
         return function(*args, **kwargs)
 
     return run
+
+
+T = TypeVar("T")
+
+
+class Registry(Generic[T]):
+
+    def __init__(self, registry_name: Optional[str] = None) -> None:
+        self._registry_name = registry_name
+        self._registry: Dict[str, T] = {}
+
+    @property
+    def registry_name(self) -> str:
+        return "registry" if self._registry_name is None else self._registry_name
+
+    def register(self, names: Union[str, List[str]]) -> Callable[[T], T]:
+        if isinstance(names, str):
+            names = [names]
+
+        def decorator(value: T) -> T:
+            # Allow registering the same value to multiple keys
+            for name in names:
+                if name in self._registry:
+                    raise ValueError(f"'{name}' is already registered in {self.registry_name}.")
+                self._registry[name] = value
+            return value
+
+        return decorator
+
+    def get_registered_keys(self) -> Iterable[str]:
+        return self._registry.keys()
+
+    def get(self, name: str) -> T:
+        try:
+            return self._registry[name]
+        except KeyError:
+            available = ", ".join(sorted(self._registry)) or "<empty>"
+            raise ValueError(
+                f"'{name}' not found in {self.registry_name}. The available values are: {available}"
+            )

--- a/src/brevitas/utils/python_utils.py
+++ b/src/brevitas/utils/python_utils.py
@@ -12,6 +12,7 @@ from typing import List
 from typing import Optional
 from typing import TypeVar
 from typing import Union
+import warnings
 
 
 class AutoName(str, Enum):
@@ -83,9 +84,16 @@ class Registry(Generic[T]):
         self._registry_name = registry_name
         self._registry: Dict[str, T] = {}
 
+    @staticmethod
+    def register(
+        registry: "Registry[T]",
+        names: Union[str, List[str]],
+    ) -> Callable[[T], T]:
+        return registry.register(names)
+
     @property
     def registry_name(self) -> str:
-        return "registry" if self._registry_name is None else self._registry_name
+        return "Registry" if self._registry_name is None else self._registry_name
 
     def register(self, names: Union[str, List[str]]) -> Callable[[T], T]:
         if isinstance(names, str):
@@ -95,7 +103,9 @@ class Registry(Generic[T]):
             # Allow registering the same value to multiple keys
             for name in names:
                 if name in self._registry:
-                    raise ValueError(f"'{name}' is already registered in {self.registry_name}.")
+                    warnings.warn(
+                        f"'{name}' is already registered in {self.registry_name}. Overwriting the existing value."
+                    )
                 self._registry[name] = value
             return value
 

--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -468,7 +468,14 @@ def generate_quantizers(
             linear_input_quant = linear_input_quant.let(
                 **{
                     'group_dim': -1, 'group_size': input_group_size})
-    return linear_input_quant, weight_quant, input_quant, q_scaled_quant, k_transposed_quant, v_quant, attn_output_weights_quant
+    return {
+        'linear_input_quant': linear_input_quant,
+        'weight_quant': weight_quant,
+        'input_quant': input_quant,
+        'q_scaled_quant': q_scaled_quant,
+        'k_transposed_quant': k_transposed_quant,
+        'v_quant': v_quant,
+        'attn_output_weights_quant': attn_output_weights_quant}
 
 
 def generate_quant_maps(

--- a/src/brevitas_examples/common/generative/quantizers.py
+++ b/src/brevitas_examples/common/generative/quantizers.py
@@ -3,6 +3,12 @@ Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 """
 
+from typing import ClassVar
+from typing import Dict
+from typing import Optional
+from typing import Type
+from typing import TypeVar
+
 from torch import nn
 
 from brevitas.core.function_wrapper.ops_ste import FloorSte
@@ -39,8 +45,10 @@ from brevitas.quant.experimental.float_quant_ocp import Fp8e4m3OCPWeightPerChann
 from brevitas.quant.scaled_int import Int8ActPerTensorFloat
 from brevitas.quant.scaled_int import Int8WeightPerChannelFloat
 from brevitas.quant.scaled_int import Int8WeightPerChannelFloatHQO
+from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 from brevitas.quant.shifted_scaled_int import ShiftedUint8ActPerTensorFloat
 from brevitas.quant.shifted_scaled_int import ShiftedUint8WeightPerChannelFloat
+from brevitas.utils.python_utils import Registry
 
 from .quant_blocks import *
 
@@ -218,3 +226,31 @@ class FP8e4m3FNUZDynamicActPerRowFloat(Fp8e4m3FNUZActPerTensorFloat):
 
 class Fp8e4m3WeightPerChannelFloatMSE(MSESymmetricScale, Fp8e4m3WeightPerChannelFloat):
     pass
+
+
+# TODO: Subject to change
+class BaseQuantizer:
+    weight_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
+    linear_input_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
+    input_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
+    q_scaled_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
+    k_transposed_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
+    v_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
+    attn_output_weights_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
+
+    @classmethod
+    def override_quantizers_dict(
+            cls: "BaseQuantizer",
+            quantizers_dict: Dict[str, Optional[ExtendedInjector]]):  # type: ignore
+        for key in quantizers_dict:
+            if hasattr(cls, key) and (value := getattr(cls, key)) is not None:
+                quantizers_dict[key] = value
+        return quantizers_dict
+
+
+CUSTOM_QUANTIZERS_REGISTRY = Registry[Type[BaseQuantizer]](registry_name="CustomQuantizersRegistry")
+
+
+@CUSTOM_QUANTIZERS_REGISTRY.register("custom_quant")
+class CustomQuantizerExample(BaseQuantizer):
+    weight_quant: ClassVar[Optional[ExtendedInjector]] = Int8WeightPerTensorFloat  # type: ignore

--- a/src/brevitas_examples/common/generative/quantizers.py
+++ b/src/brevitas_examples/common/generative/quantizers.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 from typing import Dict
 from typing import Optional
 from typing import Type
-from typing import TypeVar
+from typing import TypeAlias
 
 from torch import nn
 
@@ -51,6 +51,34 @@ from brevitas.quant.shifted_scaled_int import ShiftedUint8WeightPerChannelFloat
 from brevitas.utils.python_utils import Registry
 
 from .quant_blocks import *
+
+# Prevents Pylance from raising "Variable not allowed in type expression" error in every type hint in BaseQuantizer
+QuantInjector: TypeAlias = ExtendedInjector  # type: ignore
+
+
+class BaseQuantizer:
+    weight_quant: ClassVar[Optional[QuantInjector]] = None
+    linear_input_quant: ClassVar[Optional[QuantInjector]] = None
+    input_quant: ClassVar[Optional[QuantInjector]] = None
+    q_scaled_quant: ClassVar[Optional[QuantInjector]] = None
+    k_transposed_quant: ClassVar[Optional[QuantInjector]] = None
+    v_quant: ClassVar[Optional[QuantInjector]] = None
+    attn_output_weights_quant: ClassVar[Optional[QuantInjector]] = None
+
+    @classmethod
+    def override_quantizers_dict(
+            cls: "BaseQuantizer",
+            quantizers_dict: Dict[str,
+                                  Optional[QuantInjector]]) -> Dict[str, Optional[QuantInjector]]:
+        # Overrides the quantizers in the input dictionary
+        for key in quantizers_dict:
+            if (value := getattr(cls, key)) is not None:
+                quantizers_dict[key] = value
+        return quantizers_dict
+
+
+# Registry for custom quantizers
+CUSTOM_QUANTIZERS_REGISTRY = Registry[Type[BaseQuantizer]](registry_name="CustomQuantizersRegistry")
 
 
 class DynamicActProxyMixin(ExtendedInjector):
@@ -226,31 +254,3 @@ class FP8e4m3FNUZDynamicActPerRowFloat(Fp8e4m3FNUZActPerTensorFloat):
 
 class Fp8e4m3WeightPerChannelFloatMSE(MSESymmetricScale, Fp8e4m3WeightPerChannelFloat):
     pass
-
-
-# TODO: Subject to change
-class BaseQuantizer:
-    weight_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
-    linear_input_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
-    input_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
-    q_scaled_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
-    k_transposed_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
-    v_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
-    attn_output_weights_quant: ClassVar[Optional[ExtendedInjector]] = None  # type: ignore
-
-    @classmethod
-    def override_quantizers_dict(
-            cls: "BaseQuantizer",
-            quantizers_dict: Dict[str, Optional[ExtendedInjector]]):  # type: ignore
-        for key in quantizers_dict:
-            if hasattr(cls, key) and (value := getattr(cls, key)) is not None:
-                quantizers_dict[key] = value
-        return quantizers_dict
-
-
-CUSTOM_QUANTIZERS_REGISTRY = Registry[Type[BaseQuantizer]](registry_name="CustomQuantizersRegistry")
-
-
-@CUSTOM_QUANTIZERS_REGISTRY.register("custom_quant")
-class CustomQuantizerExample(BaseQuantizer):
-    weight_quant: ClassVar[Optional[ExtendedInjector]] = Int8WeightPerTensorFloat  # type: ignore

--- a/src/brevitas_examples/common/generative/quantizers.py
+++ b/src/brevitas_examples/common/generative/quantizers.py
@@ -78,7 +78,7 @@ class BaseQuantizer:
 
 
 # Registry for custom quantizers
-CUSTOM_QUANTIZERS_REGISTRY = Registry[Type[BaseQuantizer]](registry_name="CustomQuantizersRegistry")
+QUANTIZERS_REGISTRY = Registry[Type[BaseQuantizer]](registry_name="QuantizersRegistry")
 
 
 class DynamicActProxyMixin(ExtendedInjector):

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -21,6 +21,13 @@ def create_args_parser() -> ArgumentParser:
         default="facebook/opt-125m",
         help='HF model name. Default: facebook/opt-125m.')
     parser.add_argument(
+        '--custom-quantizer',
+        type=str,
+        default=None,
+        help=
+        'Override the quantization list with custom user defined quantizers. This must be a .py file with a list of seven quantizers. Default: None.'
+    )
+    parser.add_argument(
         '--dtype',
         type=str,
         default="auto",

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -34,6 +34,7 @@ from brevitas_examples.common.accelerate_utils.accelerate import remove_hooks
 from brevitas_examples.common.accelerate_utils.accelerate import update_internal_dict
 from brevitas_examples.common.generative.quantize import generate_quant_maps
 from brevitas_examples.common.generative.quantize import generate_quantizers
+from brevitas_examples.common.generative.quantizers import CUSTOM_QUANTIZERS_REGISTRY
 from brevitas_examples.common.parse_utils import override_defaults
 from brevitas_examples.common.parse_utils import parse_args
 from brevitas_examples.llm.gguf_export.export import save_quantized_as_gguf
@@ -411,7 +412,7 @@ def quantize_llm(args, extra_args=None):
                     'zero_point_affine_rescaling_init': args.weight_quant_rescaling_init}}
         if args.weight_narrow_range:
             weight_kwargs = {**weight_kwargs, **{'narrow_range': args.weight_narrow_range}}
-        linear_input_quant, weight_quant, input_quant, q_scaled_quant, k_transposed_quant, v_quant, attn_output_weights_quant = generate_quantizers(
+        quantizers_dict = generate_quantizers(
             weight_bit_width=args.weight_bit_width,
             weight_param_method=args.weight_param_method,
             weight_scale_precision=args.weight_scale_precision,
@@ -444,17 +445,11 @@ def quantize_llm(args, extra_args=None):
             quant_attn_mode='sdpa',
             scaling_min_val=args.scaling_min_val,
             weight_kwargs=weight_kwargs)
+        if args.custom_quantizer is not None:
+            custom_quantizer = CUSTOM_QUANTIZERS_REGISTRY.get(args.custom_quantizer)
+            quantizers_dict = custom_quantizer.override_quantizers_dict(quantizers_dict)
         layer_map = generate_quant_maps(
-            linear_input_quant=linear_input_quant,
-            weight_quant=weight_quant,
-            input_quant=input_quant,
-            q_scaled_quant=q_scaled_quant,
-            k_transposed_quant=k_transposed_quant,
-            v_quant=v_quant,
-            attn_output_weights_quant=attn_output_weights_quant,
-            dtype=dtype,
-            device=device,
-            quantize_embedding=False)
+            **quantizers_dict, dtype=dtype, device=device, quantize_embedding=False)
         if not args.quantize_last_layer:
             # Dynamo tracing changes the name of the modules, thus we need this workaround to pick
             # up the last module.

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -227,13 +227,21 @@ def parse_custom_quantizer(quant_name: str) -> str:
         quant_path = path
         quant_name = name
 
-    # Load module with the custom quantizer if plugin_path is not None
     if quant_path is not None:
+        # Retrieve previously registered quantizers
+        pre_registered_quantizers = set(QUANTIZERS_REGISTRY.get_registered_keys())
+        # Load the module with the custom quantizers
         spec = importlib.util.spec_from_file_location("custom_quant", quant_path)
         if spec is None or spec.loader is None:
             raise ImportError(f"Could not load spec for quantizer path: {quant_path}")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
+        # Retrieve newly registered quantizers
+        post_registered_quantizers = set(QUANTIZERS_REGISTRY.get_registered_keys())
+
+        logging.debug(
+            f"The following quantizers were loaded from {quant_path}: {', '.join(post_registered_quantizers - pre_registered_quantizers)}"
+        )
 
     return quant_name
 

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -4,7 +4,9 @@
 from contextlib import nullcontext
 from copy import deepcopy
 import functools
+import importlib
 import os
+from pathlib import Path
 import pprint
 import sys
 import warnings
@@ -34,7 +36,8 @@ from brevitas_examples.common.accelerate_utils.accelerate import remove_hooks
 from brevitas_examples.common.accelerate_utils.accelerate import update_internal_dict
 from brevitas_examples.common.generative.quantize import generate_quant_maps
 from brevitas_examples.common.generative.quantize import generate_quantizers
-from brevitas_examples.common.generative.quantizers import CUSTOM_QUANTIZERS_REGISTRY
+from brevitas_examples.common.generative.quantizers import QuantInjector
+from brevitas_examples.common.generative.quantizers import QUANTIZERS_REGISTRY
 from brevitas_examples.common.parse_utils import override_defaults
 from brevitas_examples.common.parse_utils import parse_args
 from brevitas_examples.llm.gguf_export.export import save_quantized_as_gguf
@@ -209,6 +212,27 @@ def find_equalized_layer(layer):
     if hasattr(layer, 'layer'):
         return find_equalized_layer(layer.layer)
     return layer
+
+
+def parse_custom_quantizer(quant_name: str) -> str:
+    # Detect "/path/to/plugin.py:quant_name"
+    quant_path = None
+    if ":" in quant_name:
+        path, name = quant_name.rsplit(":", 1)
+        # Only treat it as a file plugin if paths points to an existing .py file
+        if path.endswith(".py") and Path(path).expanduser().exists():
+            quant_path = path
+            quant_name = name
+
+    # Load module with the custom quantizer if plugin_path is not None
+    if quant_path is not None:
+        spec = importlib.util.spec_from_file_location("custom_quant", quant_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not load spec for quantizer path: {quant_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+    return quant_name
 
 
 def quantize_llm(args, extra_args=None):
@@ -446,7 +470,8 @@ def quantize_llm(args, extra_args=None):
             scaling_min_val=args.scaling_min_val,
             weight_kwargs=weight_kwargs)
         if args.custom_quantizer is not None:
-            custom_quantizer = CUSTOM_QUANTIZERS_REGISTRY.get(args.custom_quantizer)
+            quantizer_name = parse_custom_quantizer(args.custom_quantizer)
+            custom_quantizer = QUANTIZERS_REGISTRY.get(quantizer_name)
             quantizers_dict = custom_quantizer.override_quantizers_dict(quantizers_dict)
         layer_map = generate_quant_maps(
             **quantizers_dict, dtype=dtype, device=device, quantize_embedding=False)

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -219,10 +219,13 @@ def parse_custom_quantizer(quant_name: str) -> str:
     quant_path = None
     if ":" in quant_name:
         path, name = quant_name.rsplit(":", 1)
-        # Only treat it as a file plugin if paths points to an existing .py file
-        if path.endswith(".py") and Path(path).expanduser().exists():
-            quant_path = path
-            quant_name = name
+        # Treat as a file plugin if paths points to an existing .py file
+        if not Path(path).expanduser().exists():
+            raise FileNotFoundError(f"Quantizer file path {path} does not exist.")
+        if not path.endswith(".py"):
+            raise ValueError(f"{path} is not a .py file.")
+        quant_path = path
+        quant_name = name
 
     # Load module with the custom quantizer if plugin_path is not None
     if quant_path is not None:

--- a/src/brevitas_examples/stable_diffusion/main.py
+++ b/src/brevitas_examples/stable_diffusion/main.py
@@ -530,7 +530,7 @@ def quantize_sd(args: Namespace, extra_args: Optional[List[str]] = None):
             input_kwargs=input_kwargs)
 
         layer_map = generate_quant_maps(
-            *quantizers, dtype=dtype, device=args.device, quantize_embedding=False)
+            **quantizers, dtype=dtype, device=args.device, quantize_embedding=False)
 
         linear_qkwargs = layer_map[torch.nn.Linear][1]
         linear_qkwargs[

--- a/tests/brevitas/utils/test_python_utils.py
+++ b/tests/brevitas/utils/test_python_utils.py
@@ -3,7 +3,10 @@
 
 from enum import auto
 
+import pytest
+
 from brevitas.utils.python_utils import AutoName
+from brevitas.utils.python_utils import Registry
 
 
 class TestEnum(AutoName):
@@ -38,3 +41,77 @@ def test_eq_enum():
 
 def test_neq_enum():
     assert TestEnum.FIRST != TestEnum.SECOND
+
+
+class TestRegistry:
+
+    def test_register_single_name(self):
+        r = Registry()
+
+        @r.register("k")
+        class Dummy:
+            pass
+
+        dummy = r.get("k")
+
+        assert dummy is Dummy
+        assert len(r.get_registered_keys()) == 1
+        assert next(iter(r.get_registered_keys())) == "k"
+
+    def test_register_multiple_names(self):
+        r = Registry()
+
+        @r.register(["k1", "k2"])
+        class Dummy:
+            pass
+
+        dummy1 = r.get("k1")
+        dummy2 = r.get("k2")
+
+        assert dummy1 is Dummy
+        assert dummy2 is Dummy
+        assert len(r.get_registered_keys()) == 2
+        assert set(r.get_registered_keys()) == {"k1", "k2"}
+
+    def test_register_single_name_static(self):
+        r = Registry()
+
+        @Registry.register(r, "k")
+        class Dummy:
+            pass
+
+        dummy = r.get("k")
+
+        assert dummy is Dummy
+        assert len(r.get_registered_keys()) == 1
+        assert next(iter(r.get_registered_keys())) == "k"
+
+    def test_register_duplicate_raises_warning(self):
+        r = Registry("TestRegistry")
+
+        r.register("dup")("k")
+        # Patch warnings.warn and check that it is called with the expected message
+        with pytest.warns(UserWarning) as record:
+            r.register("dup")("k")
+        msg = str(record[0].message)
+        assert "'dup' is already registered in TestRegistry. Overwriting the existing value." == msg
+
+    def test_get_missing_empty_raises_valueerror(self):
+        r = Registry("TestRegistry")
+
+        with pytest.raises(ValueError) as excinfo:
+            r.get("missing")
+
+        msg = str(excinfo.value)
+        assert msg == "'missing' not found in TestRegistry. The available values are: <empty>"
+
+    def test_get_missing_raises_valueerror(self):
+        r = Registry("TestRegistry")
+
+        r.register("k1")("v1")
+        r.register("k2")("v2")
+        with pytest.raises(ValueError) as excinfo:
+            r.get("missing")
+
+        msg = str(excinfo.value)
+        assert msg == "'missing' not found in TestRegistry. The available values are: k1, k2"

--- a/tests/brevitas_examples/llm_example_quantizer.py
+++ b/tests/brevitas_examples/llm_example_quantizer.py
@@ -1,0 +1,9 @@
+from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
+from brevitas.utils.python_utils import Registry
+from brevitas_examples.common.generative.quantizers import BaseQuantizer
+from brevitas_examples.common.generative.quantizers import QUANTIZERS_REGISTRY
+
+
+@Registry.register(QUANTIZERS_REGISTRY, "example_int4_weight_quant")
+class ExampleInt8WeightQuantizer(BaseQuantizer):
+    weight_quant = Int8WeightPerTensorFloat.let(bit_width=4)

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -98,9 +98,12 @@ class LLMRunCases:
         [
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
-                "custom_quantizer": "example_int8_weight_quant"},],
+                "custom_quantizer": "example_int8_weight_quant",},
+            {
+                "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
+                "custom_quantizer": "tests/brevitas_examples/llm_example_quantizer.py:"},],
         ids=[
-            "llama",]
+            "llama-quant", "llama-quant-file",]
     )
     def case_small_models_custom_quantizer(self, run_dict, default_run_args, request):
         from brevitas.quant.scaled_int import Int8WeightPerTensorFloat

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -27,7 +27,7 @@ class LLMRunCases:
             "mistral",  #"mixtral",
             "opt",],
     )
-    def case_small_models_with_ppl(self, run_dict, default_run_args, request):
+    def case_small_models_run(self, run_dict, default_run_args, request):
         yield process_args_and_metrics(default_run_args, run_dict)
 
     # yapf: disable
@@ -92,6 +92,26 @@ class LLMRunCases:
         if config.JIT_ENABLED and run_dict.get("weight_param_method") == "mse":
             pytest.skip(reason=f'MSE as weight_param_method requires JIT to be disabled')
         yield process_args_and_metrics(default_run_args, run_dict)
+
+    @pytest_cases.parametrize(
+        "run_dict",
+        [
+            {
+                "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
+                "custom_quantizer": "example_int8_weight_quant"},],
+        ids=[
+            "llama",]
+    )
+    def case_small_models_custom_quantizer(self, run_dict, default_run_args, request):
+        from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
+        from brevitas.utils.python_utils import Registry
+        from brevitas_examples.common.generative.quantizers import BaseQuantizer
+        from brevitas_examples.common.generative.quantizers import CUSTOM_QUANTIZERS_REGISTRY
+        @Registry.register(CUSTOM_QUANTIZERS_REGISTRY, "example_int8_weight_quant")
+        class ExampleInt8WeightQuantizer(BaseQuantizer):
+            weight_quant = Int8WeightPerTensorFloat
+        yield process_args_and_metrics(default_run_args, run_dict)
+
 
 class LLMPerplexityCases:
 

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -101,7 +101,7 @@ class LLMRunCases:
                 "custom_quantizer": "example_int8_weight_quant",},
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
-                "custom_quantizer": "tests/brevitas_examples/llm_example_quantizer.py:"},],
+                "custom_quantizer": "tests/brevitas_examples/llm_example_quantizer.py:example_int4_weight_quant"},],
         ids=[
             "llama-quant", "llama-quant-file",]
     )

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -106,8 +106,8 @@ class LLMRunCases:
         from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
         from brevitas.utils.python_utils import Registry
         from brevitas_examples.common.generative.quantizers import BaseQuantizer
-        from brevitas_examples.common.generative.quantizers import CUSTOM_QUANTIZERS_REGISTRY
-        @Registry.register(CUSTOM_QUANTIZERS_REGISTRY, "example_int8_weight_quant")
+        from brevitas_examples.common.generative.quantizers import QUANTIZERS_REGISTRY
+        @Registry.register(QUANTIZERS_REGISTRY, "example_int8_weight_quant")
         class ExampleInt8WeightQuantizer(BaseQuantizer):
             weight_quant = Int8WeightPerTensorFloat
         yield process_args_and_metrics(default_run_args, run_dict)


### PR DESCRIPTION
## Reason for this PR

Currently, every time we need to support a new quantization type, we need to modify our entry-point in several ways (e.g., new args, new option in the dict), and this process does not scale up with more advanced quantization schemes.

## Changes made in this PR

- Added a generic `Registry` helper to `python_utils.py` with a decorator-based API.
- Created base class for custom quantizers (`BaseQuantizer`).
- Added new `custom-quantizer` argument to the LLM entrypoint.
- Added example demonstrating custom quantizer registration using the new registry.

## Testing Summary

- Added new test in `test_llm_cases.py`.

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.