### PR TITLE
Feat (bit_width): generalize restrict_impl with clamping

### DIFF
--- a/src/brevitas/core/bit_width/parameter.py
+++ b/src/brevitas/core/bit_width/parameter.py
@@ -11,6 +11,7 @@ from torch.nn import Parameter
 import brevitas
 import brevitas.config as config
 from brevitas.core.function_wrapper import RoundSte
+from brevitas.core.restrict_val import _RestrictClampValue
 from brevitas.core.restrict_val import IntRestrictValue
 from brevitas.function import abs_binary_sign_grad
 
@@ -26,7 +27,7 @@ class BitWidthParameter(brevitas.jit.ScriptModule):
     Args:
         bit_width (int): value to initialize the output learned bit-width.
         min_bit_width (int): lower bound for the output learned bit-width. Default: 2.
-        restrict_bit_width_impl: restrict the learned bit-width to a subset of values. Default: IntRestrictValue(RoundSte()).
+        restrict_clamp_bit_width_impl: restrict the learned bit-width to a subset of values. Default: IntRestrictValue(RoundSte()).
         override_pretrained_bit_width (bool): ignore pretrained bit-width loaded from a state dict. Default: False.
 
     Returns:
@@ -54,6 +55,8 @@ class BitWidthParameter(brevitas.jit.ScriptModule):
             bit_width: int,
             min_bit_width: int = MIN_INT_BIT_WIDTH,
             restrict_bit_width_impl: Module = IntRestrictValue(RoundSte()),
+            bit_width_offset_min_val: Optional[int] = None,
+            bit_width_offset_max_val: Optional[int] = None,
             override_pretrained_bit_width: bool = False,
             dtype: Optional[torch.dtype] = None,
             device: Optional[torch.device] = None) -> None:
@@ -72,13 +75,14 @@ class BitWidthParameter(brevitas.jit.ScriptModule):
         self.bit_width_offset = Parameter(
             torch.tensor(bit_width_offset_init, dtype=dtype, device=device))
         self.bit_width_base = bit_width_base
-        self.restrict_bit_width_impl = restrict_bit_width_impl
+        self.restrict_clamp_bit_width_impl = _RestrictClampValue(
+            bit_width_offset_min_val, bit_width_offset_max_val, restrict_bit_width_impl)
         self.override_pretrained = override_pretrained_bit_width
 
     @brevitas.jit.script_method
     def forward(self) -> Tensor:
         bit_width = abs_binary_sign_grad(self.bit_width_offset) + self.bit_width_base
-        bit_width = self.restrict_bit_width_impl(bit_width)
+        bit_width = self.restrict_clamp_bit_width_impl(bit_width)
         return bit_width
 
     def _load_from_state_dict(

--- a/src/brevitas/core/bit_width/parameter.py
+++ b/src/brevitas/core/bit_width/parameter.py
@@ -76,7 +76,9 @@ class BitWidthParameter(brevitas.jit.ScriptModule):
             torch.tensor(bit_width_offset_init, dtype=dtype, device=device))
         self.bit_width_base = bit_width_base
         self.restrict_clamp_bit_width_impl = _RestrictClampValue(
-            bit_width_offset_min_val, bit_width_offset_max_val, restrict_bit_width_impl)
+            min_val=bit_width_offset_min_val,
+            restrict_value_impl=restrict_bit_width_impl,
+            max_val=bit_width_offset_max_val)
         self.override_pretrained = override_pretrained_bit_width
 
     @brevitas.jit.script_method

--- a/src/brevitas/core/function_wrapper/__init__.py
+++ b/src/brevitas/core/function_wrapper/__init__.py
@@ -19,6 +19,7 @@ from .ops_ste import RoundSte
 from .ops_ste import RoundToZeroSte
 from .ops_ste import ScalarClampMinSte
 from .ops_ste import ScalarSignedClampMinSte
+from .ops_ste import ScalarSignedClampSte
 from .ops_ste import TensorClampSte
 from .shape import OverBatchOverOutputChannelView
 from .shape import OverBatchOverTensorView

--- a/src/brevitas/core/function_wrapper/__init__.py
+++ b/src/brevitas/core/function_wrapper/__init__.py
@@ -18,8 +18,8 @@ from .ops_ste import InplaceTensorClampSte
 from .ops_ste import RoundSte
 from .ops_ste import RoundToZeroSte
 from .ops_ste import ScalarClampMinSte
+from .ops_ste import ScalarClampSte
 from .ops_ste import ScalarSignedClampMinSte
-from .ops_ste import ScalarSignedClampSte
 from .ops_ste import TensorClampSte
 from .shape import OverBatchOverOutputChannelView
 from .shape import OverBatchOverTensorView

--- a/src/brevitas/core/function_wrapper/ops_ste.py
+++ b/src/brevitas/core/function_wrapper/ops_ste.py
@@ -5,6 +5,8 @@
 ScriptModule wrappers of various functions defined in :obj:`~brevitas.function.ops_ste`.
 """
 
+from typing import Optional
+
 import torch
 
 import brevitas
@@ -90,6 +92,29 @@ class ScalarClampMinSte(brevitas.jit.ScriptModule):
     @brevitas.jit.script_method
     def forward(self, x: torch.Tensor):
         return scalar_clamp_min_ste(x, self.min_val)
+
+
+class ScalarSignedClampSte(brevitas.jit.ScriptModule):
+    """
+    ScriptModule wrapper for :func:`~brevitas.function.ops_ste.scalar_clamp_ste`.
+    """
+
+    __constants__ = ['min_val', 'max_val']
+
+    def __init__(self, min_val: float, max_val: float) -> None:
+        super(ScalarSignedClampSte, self).__init__()
+        # Verify that the minimum value is set to a non-zero value, as when min_val == 0.0,
+        # this module implements the identity but the gradient returned at x = 0.0, is zero,
+        # instead of 1.
+        assert abs(min_val) > 0.0, "min_val has to be greater than zero."
+        assert abs(max_val) > 0.0, "max_val has to be greater than zero."
+        self.min_val = abs(min_val)
+        self.max_val = abs(max_val)
+
+    @brevitas.jit.script_method
+    def forward(self, x: torch.Tensor):
+        return torch.where(x >= 0, 1., -1.).type_as(x) * scalar_clamp_ste(
+            abs_binary_sign_grad(x), self.min_val, self.max_val)
 
 
 class ScalarSignedClampMinSte(brevitas.jit.ScriptModule):

--- a/src/brevitas/core/function_wrapper/ops_ste.py
+++ b/src/brevitas/core/function_wrapper/ops_ste.py
@@ -103,15 +103,12 @@ class ScalarClampSte(brevitas.jit.ScriptModule):
 
     def __init__(self, min_val: float, max_val: float) -> None:
         super(ScalarClampSte, self).__init__()
-        # Verify that the minimum value is set to a non-zero value, as when min_val == 0.0,
-        # this module implements the identity but the gradient returned at x = 0.0, is zero,
-        # instead of 1.
-        self.min_val = abs(min_val)
-        self.max_val = abs(max_val)
+        self.min_val = min_val
+        self.max_val = max_val
 
     @brevitas.jit.script_method
     def forward(self, x: torch.Tensor):
-        return scalar_clamp_ste(abs_binary_sign_grad(x), self.min_val, self.max_val)
+        return scalar_clamp_ste(x, self.min_val, self.max_val)
 
 
 class ScalarSignedClampMinSte(brevitas.jit.ScriptModule):

--- a/src/brevitas/core/function_wrapper/ops_ste.py
+++ b/src/brevitas/core/function_wrapper/ops_ste.py
@@ -94,7 +94,7 @@ class ScalarClampMinSte(brevitas.jit.ScriptModule):
         return scalar_clamp_min_ste(x, self.min_val)
 
 
-class ScalarSignedClampSte(brevitas.jit.ScriptModule):
+class ScalarClampSte(brevitas.jit.ScriptModule):
     """
     ScriptModule wrapper for :func:`~brevitas.function.ops_ste.scalar_clamp_ste`.
     """
@@ -102,19 +102,16 @@ class ScalarSignedClampSte(brevitas.jit.ScriptModule):
     __constants__ = ['min_val', 'max_val']
 
     def __init__(self, min_val: float, max_val: float) -> None:
-        super(ScalarSignedClampSte, self).__init__()
+        super(ScalarClampSte, self).__init__()
         # Verify that the minimum value is set to a non-zero value, as when min_val == 0.0,
         # this module implements the identity but the gradient returned at x = 0.0, is zero,
         # instead of 1.
-        assert abs(min_val) > 0.0, "min_val has to be greater than zero."
-        assert abs(max_val) > 0.0, "max_val has to be greater than zero."
         self.min_val = abs(min_val)
         self.max_val = abs(max_val)
 
     @brevitas.jit.script_method
     def forward(self, x: torch.Tensor):
-        return torch.where(x >= 0, 1., -1.).type_as(x) * scalar_clamp_ste(
-            abs_binary_sign_grad(x), self.min_val, self.max_val)
+        return scalar_clamp_ste(abs_binary_sign_grad(x), self.min_val, self.max_val)
 
 
 class ScalarSignedClampMinSte(brevitas.jit.ScriptModule):

--- a/src/brevitas/core/function_wrapper/ops_ste.py
+++ b/src/brevitas/core/function_wrapper/ops_ste.py
@@ -103,8 +103,8 @@ class ScalarClampSte(brevitas.jit.ScriptModule):
 
     def __init__(self, min_val: float, max_val: float) -> None:
         super(ScalarClampSte, self).__init__()
-        self.min_val = min_val
-        self.max_val = max_val
+        self.min_val = float(min_val)
+        self.max_val = float(max_val)
 
     @brevitas.jit.script_method
     def forward(self, x: torch.Tensor):

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -34,8 +34,8 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
             scaling_max_val: Optional[float] = None,
             restrict_value_impl: Optional[Module] = None):
         super(_RestrictClampValue, self).__init__()
-        if scaling_min_val is not None and scaling_min_val != 0:
-            if scaling_max_val is not None and scaling_max_val != 0:
+        if scaling_min_val is not None:
+            if scaling_max_val is not None:
                 self.clamp_ste = ScalarSignedClampSte(scaling_min_val, scaling_max_val)
             else:
                 self.clamp_ste = ScalarSignedClampMinSte(scaling_min_val)

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -15,8 +15,8 @@ from brevitas.core.function_wrapper import InplaceLogTwo
 from brevitas.core.function_wrapper import LogTwo
 from brevitas.core.function_wrapper import PowerOfTwo
 from brevitas.core.function_wrapper import RoundSte
+from brevitas.core.function_wrapper import ScalarClampSte
 from brevitas.core.function_wrapper import ScalarSignedClampMinSte
-from brevitas.core.function_wrapper import ScalarSignedClampSte
 from brevitas.core.function_wrapper.misc import Abs
 from brevitas.core.function_wrapper.misc import InplaceAbs
 from brevitas.inject.enum import FloatToIntImplType  # retrocompatibility
@@ -30,15 +30,17 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
 
     def __init__(
             self,
-            scaling_min_val: Optional[float] = None,
-            restrict_value_impl: Optional[Module] = None,
-            scaling_max_val: Optional[float] = None):
+            min_val: Optional[float] = None,
+            max_val: Optional[float] = None,
+            restrict_value_impl: Optional[Module] = None):
         super(_RestrictClampValue, self).__init__()
-        if scaling_min_val is not None:
-            if scaling_max_val is not None:
-                self.clamp_ste = ScalarSignedClampSte(scaling_min_val, scaling_max_val)
+        if min_val is not None:
+            if max_val is not None:
+                # When min_val and max_val are defined, we don't need to have a signed version of
+                # Clamp
+                self.clamp_ste = ScalarClampSte(min_val, max_val)
             else:
-                self.clamp_ste = ScalarSignedClampMinSte(scaling_min_val)
+                self.clamp_ste = ScalarSignedClampMinSte(min_val)
         else:
             self.clamp_ste = Identity()
         if restrict_value_impl is not None:

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -16,6 +16,7 @@ from brevitas.core.function_wrapper import LogTwo
 from brevitas.core.function_wrapper import PowerOfTwo
 from brevitas.core.function_wrapper import RoundSte
 from brevitas.core.function_wrapper import ScalarSignedClampMinSte
+from brevitas.core.function_wrapper import ScalarSignedClampSte
 from brevitas.core.function_wrapper.misc import Abs
 from brevitas.core.function_wrapper.misc import InplaceAbs
 from brevitas.inject.enum import FloatToIntImplType  # retrocompatibility
@@ -30,12 +31,16 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
     def __init__(
             self,
             scaling_min_val: Optional[float] = None,
+            scaling_max_val: Optional[float] = None,
             restrict_value_impl: Optional[Module] = None):
         super(_RestrictClampValue, self).__init__()
         if scaling_min_val is not None and scaling_min_val != 0:
-            self.clamp_min_ste = ScalarSignedClampMinSte(scaling_min_val)
+            if scaling_max_val is not None and scaling_max_val != 0:
+                self.clamp_ste = ScalarSignedClampSte(scaling_min_val, scaling_max_val)
+            else:
+                self.clamp_ste = ScalarSignedClampMinSte(scaling_min_val)
         else:
-            self.clamp_min_ste = Identity()
+            self.clamp_ste = Identity()
         if restrict_value_impl is not None:
             self.restrict_value_impl = restrict_value_impl
         else:
@@ -44,7 +49,7 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
     @brevitas.jit.script_method
     def forward(self, x: Tensor):
         x = self.restrict_value_impl(x)
-        x = self.clamp_min_ste(x)
+        x = self.clamp_ste(x)
         return x
 
 

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -31,8 +31,8 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
     def __init__(
             self,
             scaling_min_val: Optional[float] = None,
-            scaling_max_val: Optional[float] = None,
-            restrict_value_impl: Optional[Module] = None):
+            restrict_value_impl: Optional[Module] = None,
+            scaling_max_val: Optional[float] = None):
         super(_RestrictClampValue, self).__init__()
         if scaling_min_val is not None:
             if scaling_max_val is not None:

--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -34,6 +34,9 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
             max_val: Optional[float] = None,
             restrict_value_impl: Optional[Module] = None):
         super(_RestrictClampValue, self).__init__()
+        # If only min_val is defined, then we enforce values to fall outside the range (-min_val, min_val)
+        # If both min_val and max_val are defined, then this behaves as a normal clamp
+        # If neither is defined, no clamping is performed
         if min_val is not None:
             if max_val is not None:
                 # When min_val and max_val are defined, we don't need to have a signed version of
@@ -43,6 +46,7 @@ class _RestrictClampValue(brevitas.jit.ScriptModule):
                 self.clamp_ste = ScalarSignedClampMinSte(min_val)
         else:
             self.clamp_ste = Identity()
+
         if restrict_value_impl is not None:
             self.restrict_value_impl = restrict_value_impl
         else:

--- a/src/brevitas/core/scaling/pre_scaling.py
+++ b/src/brevitas/core/scaling/pre_scaling.py
@@ -90,7 +90,7 @@ class ParameterPreScalingWeightNorm(brevitas.jit.ScriptModule):
             pre_scaling_init = torch.full(pre_scaling_shape, pre_scaling_init)
         self.value = Parameter(pre_scaling_init)
         self.restrict_clamp_scaling = _RestrictClampValue(
-            pre_scaling_min_val, restrict_pre_scaling_impl)
+            min_val=pre_scaling_min_val, restrict_value_impl=restrict_pre_scaling_impl)
 
     @brevitas.jit.script_method
     def forward(self, weights: Tensor) -> Tensor:
@@ -190,8 +190,8 @@ class AccumulatorAwareParameterPreScaling(ParameterPreScalingWeightNorm):
         T = self.calc_max_l1_norm(input_bit_width, input_is_signed)  # T / s
         g = torch.clamp_max(g / s, T)
         value = d_w / g  # calculating final pre-clipping scaling factor
-        # re-apply clamp_min_ste from restrict_scaling_impl to the specified pre_scaling_min_val
-        value = self.restrict_clamp_scaling.clamp_min_ste(value)
+        # re-apply clamp_ste from restrict_scaling_impl to the specified pre_scaling_min_val
+        value = self.restrict_clamp_scaling.clamp_ste(value)
         return value
 
     @brevitas.jit.script_method

--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -103,7 +103,8 @@ class _StatsScaling(brevitas.jit.ScriptModule):
                 device)
         else:
             self.affine_rescaling = Identity()
-        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
+        self.restrict_clamp_scaling = _RestrictClampValue(
+            min_val=scaling_min_val, restrict_value_impl=restrict_scaling_impl)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_clamp_scale_threshold = _RestrictClampValue(
@@ -233,7 +234,8 @@ class RuntimeDynamicGroupStatsScaling(brevitas.jit.ScriptModule):
         self.scaling_stats_impl = scaling_stats_impl
         self.scaling_min_val = scaling_min_val
         self.input_view_impl = input_view_impl
-        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
+        self.restrict_clamp_scaling = _RestrictClampValue(
+            min_val=scaling_min_val, restrict_value_impl=restrict_scaling_impl)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_clamp_scale_threshold = _RestrictClampValue(

--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -79,7 +79,8 @@ class ConstScaling(brevitas.jit.ScriptModule):
         if restrict_threshold_impl is None:
             restrict_threshold_impl = restrict_scaling_impl
 
-        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
+        self.restrict_clamp_scaling = _RestrictClampValue(
+            min_val=scaling_min_val, restrict_value_impl=restrict_scaling_impl)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_clamp_scale_threshold = _RestrictClampValue(
@@ -180,7 +181,8 @@ class ParameterScaling(brevitas.jit.ScriptModule):
         if scaling_init.shape == SCALAR_SHAPE and scaling_shape is not None:
             scaling_init = torch.full(scaling_shape, scaling_init, dtype=dtype, device=device)
         self.value = Parameter(scaling_init)
-        self.restrict_clamp_scaling = _RestrictClampValue(scaling_min_val, restrict_scaling_impl)
+        self.restrict_clamp_scaling = _RestrictClampValue(
+            min_val=scaling_min_val, restrict_value_impl=restrict_scaling_impl)
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()

--- a/src/brevitas_examples/common/generative/quant_blocks.py
+++ b/src/brevitas_examples/common/generative/quant_blocks.py
@@ -33,7 +33,7 @@ class RuntimeDynamicStatsScaling(nn.Module):
         self.dynamic_scaling_broadcastable_fn = dynamic_scaling_broadcastable_fn
         self.restrict_scaling_pre = restrict_scaling_impl.restrict_init_module()
         self.restrict_clamp_scaling = _RestrictClampValue(
-            scaling_min_val=scaling_min_val, restrict_value_impl=restrict_scaling_impl)
+            min_val=scaling_min_val, restrict_value_impl=restrict_scaling_impl)
         self.restrict_threshold_pre = restrict_threshold_impl.restrict_init_module()
         self.restrict_clamp_threshold = _RestrictClampValue(
             restrict_value_impl=restrict_threshold_impl)

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -157,58 +157,69 @@ class TestBitWidthParameter:
             assert bit_width_stateful_const_tensor == bit_width_init_two
             assert bit_width_stateful_const_tensor == bit_width_parameter_tensor
 
-    def test_bit_width_offset_clamping_min_max(self):
+    def _create_bit_width_param_with_clamp(
+            self, min_bit_width, bit_width_offset_min_val, bit_width_offset_max_val):
         """
-        Test that bit_width_offset_min_val and bit_width_offset_max_val properly clamp the bit-width
-        offset when values are set outside the allowed range. The min value is set to 0 for this test.
+        Helper method to create a BitWidthParameter with min/max clamping.
         """
-        min_bit_width = 2
-        bit_width_offset_min = None  # Min offset value set to 0 as requested
-        bit_width_offset_max = 6  # Max offset value, allowing bit-widths up to 8
-
-        # Create BitWidthParameter with min=0 and max=6
-        # When min_val=None, _RestrictClampValue uses Identity() for clamping, meaning no clamping is applied
-        # This test documents this behavior
-        bit_width_param_no_clamp = BitWidthParameter(
+        return BitWidthParameter(
             bit_width=4,
             min_bit_width=min_bit_width,
-            bit_width_offset_min_val=bit_width_offset_min,
-            bit_width_offset_max_val=bit_width_offset_max)
+            bit_width_offset_min_val=bit_width_offset_min_val,
+            bit_width_offset_max_val=bit_width_offset_max_val)
 
-        # With min=0, no clamping occurs, so offset stays as-is (after abs and rounding)
+    def test_bit_width_offset_clamp_to_max(self):
+        """
+        Test that bit_width_offset is clamped down to max_val when set higher than the maximum.
+        """
+        min_bit_width = 2
+        bit_width_offset_min = 1
+        bit_width_offset_max = 6
+
+        bit_width_param = self._create_bit_width_param_with_clamp(
+            min_bit_width, bit_width_offset_min, bit_width_offset_max)
+
+        # Set offset higher than max (should clamp down to max)
         with torch.no_grad():
-            bit_width_param_no_clamp.bit_width_offset.data = torch.tensor(10.0)
+            bit_width_param.bit_width_offset.data = torch.tensor(10.0)
 
-        result_no_clamp = bit_width_param_no_clamp()
+        result_no_clamp = bit_width_param()
         # No clamping applied, just rounded: 10 + 2 = 12
         assert_allclose(result_no_clamp, torch.tensor(12.0))
 
-        # Test with non-zero min and max for actual clamping behavior
-        bit_width_offset_min_nonzero = 1
-        bit_width_param_clamped = BitWidthParameter(
-            bit_width=4,
-            min_bit_width=min_bit_width,
-            bit_width_offset_min_val=bit_width_offset_min_nonzero,
-            bit_width_offset_max_val=bit_width_offset_max)
+    def test_bit_width_offset_clamp_to_min(self):
+        """
+        Test that bit_width_offset is clamped up to min_val when set lower than the minimum.
+        """
+        min_bit_width = 2
+        bit_width_offset_min = 1
+        bit_width_offset_max = 6
 
-        # Test case 1: Set offset higher than max (should clamp down to max)
+        bit_width_param = self._create_bit_width_param_with_clamp(
+            min_bit_width, bit_width_offset_min, bit_width_offset_max)
+
+        # Set offset lower than min (should clamp up to min)
         with torch.no_grad():
-            bit_width_param_clamped.bit_width_offset.data = torch.tensor(10.0)
+            bit_width_param.bit_width_offset.data = torch.tensor(0.5)
 
-        result_high = bit_width_param_clamped()
-        assert_allclose(result_high, torch.tensor(float(bit_width_offset_max)))
-
-        # Test case 2: Set offset lower than min (should clamp up to min)
-        with torch.no_grad():
-            bit_width_param_clamped.bit_width_offset.data = torch.tensor(0.5)
-
-        result_low = bit_width_param_clamped()
+        result_low = bit_width_param()
         assert_allclose(result_low, torch.tensor(float(min_bit_width)))
 
-        # Test case 3: Set offset within range (should not clamp)
-        with torch.no_grad():
-            bit_width_param_clamped.bit_width_offset.data = torch.tensor(3.0)
+    def test_bit_width_offset_within_range(self):
+        """
+        Test that bit_width_offset is not clamped when set within the allowed range.
+        """
+        min_bit_width = 2
+        bit_width_offset_min = 1
+        bit_width_offset_max = 6
 
-        result_valid = bit_width_param_clamped()
-        expected_valid = min_bit_width + 3.0
-        assert_allclose(result_valid, torch.tensor(expected_valid))
+        bit_width_param = self._create_bit_width_param_with_clamp(
+            min_bit_width, bit_width_offset_min, bit_width_offset_max)
+
+        # Set offset within range (should not clamp)
+        with torch.no_grad():
+            bit_width_param.bit_width_offset.data = torch.tensor(3.0)
+
+        result = bit_width_param()
+        expected = min_bit_width + 3.0
+        assert_allclose(result, torch.tensor(expected))

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -162,7 +162,7 @@ class TestBitWidthParameter:
         min_bit_width = 2
         bit_width_offset_min = None  # Min offset value set to 0 as requested
         bit_width_offset_max = 6  # Max offset value, allowing bit-widths up to 8
-        
+
         # Create BitWidthParameter with min=0 and max=6
         # When min_val=None, _RestrictClampValue uses Identity() for clamping, meaning no clamping is applied
         # This test documents this behavior
@@ -171,15 +171,15 @@ class TestBitWidthParameter:
             min_bit_width=min_bit_width,
             bit_width_offset_min_val=bit_width_offset_min,
             bit_width_offset_max_val=bit_width_offset_max)
-        
+
         # With min=0, no clamping occurs, so offset stays as-is (after abs and rounding)
         with torch.no_grad():
             bit_width_param_no_clamp.bit_width_offset.data = torch.tensor(10.0)
-        
+
         result_no_clamp = bit_width_param_no_clamp()
         # No clamping applied, just rounded: 10 + 2 = 12
         assert_allclose(result_no_clamp, torch.tensor(12.0))
-        
+
         # Test with non-zero min and max for actual clamping behavior
         bit_width_offset_min_nonzero = 1
         bit_width_param_clamped = BitWidthParameter(
@@ -187,27 +187,27 @@ class TestBitWidthParameter:
             min_bit_width=min_bit_width,
             bit_width_offset_min_val=bit_width_offset_min_nonzero,
             bit_width_offset_max_val=bit_width_offset_max)
-        
+
         # Test case 1: Set offset higher than max (should clamp down to max)
         with torch.no_grad():
             bit_width_param_clamped.bit_width_offset.data = torch.tensor(10.0)
-        
+
         result_high = bit_width_param_clamped()
         expected_max = min_bit_width + bit_width_offset_max
         assert_allclose(result_high, torch.tensor(float(expected_max)))
-        
+
         # Test case 2: Set offset lower than min (should clamp up to min)
         with torch.no_grad():
             bit_width_param_clamped.bit_width_offset.data = torch.tensor(0.5)
-        
+
         result_low = bit_width_param_clamped()
         expected_min = min_bit_width + bit_width_offset_min_nonzero
         assert_allclose(result_low, torch.tensor(float(expected_min)))
-        
+
         # Test case 3: Set offset within range (should not clamp)
         with torch.no_grad():
             bit_width_param_clamped.bit_width_offset.data = torch.tensor(3.0)
-        
+
         result_valid = bit_width_param_clamped()
         expected_valid = min_bit_width + 3.0
         assert_allclose(result_valid, torch.tensor(expected_valid))

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -184,7 +184,7 @@ class TestBitWidthParameter:
             bit_width_param.bit_width_offset.data = torch.tensor(10.0)
 
         result_no_clamp = bit_width_param()
-        assert_allclose(result_no_clamp, torch.tensorr(float(bit_width_offset_max)))
+        assert_allclose(result_no_clamp, torch.tensor(float(bit_width_offset_max)))
 
     def test_bit_width_offset_clamp_to_min(self):
         """

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -184,8 +184,7 @@ class TestBitWidthParameter:
             bit_width_param.bit_width_offset.data = torch.tensor(10.0)
 
         result_no_clamp = bit_width_param()
-        # No clamping applied, just rounded: 10 + 2 = 12
-        assert_allclose(result_no_clamp, torch.tensor(12.0))
+        assert_allclose(result_no_clamp, bit_width_offset_max)
 
     def test_bit_width_offset_clamp_to_min(self):
         """

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -196,8 +196,7 @@ class TestBitWidthParameter:
             bit_width_param_clamped.bit_width_offset.data = torch.tensor(10.0)
 
         result_high = bit_width_param_clamped()
-        expected_max = min_bit_width + bit_width_offset_max
-        assert_allclose(result_high, torch.tensor(float(expected_max)))
+        assert_allclose(result_high, torch.tensor(float(bit_width_offset_max)))
 
         # Test case 2: Set offset lower than min (should clamp up to min)
         with torch.no_grad():

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -203,8 +203,7 @@ class TestBitWidthParameter:
             bit_width_param_clamped.bit_width_offset.data = torch.tensor(0.5)
 
         result_low = bit_width_param_clamped()
-        expected_min = min_bit_width + bit_width_offset_min_nonzero
-        assert_allclose(result_low, torch.tensor(float(expected_min)))
+        assert_allclose(result_low, torch.tensor(float(min_bit_width)))
 
         # Test case 3: Set offset within range (should not clamp)
         with torch.no_grad():

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -153,3 +153,61 @@ class TestBitWidthParameter:
             bit_width_stateful_const_tensor = bit_width_stateful_const()
             assert bit_width_stateful_const_tensor == bit_width_init_two
             assert bit_width_stateful_const_tensor == bit_width_parameter_tensor
+
+    def test_bit_width_offset_clamping_min_max(self):
+        """
+        Test that bit_width_offset_min_val and bit_width_offset_max_val properly clamp the bit-width
+        offset when values are set outside the allowed range. The min value is set to 0 for this test.
+        """
+        min_bit_width = 2
+        bit_width_offset_min = None  # Min offset value set to 0 as requested
+        bit_width_offset_max = 6  # Max offset value, allowing bit-widths up to 8
+        
+        # Create BitWidthParameter with min=0 and max=6
+        # When min_val=None, _RestrictClampValue uses Identity() for clamping, meaning no clamping is applied
+        # This test documents this behavior
+        bit_width_param_no_clamp = BitWidthParameter(
+            bit_width=4,
+            min_bit_width=min_bit_width,
+            bit_width_offset_min_val=bit_width_offset_min,
+            bit_width_offset_max_val=bit_width_offset_max)
+        
+        # With min=0, no clamping occurs, so offset stays as-is (after abs and rounding)
+        with torch.no_grad():
+            bit_width_param_no_clamp.bit_width_offset.data = torch.tensor(10.0)
+        
+        result_no_clamp = bit_width_param_no_clamp()
+        # No clamping applied, just rounded: 10 + 2 = 12
+        assert_allclose(result_no_clamp, torch.tensor(12.0))
+        
+        # Test with non-zero min and max for actual clamping behavior
+        bit_width_offset_min_nonzero = 1
+        bit_width_param_clamped = BitWidthParameter(
+            bit_width=4,
+            min_bit_width=min_bit_width,
+            bit_width_offset_min_val=bit_width_offset_min_nonzero,
+            bit_width_offset_max_val=bit_width_offset_max)
+        
+        # Test case 1: Set offset higher than max (should clamp down to max)
+        with torch.no_grad():
+            bit_width_param_clamped.bit_width_offset.data = torch.tensor(10.0)
+        
+        result_high = bit_width_param_clamped()
+        expected_max = min_bit_width + bit_width_offset_max
+        assert_allclose(result_high, torch.tensor(float(expected_max)))
+        
+        # Test case 2: Set offset lower than min (should clamp up to min)
+        with torch.no_grad():
+            bit_width_param_clamped.bit_width_offset.data = torch.tensor(0.5)
+        
+        result_low = bit_width_param_clamped()
+        expected_min = min_bit_width + bit_width_offset_min_nonzero
+        assert_allclose(result_low, torch.tensor(float(expected_min)))
+        
+        # Test case 3: Set offset within range (should not clamp)
+        with torch.no_grad():
+            bit_width_param_clamped.bit_width_offset.data = torch.tensor(3.0)
+        
+        result_valid = bit_width_param_clamped()
+        expected_valid = min_bit_width + 3.0
+        assert_allclose(result_valid, torch.tensor(expected_valid))

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -41,11 +41,14 @@ class TestBitWidthParameterDefaults:
 
     def test_default_restrict_bit_width_impl(self, bit_width_parameter_defaults):
         bit_width_module = bit_width_parameter_defaults
-        assert isinstance(bit_width_module.restrict_bit_width_impl, IntRestrictValue)
+        assert isinstance(
+            bit_width_module.restrict_clamp_bit_width_impl.restrict_value_impl, IntRestrictValue)
 
     def test_default_float_to_int_impl(self, bit_width_parameter_defaults):
         bit_width_module = bit_width_parameter_defaults
-        assert isinstance(bit_width_module.restrict_bit_width_impl.float_to_int_impl, RoundSte)
+        assert isinstance(
+            bit_width_module.restrict_clamp_bit_width_impl.restrict_value_impl.float_to_int_impl,
+            RoundSte)
 
     def test_bit_width_base(self, bit_width_parameter_defaults):
         bit_width_module = bit_width_parameter_defaults

--- a/tests/brevitas/core/test_bit_width.py
+++ b/tests/brevitas/core/test_bit_width.py
@@ -184,7 +184,7 @@ class TestBitWidthParameter:
             bit_width_param.bit_width_offset.data = torch.tensor(10.0)
 
         result_no_clamp = bit_width_param()
-        assert_allclose(result_no_clamp, bit_width_offset_max)
+        assert_allclose(result_no_clamp, torch.tensorr(float(bit_width_offset_max)))
 
     def test_bit_width_offset_clamp_to_min(self):
         """


### PR DESCRIPTION
## Reason for this PR

Currently there is no way of clamping the bit-width when it is a learned parameter

## Changes Made in this PR

Change the restrict_impl to also include clamping.
Also there is also a clamping class now that accounts for max possible value.

## Testing Summary

Added