### PR TITLE
Feat (data): compute perplexity at float32

### DIFF
--- a/src/brevitas_examples/llm/llm_quant/eval.py
+++ b/src/brevitas_examples/llm/llm_quant/eval.py
@@ -53,7 +53,8 @@ def compute_perplexity(
         data: List[Dict],
         context_length: int,
         tokenizer: Any,
-        seed: int = 0):
+        seed: int = 0,
+        dtype: torch.dtype = torch.float32):
     random.seed(seed)
     np.random.seed(seed)
     torch.random.manual_seed(seed)
@@ -96,6 +97,7 @@ def compute_perplexity(
             # Fuse batch and sequence length dimensions.
             reference_labels = reference_labels.view(reference_labels.shape[-1])
             shift_logits = shift_logits.view(-1, shift_logits.shape[-1])
+            shift_logits = shift_logits.to(dtype)
 
             loss = cross_entropy_loss(shift_logits, reference_labels)
 
@@ -103,4 +105,4 @@ def compute_perplexity(
 
     ppl = torch.exp(torch.stack(nlls).mean())
 
-    return ppl
+    return ppl.item()


### PR DESCRIPTION
## Reason for this PR

Decouples model precision from evaluation precision. Allows running perplexity evaluation at a different precision (e.g., `float32`) than the model execution precision (e.g., `bfloat16`) for more accurate evaluation metrics.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

Added `dtype` parameter to `compute_perplexity()` in `eval.py`

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

No existing tests directly use `compute_perplexity`. The LLM tests currently use float32, so no updates needed.

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
