### PR TITLE
Feat (cli): rename block_rotation_dim to rotation_block_size

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1632,7 +1632,7 @@ def _compute_rotations(
         region for region in regions if len(region.srcs) > 0]
 
     # Pre-initialize to None to avoid issue down the line
-    expanded_rot_mat, expanded_K, rot_mat, K = None, None, None, None
+    rot_mat, K = None, None
     for region in regions:
         insert_rotation_module = len(region.srcs) == 0
 

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1566,7 +1566,7 @@ def random_orthogonal_matrix(size):
 
 def _compute_hidden_dim(
         region: Region,
-        block_rotation_dim: Optional[int] = None,
+        rotation_block_size: Optional[int] = None,
         insert_rotation_module: bool = False,
         disable_block_rotation_for_fused: bool = False,
         expansion_step: int = 1) -> int:
@@ -1579,7 +1579,7 @@ def _compute_hidden_dim(
 
     Args:
         region: The region for which to compute hidden dimension.
-        block_rotation_dim: Optional block rotation dimension for block-wise rotations.
+        rotation_block_size: Optional block rotation dimension for block-wise rotations.
         insert_rotation_module: Whether this region is an orphan sink (online rotation).
         disable_block_rotation_for_fused: Whether to disable block rotation for fused rotations.
         expansion_step: Number of steps for finding closest hadamard number (used for expansion).
@@ -1595,7 +1595,7 @@ def _compute_hidden_dim(
         hidden_dim = find_closest_hadamard_number(hidden_dim, steps=expansion_step)
 
     # Step 3: Apply block rotation if applicable
-    apply_block_rotation = block_rotation_dim is not None
+    apply_block_rotation = rotation_block_size is not None
 
     # insert_rotation_module is True for orphan sinks (aka online rotations). Sometimes we want to use
     # block rotations only for online rotations and full-vector for fused rotations.
@@ -1604,8 +1604,8 @@ def _compute_hidden_dim(
 
     if apply_block_rotation:
         # Check block_rotation is compatible with the current shape
-        if (hidden_dim // block_rotation_dim > 1) and (hidden_dim % block_rotation_dim == 0):
-            hidden_dim = block_rotation_dim
+        if (hidden_dim // rotation_block_size > 1) and (hidden_dim % rotation_block_size == 0):
+            hidden_dim = rotation_block_size
         else:
             logging.info(
                 f"Block rotation shape is not compatible with hidden_dim={hidden_dim}."
@@ -1620,7 +1620,7 @@ def _compute_rotations(
         full_rotation_method='had',
         fuse_rotations: bool = True,
         expansion_step: int = 1,
-        block_rotation_dim: Optional[int] = None,
+        rotation_block_size: Optional[int] = None,
         disable_block_rotation_for_fused: bool = False):
 
     rewriters = []
@@ -1638,12 +1638,12 @@ def _compute_rotations(
 
         if not insert_rotation_module and full_rotation_method == 'ort':
             assert not region.expand_region, "Orthogonal rotation not compatible with expansion"
-            assert block_rotation_dim is None, "Orthogonal rotation not compatible with blockwise rotation"
+            assert rotation_block_size is None, "Orthogonal rotation not compatible with blockwise rotation"
 
         # Compute hidden_dim per region (includes expansion if applicable)
         hidden_dim = _compute_hidden_dim(
             region=region,
-            block_rotation_dim=block_rotation_dim,
+            rotation_block_size=rotation_block_size,
             insert_rotation_module=insert_rotation_module,
             disable_block_rotation_for_fused=disable_block_rotation_for_fused,
             expansion_step=expansion_step)
@@ -1673,7 +1673,7 @@ def _compute_rotations(
                 rot_func = _apply_had_device
             except AssertionError as e:
                 logging.info(f"Incompatible dim {hidden_dim} for hadamard rotation")
-                if not insert_rotation_module and not region.expand_region and block_rotation_dim is None:
+                if not insert_rotation_module and not region.expand_region and rotation_block_size is None:
                     logging.info("Falling back to orthogonal matrices")
                     rot_mat = random_orthogonal_matrix(hidden_dim)
                     rot_func = _apply_ort_device
@@ -1945,7 +1945,7 @@ class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
             rotate_matmul: bool = False,
             use_parametrized_rotations: bool = False,
             full_rotation_method: str = 'had',
-            block_rotation_dim: Optional[int] = None,
+            rotation_block_size: Optional[int] = None,
             disable_block_rotation_for_fused: bool = False,
             layers_to_expand: Optional[List[str]] = None,
             expansion_step: int = None,
@@ -1971,7 +1971,7 @@ class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
         self.sdpa_regions = sdpa_regions
         self.expansion_step = expansion_step
         self.delay_rewriters = delay_rewriters
-        self.block_rotation_dim = block_rotation_dim
+        self.rotation_block_size = rotation_block_size
         self.disable_block_rotation_for_fused = disable_block_rotation_for_fused
         self.regions = []
 
@@ -2155,7 +2155,7 @@ class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
                     self.full_rotation_method,
                     fuse_rotations=not self.use_parametrized_rotations,
                     expansion_step=first_exp_step,
-                    block_rotation_dim=self.block_rotation_dim,
+                    rotation_block_size=self.rotation_block_size,
                     disable_block_rotation_for_fused=self.disable_block_rotation_for_fused))
             rewriters.extend(
                 _compute_rotations(
@@ -2164,7 +2164,7 @@ class GraphRotationEqualization(RotationEqualization, RegionWalkMixin):
                     self.full_rotation_method,
                     fuse_rotations=not self.use_parametrized_rotations,
                     expansion_step=second_exp_step,
-                    block_rotation_dim=self.block_rotation_dim,
+                    rotation_block_size=self.rotation_block_size,
                     disable_block_rotation_for_fused=self.disable_block_rotation_for_fused))
             if len(expanded_regions) > 0:
                 parameter_number_post = 0
@@ -2276,12 +2276,12 @@ class LayerwiseActivationRotation(RotationEqualization):
             blacklist_layer: Optional[List] = None,
             layers_to_expand: Optional[List] = None,
             expansion_step: int = 0,
-            block_rotation_dim: Optional[int] = None,
+            rotation_block_size: Optional[int] = None,
             extra_state_kwargs: Optional[Dict[str, Tuple]] = None):
 
         RotationEqualization.__init__(self, blacklist_layer, layers_to_expand)
         self.expansion_step = expansion_step
-        self.block_rotation_dim = block_rotation_dim
+        self.rotation_block_size = rotation_block_size
         self.supported_sinks = (nn.Linear,)
 
     def apply(self, model: nn.Module) -> nn.Module:
@@ -2302,6 +2302,6 @@ class LayerwiseActivationRotation(RotationEqualization):
                     model,
                     regions,
                     expansion_step=self.expansion_step,
-                    block_rotation_dim=self.block_rotation_dim))
+                    rotation_block_size=self.rotation_block_size))
         model = self.transform_model(model, rewriters, delay_rewriters=False)
         return model

--- a/src/brevitas/graph/permute.py
+++ b/src/brevitas/graph/permute.py
@@ -58,7 +58,7 @@ def register_permutation_method(name: str):
 
     Examples:
         >>> @register_permutation_method("my_permute")
-        ... def my_permute_method(x, block_rotation_dim):
+        ... def my_permute_method(x, block_size):
         ...     return torch.arange(x.shape[-1])
     """
 

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -366,7 +366,7 @@ def create_args_parser() -> ArgumentParser:
         'When layer expansion is set, decide how much to increase the layer sizes. Default: %(default)s'
     )
     parser.add_argument(
-        '--block-rotation-dim',
+        '--rotation-block-size',
         type=int,
         default=None,
         help='Perform blockwise rotations when possible. Default: %(default)s')

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -136,7 +136,7 @@ def fused_rotation_no_fx(model, calibration_loader, args):
         delay_rewriters=delay_rewriters,
         expansion_step=args.expansion_step,
         layers_to_expand=layers_to_expand,
-        block_rotation_dim=args.block_rotation_dim,
+        rotation_block_size=args.rotation_block_size,
         disable_block_rotation_for_fused=args.disable_block_rotation_for_fused,
         extra_state_kwargs=extra_state_kwargs)
 
@@ -145,7 +145,7 @@ def fused_rotation_no_fx(model, calibration_loader, args):
         with rotate_permute_mode(fx_model,
                                  rotation=eq,
                                  permute_fn=args.permute_fn,
-                                 block_size=args.block_rotation_dim,
+                                 block_size=args.rotation_block_size,
                                  disable_for_fused_rotations=args.disable_block_rotation_for_fused,
                                  extra_state_kwargs=extra_state_kwargs) as rpm:
 
@@ -407,7 +407,7 @@ def quantize_llm(args, extra_args=None):
             use_parametrized_rotations=args.optimize_rotations,
             expansion_step=args.expansion_step,
             layers_to_expand=layers_to_expand,
-            block_rotation_dim=args.block_rotation_dim,
+            rotation_block_size=args.rotation_block_size,
             disable_block_rotation_for_fused=args.disable_block_rotation_for_fused,
             extra_state_kwargs={'scale_invariant_layers': rmsnorm_classes})
         model = eq.apply(model)
@@ -425,7 +425,7 @@ def quantize_llm(args, extra_args=None):
         eq = LayerwiseActivationRotation(
             layers_to_expand=layers_to_expand,
             expansion_step=args.expansion_step,
-            block_rotation_dim=args.block_rotation_dim)
+            rotation_block_size=args.rotation_block_size)
         model = eq.apply(model)
         remove_hooks(model)
 

--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -434,7 +434,7 @@ def compare_model_weights(model_fused, model_unfused, classes_to_compare=(nn.Lin
 @pytest_cases.parametrize('fuse_rotations', [False, True], ids=["unfused", "fused"])
 @pytest_cases.parametrize('use_fx', [True, False], ids=["fx", "no-fx"])
 @pytest_cases.parametrize('expansion_step', [3, 0], ids=["expansion", "no-expansion"])
-@pytest_cases.parametrize('block_rotation_dim', [12, None])
+@pytest_cases.parametrize('rotation_block_size', [12, None])
 @pytest_cases.parametrize('disable_block_rotation_for_fused', [True, False])
 def test_compute_rotations(
         rotation_model,
@@ -444,11 +444,11 @@ def test_compute_rotations(
         fuse_rotations,
         use_fx,
         expansion_step,
-        block_rotation_dim,
+        rotation_block_size,
         disable_block_rotation_for_fused):
     if expansion_step > 0 and full_rotation_method == 'ort':
         pytest.skip("Expansion is not compatible with orthogonal rotations")
-    if block_rotation_dim is not None and full_rotation_method == 'ort':
+    if rotation_block_size is not None and full_rotation_method == 'ort':
         pytest.skip("Block rotation is not compatible with orthogonal rotations")
     # Instantiate a residual model for which a collection of regions is available
     model = rotation_model()
@@ -520,7 +520,7 @@ def test_compute_rotations(
                 full_rotation_method=full_rotation_method,
                 fuse_rotations=False,
                 expansion_step=expansion_step,
-                block_rotation_dim=block_rotation_dim,
+                rotation_block_size=rotation_block_size,
                 disable_block_rotation_for_fused=disable_block_rotation_for_fused)
     elif full_rotation_method == 'ort':
         with patch('brevitas.graph.equalize.random_orthogonal_matrix',
@@ -531,7 +531,7 @@ def test_compute_rotations(
                 full_rotation_method=full_rotation_method,
                 fuse_rotations=False,
                 expansion_step=expansion_step,
-                block_rotation_dim=block_rotation_dim,
+                rotation_block_size=rotation_block_size,
                 disable_block_rotation_for_fused=disable_block_rotation_for_fused)
 
     apply_rewriters(rotated_model_unfused, rewriters)
@@ -549,7 +549,7 @@ def test_compute_rotations(
             full_rotation_method=full_rotation_method,
             fuse_rotations=True,
             expansion_step=expansion_step,
-            block_rotation_dim=block_rotation_dim,
+            rotation_block_size=rotation_block_size,
             disable_block_rotation_for_fused=disable_block_rotation_for_fused)
         apply_rewriters(rotated_model_fused, r)
 

--- a/tests/brevitas/graph/test_permute.py
+++ b/tests/brevitas/graph/test_permute.py
@@ -82,7 +82,7 @@ def test_rotate_permute_mode(
     rotation = GraphRotationEqualization(
         expansion_step=expansion_step,
         layers_to_expand=[],
-        block_rotation_dim=block_size,
+        rotation_block_size=block_size,
         orphan_sink=orphan_sink,
         disable_block_rotation_for_fused=disable_for_fused_rotations,
         return_rewriters=True,
@@ -134,7 +134,7 @@ def test_permute_block_size_compatibility(rotation_model, block_size, device):
     rotation = GraphRotationEqualization(
         expansion_step=0,
         layers_to_expand=[],
-        block_rotation_dim=block_size,
+        rotation_block_size=block_size,
         disable_block_rotation_for_fused=False,
         return_rewriters=True,
         delay_rewriters=True)

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -707,7 +707,7 @@ class LLMRotationOptimizationCases:
             "optimize_rotations": True,
             "rotation_orphan_sink": True,
             "rotation_mode": "had",
-            "block_rotation_dim": 32,
+            "rotation_block_size": 32,
             "nsamples_rot_calibration": 2,
             "dtype": "float32",
             "extra_args": [


### PR DESCRIPTION
## Reason for this PR

Rename `block_rotation_dim` to `rotation_block_size` for clearer naming consistency.

## Changes Made in this PR

Renamed parameter `block_rotation_dim` to `rotation_block_size`.

## Testing Summary

No new tests required (parameter rename only)

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
