### PR TITLE
Fix (mx_quant_ocp): Fix MX MSE quantizer

### DIFF
--- a/src/brevitas/quant/experimental/mx_quant_ocp.py
+++ b/src/brevitas/quant/experimental/mx_quant_ocp.py
@@ -106,7 +106,7 @@ class MXFloat8e4m3Act(MXActMixin, GroupwiseActFloatProxyMixin, FpOCPAct, ScaledF
     mantissa_bit_width = 3
 
 
-class MXFloat8e4m3WeightMSE(MXFloat8e4m3Weight, MSESymmetricScale):
+class MXFloat8e4m3WeightMSE(MSESymmetricScale, MXFloat8e4m3Weight):
     """
     MX Float signed weight quantizer with per-channel MSE-based scaling.
     """

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -406,6 +406,26 @@ class LLMQuantLayerTypeCases:
             "quant_sdpa": "fx",
             "exp_layer_types": {
                 "attn_output": "<class 'brevitas.nn.quant_sdpa.QuantScaledDotProductAttention'>",}},
+        {
+            "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
+            "weight_quant_format": "float_ocp_e4m3",
+            "weight_scale_precision": "po2_scale",
+            "weight_param_method": "stats",
+            "weight_quant_granularity": "per_group",
+            "weight_group_size": 16,
+            "weight_quant_type": "sym",
+            "weight_param_method": "mse",
+            "input_quant_format": "float_ocp_e5m2",
+            "input_scale_type": "dynamic",
+            "input_scale_precision": "po2_scale",
+            "input_param_method": "stats",
+            "input_quant_granularity": "per_group",
+            "input_group_size": 16,
+            "input_quant_type": "sym",
+            "act_calibration": False,
+            "exp_layer_types": {
+                "model.layers.0.self_attn.q_proj.weight_quant.tensor_quant.scaling_impl.parameter_list_stats.stats.stats_impl":
+                    "<class 'brevitas.core.stats.stats_op.MSE'>",},},
         ],
         ids=[
             "mistral-int8",
@@ -417,7 +437,8 @@ class LLMQuantLayerTypeCases:
             "llama-int8-rotation=layerwise",
             "mistral-int8-quant-last-layer",
             "llama-int8-svd_quant",
-            "opt-quant-sdpa",],)
+            "opt-quant-sdpa",
+            "llama-mxfp8-mse"],)
     def case_small_models_quant_layer(self, run_dict, default_run_args, request):
         yield process_args_and_metrics(default_run_args, run_dict, extra_keys=["exp_layer_types"])
 


### PR DESCRIPTION
The MX MSE quantizer used to be defined as follows:
```
class MXFloat8e4m3WeightMSE(MXFloat8e4m3Weight, MSESymmetricScale):
    """
    MX Float signed weight quantizer with per-channel MSE-based scaling.
    """
    pass
```
With its method resolution order being:
```
(<class 'brevitas.quant.experimental.mx_quant_ocp.MXFloat8e4m3WeightMSE'>, <class 'brevitas.quant.experimental.mx_quant_ocp.MXFloat8e4m3Weight'>, ..., <class 'brevitas.quant.base.MSESymmetricScale'>, <class 'brevitas.inject.Injector'>, <class 'object'>)
```
Therefore, the attribute `scaling_stats_impl` is resolved from `<class 'brevitas.quant.experimental.mx_quant_ocp.MXFloat8e4m3Weight'>`, instead of being resolved from the override in `<class 'brevitas.quant.base.MSESymmetricScale'>`, i.e. 
```
@value
    def scaling_stats_impl():
        return this.mse_scale.stats_impl
```
Consequently, the quantizer for `--weight-param-method stats` is the same as for `--weight-param-method mse`. To solve this, the order in the parent classes can be inverted in `MXFloat8e4m3WeightMSE`. With this change, the difference between the quantizers
```
weight_quant_mse_legacy_injector = type("MXFloat8e4m3WeightMSE", (MXFloat8e4m3Weight, MSESymmetricScale), {}) 
weight_quant_mse_fixed_injector = type("MXFloat8e4m3WeightMSEFix", (MSESymmetricScale, MXFloat8e4m3Weight), {}) 
```
is the following:
```
30c30
<             (view_shape_impl): OverSubChannelBlockView()
---
>             (view_shape_impl): Identity()
33c33,36
<             (stats_impl): AbsMax()
---
>             (stats_impl): MSE(
>               (mse_init_op): AbsMax()
>               (input_view_shape_impl): OverSubChannelBlockView()
>             )
```
Which matches the expected behaviour when selecting `--weight-param-method mse`.

For instance, the following
```
python /llm/main.py --weight-bit-width 3 --weight-group-size 32 --weight-param-method stats --weight-quant-format float_ocp_e1m1 --weight-quant-granularity per_group --weight-quant-type sym --weight-scale-precision po2_scale --scale-rounding-func-type floor --eval
```
gives the output:
```
Quantized perplexity (wikitext2): 159.935
```

Before the  change, the PPL with `weight-param-method mse` would match, i.e.
```
python /llm/main.py --weight-bit-width 3 --weight-group-size 32 --weight-param-method mse --weight-quant-format float_ocp_e1m1 --weight-quant-granularity per_group --weight-quant-type sym --weight-scale-precision po2_scale --scale-rounding-func-type floor --eval
```
gives the output:
```
Quantized perplexity (wikitext2): 159.935
```

While after the change, it yields:
```
Quantized perplexity (wikitext2): 108.628
```
