### PR TITLE
test (qonnx): Fixes to QONNX export tests when (`dynamo=True`)

### DIFF
--- a/src/brevitas/export/onnx/qonnx/custom_ops.py
+++ b/src/brevitas/export/onnx/qonnx/custom_ops.py
@@ -220,7 +220,7 @@ def _trunc_quant_fake(
 
 
 @onnxscript.script(qonnx_op, default_opset=qonnx_op)
-def TruncQuant(
+def Trunc(
         x: FLOAT,
         scale: FLOAT,
         zero_point: FLOAT,
@@ -245,7 +245,7 @@ def trunc_quant_wrapper(
         rounding_mode: str,
         signed: int,
         narrow: int) -> FLOAT:
-    return TruncQuant(
+    return Trunc(
         x,
         scale,
         zero_point,

--- a/src/brevitas/export/onnx/qonnx/custom_ops.py
+++ b/src/brevitas/export/onnx/qonnx/custom_ops.py
@@ -207,14 +207,14 @@ def trunc_quant(
 @trunc_quant.register_fake
 def _trunc_quant_fake(
     tensor_x,
-    scale: torch.Tensor,
-    zero_point: torch.Tensor,
-    input_bit_width: torch.Tensor,
-    output_scale: torch.Tensor,
-    output_bit_width: torch.Tensor,
-    rounding_mode: str,
-    signed: int,
-    narrow: int,
+    scale,
+    zero_point,
+    input_bit_width,
+    output_scale,
+    output_bit_width,
+    rounding_mode,
+    signed,
+    narrow,
 ):
     return torch.empty_like(tensor_x)
 

--- a/src/brevitas/export/onnx/qonnx/function.py
+++ b/src/brevitas/export/onnx/qonnx/function.py
@@ -155,7 +155,7 @@ class BrevitasTruncFn(Function):
             output_scale,
             output_bit_width,
             rounding_mode):
-        trunc_quant(
+        return trunc_quant(
             x,
             scale,
             zero_point,
@@ -165,7 +165,6 @@ class BrevitasTruncFn(Function):
             rounding_mode,
             int(signed),
             int(narrow_range))
-        return x
 
 
 class BrevitasQuantLSTMCellFn(Function):

--- a/tests/brevitas_finn/brevitas_examples/test_mobilenet_finn_export.py
+++ b/tests/brevitas_finn/brevitas_examples/test_mobilenet_finn_export.py
@@ -38,7 +38,7 @@ SEED = 0
 @pytest.mark.parametrize("pretrained", [True])
 @requires_package_ge('qonnx', MIN_QONNX_VERSION)
 def test_mobilenet_v1_4b(pretrained, qonnx_export_fn, request):
-    finn_onnx = "mobilenet_v1_4b_{request.node.callspec.id}.onnx"
+    finn_onnx = f"mobilenet_v1_4b_{request.node.callspec.id}.onnx"
     mobilenet = quant_mobilenet_v1_4b(pretrained)
     mobilenet.eval()
     #load a random test vector

--- a/tests/export_fixture.py
+++ b/tests/export_fixture.py
@@ -17,7 +17,7 @@ def _get_qonnx_export_modes():
         export_fns = [export_qonnx]
         export_ids = ["torchscript"]
     else:
-        export_fns = [export_qonnx, partial(export_qonnx, dynamo=True, optimize=True)]
+        export_fns = [partial(export_qonnx, dynamo=False), partial(export_qonnx, dynamo=True, optimize=True)]
         export_ids = ["torchscript", "dynamo"]
     return export_fns, export_ids
 

--- a/tests/export_fixture.py
+++ b/tests/export_fixture.py
@@ -17,7 +17,8 @@ def _get_qonnx_export_modes():
         export_fns = [export_qonnx]
         export_ids = ["torchscript"]
     else:
-        export_fns = [partial(export_qonnx, dynamo=False), partial(export_qonnx, dynamo=True, optimize=True)]
+        export_fns = [
+            partial(export_qonnx, dynamo=False), partial(export_qonnx, dynamo=True, optimize=True)]
         export_ids = ["torchscript", "dynamo"]
     return export_fns, export_ids
 


### PR DESCRIPTION
Up until the release of QONNX v1.0.0, our TruncQuant tests were disabled, since there was a [mismatch between behaviour](#1042 ). With the release, some changes / bugfixes need to be made before re-enabling the tests, specifically:
 - Generate the node "Trunc", not "TruncQuant"
 - Fix issue during dynamo tracing of node not being picked up
 - Remove type hints for fake quant node (not necessary, but now matches other ops)
 - Fix f-string in ONNX export test