### PR TITLE
Feat (quantize): Signed Po2 scales

### DIFF
--- a/src/brevitas/core/restrict_val.py
+++ b/src/brevitas/core/restrict_val.py
@@ -210,6 +210,34 @@ class PowerOfTwoRestrictValue(brevitas.jit.ScriptModule):
         return x
 
 
+class SignedPowerOfTwoRestrictValue(brevitas.jit.ScriptModule):
+
+    def __init__(self, restrict_value_float_to_int_impl: Module = RoundSte()):
+        super(SignedPowerOfTwoRestrictValue, self).__init__()
+        self.float_to_int_impl = restrict_value_float_to_int_impl
+        self.power_of_two: Module = PowerOfTwo()
+
+    def restrict_init_float(self, x: float) -> float:
+        return x
+
+    def restrict_init_tensor(self, x: Tensor) -> Tensor:
+        return x
+
+    def restrict_init_module(self):
+        return Identity()
+
+    def restrict_init_inplace_module(self):
+        return Identity()
+
+    @brevitas.jit.script_method
+    def forward(self, x: Tensor) -> Tensor:
+        x_sign = torch.sign(x)
+        x = torch.log2(torch.abs(x))
+        x = self.float_to_int_impl(x)
+        x = x_sign * self.power_of_two(x)
+        return x
+
+
 class QuantRestrictValue(brevitas.jit.ScriptModule):
 
     def __init__(

--- a/src/brevitas/inject/enum.py
+++ b/src/brevitas/inject/enum.py
@@ -34,6 +34,7 @@ class RestrictValueType(AutoName):
     LOG_FP = auto()
     INT = auto()
     POWER_OF_TWO = auto()
+    SIGNED_POWER_OF_TWO = auto()
 
 
 class FloatToIntImplType(AutoName):

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -247,6 +247,8 @@ class SolveIntScalingImplFromEnum(ExtendedInjector):
             return IntScaling
         elif restrict_scaling_type == RestrictValueType.POWER_OF_TWO:
             return PowerOfTwoIntScaling
+        elif restrict_scaling_type == RestrictValueType.SIGNED_POWER_OF_TWO:
+            return PowerOfTwoIntScaling
         else:
             raise RuntimeError(f"{restrict_scaling_type} not recognized.")
 

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -247,6 +247,7 @@ class SolveIntScalingImplFromEnum(ExtendedInjector):
             return IntScaling
         elif restrict_scaling_type == RestrictValueType.POWER_OF_TWO:
             return PowerOfTwoIntScaling
+        # `int_threshold` is unsigned by construction
         elif restrict_scaling_type == RestrictValueType.SIGNED_POWER_OF_TWO:
             return PowerOfTwoIntScaling
         else:

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -87,6 +87,8 @@ def solve_restrict_value_impl_from_enum(impl_type):
         return LogFloatRestrictValue
     elif impl_type == RestrictValueType.POWER_OF_TWO:
         return PowerOfTwoRestrictValue
+    elif impl_type == RestrictValueType.SIGNED_POWER_OF_TWO:
+        return SignedPowerOfTwoRestrictValue
     else:
         raise RuntimeError(f"{impl_type} not recognized.")
 

--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -259,7 +259,9 @@ def maybe_inject_signed_scale_kwargs(
         return injector
     return injector.let(
         **{
-            'restrict_scaling_type': RestrictValueType.SIGNED_FP,
+            'restrict_scaling_type': (
+                RestrictValueType.SIGNED_FP if 'po2' not in
+                scale_quant_format else RestrictValueType.SIGNED_POWER_OF_TWO),
             'scaling_stats_op': StatsOp.SIGNED_MAX,})
 
 

--- a/src/brevitas_examples/common/generative/quantize.py
+++ b/src/brevitas_examples/common/generative/quantize.py
@@ -394,6 +394,7 @@ def generate_quantizers(
         # Enable signed scale if specified in the attention scale precision format
         k_transposed_quant = maybe_inject_signed_scale_kwargs(
             k_transposed_quant, attn_scale_precision, attn_scale_quant_kwargs)
+
         if attn_quant_config == "qkvs" or attn_quant_config == 'qkv':
             q_scaled_quant = k_transposed_quant  # later we define attn_output_weights_quant=q_scaled_quant, so don't instantiate it here
         elif attn_quant_config == "kv":

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -157,7 +157,7 @@ def create_args_parser() -> ArgumentParser:
         '--input-scale-precision',
         type=str,
         default='float_scale',
-        choices=['signed_float_scale', 'float_scale', 'po2_scale'],
+        choices=['signed_float_scale', 'float_scale', 'po2_scale', 'signed_po2_scale'],
         help='Whether input scale is a float value or a po2. Default: float.')
     parser.add_argument(
         '--input-scale-type',
@@ -212,7 +212,7 @@ def create_args_parser() -> ArgumentParser:
         '--attn-scale-precision',
         type=str,
         default=None,
-        choices=['signed_float_scale', 'float_scale', 'po2_scale'],
+        choices=['signed_float_scale', 'float_scale', 'po2_scale', 'signed_po2_scale'],
         help='Whether input scale is a float value or a po2. Default: (same as input).')
     parser.add_argument(
         '--attn-scale-type',

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -84,7 +84,7 @@ def create_args_parser() -> ArgumentParser:
         '--weight-scale-precision',
         type=str,
         default='float_scale',
-        choices=['signed_float_scale', 'float_scale', 'po2_scale'],
+        choices=['signed_float_scale', 'float_scale', 'po2_scale', 'signed_po2_scale'],
         help='Whether scale is a float value or a po2. Default: %(default)s.')
     parser.add_argument(
         '--weight-quant-rescaling-init',

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -176,7 +176,7 @@ class LLMPerplexityCases:
         "llama_float_dynamic_input",
         "mistral",
         "opt-quant-sdpa",
-        "rotation_fx_and_gptq"
+        "rotation_fx_and_gptq",
         "llama_signed_scale",
         ],)
     def case_small_models_with_ppl(self, run_dict, default_run_args, request):

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -176,7 +176,7 @@ class LLMPerplexityCases:
         "llama_float_dynamic_input",
         "mistral",
         "opt-quant-sdpa",
-        "rotation_fx_and_gptq",
+        "rotation_fx_and_gptq"
         "llama_signed_scale",
         ],)
     def case_small_models_with_ppl(self, run_dict, default_run_args, request):


### PR DESCRIPTION
## Reason for this PR

Add support for **signed power‑of‑two (Po2) scaling**.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

- Added `SignedPowerOfTwoRestrictValue` implementing signed Po2 restriction.
- Introduced `SIGNED_POWER_OF_TWO` in `RestrictValueType` and solver mapping.
- Extended LLM CLI options with `signed_po2_scale`.


<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

TBA

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
