### PR TITLE
deps (python): remove python 3.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ If you like this project please consider ⭐ this repo, as it is the simplest an
 
 ## Requirements
 
-* Python >= 3.9, <3.13
-* [Pytorch](https://pytorch.org) >= 1.12, <= 2.8 (more recent versions would be untested).
+* Python >= 3.10, <3.13
+* [Pytorch](https://pytorch.org) >= 1.12, <= 2.9 (more recent versions would be untested).
 * Windows, Linux or macOS.
 * GPU training-time acceleration (*Optional* but recommended).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you like this project please consider ⭐ this repo, as it is the simplest an
 ## Requirements
 
 * Python >= 3.10, <3.13
-* [Pytorch](https://pytorch.org) >= 1.12, <= 2.9 (more recent versions would be untested).
+* [Pytorch](https://pytorch.org) >= 1.12, <= 2.9.1 (more recent versions would be untested).
 * Windows, Linux or macOS.
 * GPU training-time acceleration (*Optional* but recommended).
 

--- a/docsrc/source/setup.rst
+++ b/docsrc/source/setup.rst
@@ -8,8 +8,8 @@ Requirements
 Installation Requirements
 '''''''''''''''''''''''''
 
--  Python >= 3.9.
--  `Pytorch`_ >= 1.9.1, <= 2.4 (more recent versions would be untested).
+-  Python >= 3.10, <3.13.
+-  `Pytorch`_ >= 1.9.1, <= 2.9.1 (more recent versions would be untested).
 -  Windows, Linux or macOS.
 -  GPU training-time acceleration (*optional* but recommended).
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="AMD Research and Advanced Development",
     author_email="brevitas-external@amd.com",
     url="https://github.com/Xilinx/brevitas",
-    python_requires=">=3.9, <3.13",
+    python_requires=">=3.10, <3.13",
     install_requires=read_requirements('requirements.txt'),
     extras_require={
         "numpy": read_requirements('requirements-numpy.txt'),


### PR DESCRIPTION
Given that [python3.9 is EoL](https://devguide.python.org/versions/) and that [this issue](https://github.com/fastmachinelearning/qonnx/issues/237) is causing [havoc with our CI](https://github.com/Xilinx/brevitas/actions/runs/22713177994/job/65856067152), I suggest that we remove python 3.9 support and require python 3.10 and above.