### PR TITLE
Fix (eq): general check for GPU with fast_hadamard_transform

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1530,8 +1530,7 @@ class GraphActivationEqualization(ActivationEqualization):
 
 
 def _apply_had_device(tensor, had_K, K):
-    is_gpu = 'cuda' in str(tensor.device)
-    if is_gpu and fast_hadamard_transform is not None:
+    if tensor.is_cuda and fast_hadamard_transform is not None:
         return matmul_hadU_cuda(tensor, had_K, K)
     else:
         return matmul_hadU(tensor)

--- a/src/brevitas/nn/equalized_layer.py
+++ b/src/brevitas/nn/equalized_layer.py
@@ -86,7 +86,6 @@ class RotatedModule(torch.nn.Module):
         self.hidden_dim = hidden_dim
 
     def forward(self, inp, **kwargs):
-        is_cuda = 'cuda' in str(inp.device) and torch.version.cuda is not None
         if self.expand_input:
             # TODO: This only works for Linear layers. We have an assert in equalize.py to check for this
             featured_dim = inp.dim() - 1
@@ -101,7 +100,7 @@ class RotatedModule(torch.nn.Module):
             # If init_shape[-1] == had_shape, the next reshape+squeeze is a no-op
             inp = inp.reshape(*init_shape[:-1], init_shape[-1] // self.hidden_dim,
                               self.hidden_dim).squeeze()
-        if is_cuda and fast_hadamard_transform is not None:
+        if inp.is_cuda and fast_hadamard_transform is not None:
             if self.had_mat is None or self.k is None:
                 had_K, K = get_hadK(inp.shape[-1])
             else:
@@ -117,10 +116,9 @@ class RotatedModule(torch.nn.Module):
 
 
 def functional_rotate_input(inp, transpose=False):
-    is_cuda = 'cuda' in str(inp.device) and torch.version.cuda is not None
     if transpose:
         inp = inp.transpose(-2, -1)
-    if is_cuda and fast_hadamard_transform is not None:
+    if inp.is_cuda and fast_hadamard_transform is not None:
         had_K, K = get_hadK(inp.shape[-1])
         inp = matmul_hadU_cuda(inp, had_K, K)
     else:


### PR DESCRIPTION
## Reason for this PR

See #1466 

Missed `equalized_layer` in #1469 

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

Removed `torch.version.cuda is not None` from `_apply_had_device`, `RotatedModule`, and `functional_rotate_input`.

Using tensor attribute `tensor.is_cuda` instead.

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

N/A

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
