### PR TITLE
Fix (graph/gpxq): ConvTranspose temporarily unsupported

### DIFF
--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -116,6 +116,11 @@ class gpxq_mode(quantization_status_manager):
         else:
             is_quant_enabled = False
         if isinstance(module, (nn.Linear, *SUPPORTED_CONV_OP)):
+            # ConvTranspose is temporarily unsupported in GPxQ
+            # See https://github.com/Xilinx/brevitas/issues/1479
+            if is_conv_transposed(module):
+                warnings.warn("ConvTranspose is temporarily unsupported for GPxQ, skipping.")
+                return False
             return is_quant_enabled
         else:
             return False


### PR DESCRIPTION
## Reason for this PR

Temporary patch for #1479 

## Changes Made in this PR

Disable GPxQ for ConvTranspose

The remaining code around conv_transpose support is still left in place, so that developing a solution can start from there.
