### PR TITLE
Feat (graph/equalize): LayerNorm affine merge at float64

### DIFF
--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -2286,7 +2286,7 @@ class MergeLnAffine(GraphTransform, RegionWalkMixin):
 
                 for name in region.sinks:
                     module = region.get_module_from_name(name)
-                    if not _is_supported_ln_shape(layernorm_module, module):
+                    if not _is_supported_ln_shape(layernorm_module, module.in_features):
                         _raise_merge_ln_error(layernorm_module, module)
 
                     scale_bias = id(module) not in scaled_biases

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1830,11 +1830,6 @@ def _is_supported_ln_shape(layer_norm, channels):
     ) == channels
 
 
-def _is_supported_ln_affine_merge(layer_norm, next_module):
-    return isinstance(next_module, nn.Linear) and _is_supported_ln_shape(
-        layer_norm, next_module.in_features)
-
-
 def _raise_merge_ln_error(layer_norm, next_module):
     raise RuntimeError(
         f"Unsupported affine merge from {layer_norm.__class__.__name__} into "
@@ -2289,9 +2284,9 @@ class MergeLnAffine(GraphTransform, RegionWalkMixin):
                 if not layernorm_module.elementwise_affine:
                     continue
 
-                for name, indexes in region.sinks.items():
+                for name in region.sinks:
                     module = region.get_module_from_name(name)
-                    if not _is_supported_ln_affine_merge(layernorm_module, module):
+                    if not _is_supported_ln_shape(layernorm_module, module):
                         _raise_merge_ln_error(layernorm_module, module)
 
                     scale_bias = id(module) not in scaled_biases

--- a/src/brevitas/graph/equalize.py
+++ b/src/brevitas/graph/equalize.py
@@ -1813,28 +1813,58 @@ def fuse_parametrizations(model: nn.Module) -> nn.Module:
 
 
 def _replace_bias(next_module, new_bias):
-    new_bias = new_bias.view(-1)
+    new_bias = new_bias.view(-1).to(
+        device=next_module.weight.device, dtype=next_module.weight.dtype)
     if next_module.bias is not None:
         next_module.bias.data.copy_(new_bias)
     else:
-        new_bias = new_bias.to(next_module.weight.device).to(next_module.weight.dtype)
         next_module.register_parameter('bias', nn.Parameter(new_bias))
 
 
-def _merge_ln(layer_norm, next_module, scale_bias_by_weight):
-    view_shape = (1, -1)
-    # Merge weight
-    if scale_bias_by_weight and hasattr(layer_norm, 'bias'):
-        layer_norm.bias.data /= layer_norm.weight.data
-    # We can't do an inplace update as some layers we merge into like lm_head might share the weight tensor
-    scale = layer_norm.weight.data.view(view_shape).expand_as(next_module.weight)
-    next_module.weight = nn.Parameter(next_module.weight.clone() * scale)
+def _has_bias(module):
+    return hasattr(module, 'bias') and module.bias is not None
 
-    # Merge bias, new_bias includes the bias of next_module by going through its fwd
-    if hasattr(layer_norm, 'bias'):
-        inp = layer_norm.bias.data.view(view_shape)
-        new_bias = next_module(inp)
-        _replace_bias(next_module, new_bias)
+
+def _is_supported_ln_shape(layer_norm, channels):
+    return layer_norm.weight is not None and layer_norm.weight.ndim == 1 and layer_norm.weight.numel(
+    ) == channels
+
+
+def _is_supported_ln_affine_merge(layer_norm, next_module):
+    return isinstance(next_module, nn.Linear) and _is_supported_ln_shape(
+        layer_norm, next_module.in_features)
+
+
+def _raise_merge_ln_error(layer_norm, next_module):
+    raise RuntimeError(
+        f"Unsupported affine merge from {layer_norm.__class__.__name__} into "
+        f"{next_module.__class__.__name__}. LayerNorm/RMSNorm affine parameters must be channelwise "
+        f"and the sink must be Linear.")
+
+
+def _merge_ln(layer_norm, next_module, scale_bias_by_weight):
+    weight_dtype = next_module.weight.dtype
+    weight_device = next_module.weight.device
+    weight = next_module.weight.detach().to(dtype=torch.float64)
+    gamma = layer_norm.weight.detach().to(device=weight_device, dtype=torch.float64)
+    beta = None
+    if _has_bias(layer_norm):
+        beta = layer_norm.bias.detach().to(device=weight_device, dtype=torch.float64)
+        if scale_bias_by_weight:
+            beta = beta / gamma
+
+    merged_weight = weight * gamma.view(1, -1)
+    if beta is not None:
+        bias_delta = torch.mv(merged_weight, beta)
+
+    next_module.weight = nn.Parameter(merged_weight.to(device=weight_device, dtype=weight_dtype))
+
+    if beta is not None:
+        current_bias = next_module.bias.detach().to(
+            device=weight_device,
+            dtype=torch.float64) if next_module.bias is not None else torch.zeros(
+                next_module.out_features, device=weight_device, dtype=torch.float64)
+        _replace_bias(next_module, current_bias + bias_delta)
 
 
 class RegionWalkMixin:
@@ -2251,7 +2281,6 @@ class MergeLnAffine(GraphTransform, RegionWalkMixin):
 
     def apply(self, graph_model: GraphModule) -> GraphModule:
         regions = _extract_regions(graph_model, state_impl_kwargs=self.full_state_kwargs)
-
         if len(regions) > 0:
             scaled_biases = set()
             for region in regions:
@@ -2259,8 +2288,12 @@ class MergeLnAffine(GraphTransform, RegionWalkMixin):
                 layernorm_module = region.get_module_from_name(layernorm_module_name)
                 if not layernorm_module.elementwise_affine:
                     continue
+
                 for name, indexes in region.sinks.items():
                     module = region.get_module_from_name(name)
+                    if not _is_supported_ln_affine_merge(layernorm_module, module):
+                        _raise_merge_ln_error(layernorm_module, module)
+
                     scale_bias = id(module) not in scaled_biases
                     _merge_ln(layernorm_module, module, scale_bias_by_weight=scale_bias)
 

--- a/tests/brevitas/graph/test_ln_affine_merge.py
+++ b/tests/brevitas/graph/test_ln_affine_merge.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import copy
+
+import pytest
+import torch
+import torch.nn as nn
+
+from brevitas.fx import symbolic_trace
+from brevitas.graph.equalize import MergeLnAffine
+from tests.marker import requires_pt_ge
+
+ATOL = 1e-5
+
+
+class LinearLnModel(nn.Module):
+
+    def __init__(self, dtype=torch.float32, bias=True):
+        super().__init__()
+        self.ln = nn.LayerNorm(4, dtype=dtype)
+        self.linear = nn.Linear(4, 3, bias=bias, dtype=dtype)
+
+    def forward(self, x):
+        return self.linear(self.ln(x))
+
+
+class LinearRmsModel(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.rms = nn.RMSNorm(4)
+        self.linear = nn.Linear(4, 3)
+
+    def forward(self, x):
+        return self.linear(self.rms(x))
+
+
+class MismatchedLinearLnModel(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.ln = nn.LayerNorm(3)
+        self.linear = nn.Linear(4, 3)
+
+    def forward(self, x):
+        return self.linear(self.ln(x[..., :3]))
+
+
+def _apply_merge(model):
+    graph_model = symbolic_trace(model.eval())
+    return MergeLnAffine().apply(graph_model)
+
+
+def _set_nontrivial_affine(module):
+    with torch.no_grad():
+        module.weight.copy_(torch.tensor([1.5, 0.5, 2.0, 0.25], dtype=module.weight.dtype))
+        if hasattr(module, 'bias') and module.bias is not None:
+            module.bias.copy_(torch.tensor([0.1, -0.2, 0.3, -0.4], dtype=module.bias.dtype))
+
+
+def _merge_output_is_invariant(model, inp, atol=ATOL):
+    model.eval()
+    original_weight = model.linear.weight.detach().clone()
+    with torch.no_grad():
+        expected = model(inp)
+    graph_model = _apply_merge(copy.deepcopy(model))
+    with torch.no_grad():
+        out = graph_model(inp)
+    assert torch.allclose(out, expected, atol=atol)
+    assert not torch.allclose(graph_model.linear.weight, original_weight)
+
+
+def test_linear_ln_affine_merge_output_invariant():
+    model = LinearLnModel()
+    _set_nontrivial_affine(model.ln)
+    inp = torch.randn(2, 4)
+    _merge_output_is_invariant(model, inp)
+
+
+@requires_pt_ge('2.4')
+def test_linear_rms_affine_merge_output_invariant():
+    model = LinearRmsModel()
+    _set_nontrivial_affine(model.rms)
+    inp = torch.randn(2, 4)
+    _merge_output_is_invariant(model, inp)
+
+
+def test_merge_keeps_low_precision_sink_dtype_and_uses_bias_registration():
+    model = LinearLnModel(dtype=torch.float16, bias=False)
+    _set_nontrivial_affine(model.ln)
+    with torch.no_grad():
+        model.linear.weight.copy_(
+            torch.tensor(
+                [[1.0, -2.0, 3.0, -4.0], [0.5, 1.5, -0.5, 2.0], [-1.0, 0.25, 0.75, -0.125]],
+                dtype=torch.float16))
+
+    expected_weight = (
+        model.linear.weight.detach().to(torch.float64) *
+        model.ln.weight.detach().to(torch.float64).view(1, -1)).to(torch.float16)
+    expected_bias = torch.mv(
+        expected_weight.detach().to(torch.float64),
+        (model.ln.bias.detach().to(torch.float64) / model.ln.weight.detach().to(torch.float64))).to(
+            torch.float16)
+
+    graph_model = _apply_merge(copy.deepcopy(model))
+
+    assert graph_model.linear.weight.dtype == torch.float16
+    assert graph_model.linear.bias.dtype == torch.float16
+    assert torch.equal(graph_model.linear.weight, expected_weight)
+    assert torch.equal(graph_model.linear.bias, expected_bias)


### PR DESCRIPTION
## Reason for this PR

It is safer to perform operations like merging of affine parameters of LN at float64

## Changes Made in this PR

As described above, plus tests

