### PR TITLE
Feat (quant_tensor): convert from NamedTuple to Tensor subclass

### DIFF
--- a/notebooks/minifloat_mx_tutorial.ipynb
+++ b/notebooks/minifloat_mx_tutorial.ipynb
@@ -137,7 +137,7 @@
    "source": [
     "Groupwise quantization is built on top of integer/minifloat quantization, with special considerations to accomodate for the groupwise scaling.\n",
     "\n",
-    "Compared to Int/Float QuantTensor, the main difference of their groupwise equivalent is that value, scale, and zero_point are not direct attributes anymore but properties. The new attributes are value_, scale_, and zero_point_.\n",
+     "Compared to Int/Float QuantTensor, the main difference of their groupwise equivalent is that value, scale, and zero_point are not direct attributes anymore but properties. The raw (grouped) attributes are `_value_`, `scale_`, and `zero_point_`.\n",
     "\n",
     "The reason for this is shaping. When quantizing a tensor with shapes [O, I], where O is output channel and I is input channel, with groupsize k, groupwise quantization is normally represented as follow:\n",
     "\n",
@@ -284,8 +284,8 @@
     "o = mx_model(x)\n",
     "\n",
     "# The quant weight of the padded model is different from the non padding one\n",
-    "print(f\"Non padding weights shape {mx_model_no_padding.conv.quant_weight().value_.shape}\")\n",
-    "print(f\"Padded weights shape {mx_model.conv.quant_weight().value_.shape}\")\n",
+"print(f\"Non padding weights shape {mx_model_no_padding.conv.quant_weight()._value_.shape}\")\n",
+     "print(f\"Padded weights shape {mx_model.conv.quant_weight()._value_.shape}\")\n",
     "\n",
     "# However, results are still the same \n",
     "assert torch.allclose(o, o_no_padding)"

--- a/src/brevitas/export/onnx/manager.py
+++ b/src/brevitas/export/onnx/manager.py
@@ -149,7 +149,7 @@ class ONNXBaseManager(BaseManager, ABC):
                     elif input_t is not None:
                         args = input_t
                     # do a forward pass with the dummy input to e.g. store input/output shapes
-                    if isinstance(args, tuple) and not isinstance(args, QuantTensor):
+                    if isinstance(args, tuple):
                         # https://pytorch.org/docs/stable/onnx.html#torch.onnx.export
                         if isinstance(args[-1], dict) and isinstance(args[-2], dict):
                             model_args = args[:-2] + (args[-1],)

--- a/src/brevitas/nn/mixin/base.py
+++ b/src/brevitas/nn/mixin/base.py
@@ -22,11 +22,8 @@ from brevitas.common import LayerProtocol
 from brevitas.inject import ExtendedInjector
 from brevitas.inject import Injector
 from brevitas.quant_tensor import _unpack_quant_tensor
-from brevitas.quant_tensor import FloatQuantTensor
 from brevitas.quant_tensor import IntQuantTensor
 from brevitas.quant_tensor import QuantTensor
-from brevitas.quant_tensor.groupwise_float_quant_tensor import GroupwiseFloatQuantTensor
-from brevitas.quant_tensor.groupwise_int_quant_tensor import GroupwiseIntQuantTensor
 
 from .utils import filter_kwargs
 
@@ -73,22 +70,7 @@ class QuantLayerMixin(ExportMixin, LayerProtocol):
     def channelwise_separable(self) -> bool:
         pass
 
-    def get_quant_tensor_class(self, inp: Union[Tensor, QuantTensor]):
-        quant_tensor_classes = [
-            IntQuantTensor, FloatQuantTensor, GroupwiseIntQuantTensor, GroupwiseFloatQuantTensor]
-        for qt_class in quant_tensor_classes:
-            if len(inp) == len(qt_class._fields):
-                return qt_class
-        return None
-
     def unpack_input(self, inp: Union[Tensor, QuantTensor]) -> Union[Tensor, QuantTensor]:
-        # Hack to recognize a QuantTensor that has decayed to a tuple
-        # when used as input to tracing (e.g. during ONNX export)
-        if (torch._C._get_tracing_state() is not None and isinstance(inp, tuple) and
-                all([isinstance(t, Tensor) for t in inp])):
-            qt_class = self.get_quant_tensor_class(inp)
-            if qt_class is not None:
-                inp = qt_class(*inp)
         if not torch._C._get_tracing_state() and not is_dynamo_compiling():
             if isinstance(inp, QuantTensor):
                 inp = inp.set(value=inp.value.rename(None))

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -281,7 +281,7 @@ class DecoupledWeightQuantWithInputProxyFromInjector(DecoupledWeightQuantProxyFr
             self._cached_act = cached_inp
 
         if self.is_quant_enabled:
-            if quant_input is None or isinstance(quant_input, Tensor):
+            if quant_input is None or not isinstance(quant_input, IntQuantTensor):
                 assert self._cached_act is not None, "No cached quant input found. Enable caching and perform a forward pass"
                 quant_input = self._cached_act
             else:

--- a/src/brevitas/quant_tensor/__init__.py
+++ b/src/brevitas/quant_tensor/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from .base_quant_tensor import *
 from .base_quant_tensor import _unpack_quant_tensor
+from .base_quant_tensor import QuantTensor
 from .float_quant_tensor import *
 from .groupwise_float_quant_tensor import *
 from .groupwise_int_quant_tensor import *

--- a/src/brevitas/quant_tensor/base_quant_tensor.py
+++ b/src/brevitas/quant_tensor/base_quant_tensor.py
@@ -39,10 +39,6 @@ class QuantTensor(Tensor):
         # Use as_subclass to preserve grad_fn and requires_grad.
         return Tensor.as_subclass(self, Tensor)
 
-    @property
-    def tensor(self):
-        return self.value
-
     # Mapping from _fields names to constructor parameter names.
     # Override in subclasses where they differ (e.g. groupwise: scale_ -> scale).
     _field_to_constructor_param = {}

--- a/src/brevitas/quant_tensor/base_quant_tensor.py
+++ b/src/brevitas/quant_tensor/base_quant_tensor.py
@@ -165,6 +165,15 @@ class QuantTensor(Tensor):
     def __sub__(self, other):
         return self.__add__(-other)
 
+    def __iadd__(self, other):
+        return self.__add__(other)
+
+    def __imul__(self, other):
+        return self.__mul__(other)
+
+    def __isub__(self, other):
+        return self.__sub__(other)
+
     def __pos__(self):
         return self
 

--- a/src/brevitas/quant_tensor/base_quant_tensor.py
+++ b/src/brevitas/quant_tensor/base_quant_tensor.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import List
-from typing import NamedTuple
 from typing import Optional
 from typing import Tuple
 
@@ -15,38 +14,101 @@ from brevitas.utils.torch_utils import float_internal_scale
 TOLERANCE = {torch.float64: 1e-1, torch.float32: 2e-1, torch.float16: 0.5, torch.bfloat16: 0.5}
 
 
-# Base class for all QuantTensor.
-# Only assumptions made by these methods are:
-# - `self` is a NamedTuple with a `_fields` attribute
-# - `self` has a `value` attribute
-class QuantTensor:
+# Base class for all QuantTensor types.
+# Subclasses torch.Tensor, where the underlying tensor data represents the dequantized `value`.
+# Quantization metadata (scale, zero_point, bit_width, etc.) are stored as regular attributes.
+class QuantTensor(Tensor):
 
-    def detach_(self):
-        for field in self._fields:
-            getattr(self, field).detach_()
+    @staticmethod
+    def __new__(cls, value, *args, **kwargs):
+        if not isinstance(value, Tensor):
+            value = torch.tensor(value, dtype=torch.float)
+        # Create tensor subclass wrapping the value data.
+        # Use as_subclass to preserve grad_fn and requires_grad.
+        return value.as_subclass(cls)
 
-    def detach(self):
-        qt_type = type(self)
-        values = []
-        for field in self._fields:
-            value = getattr(self, field)
-            if isinstance(value, Tensor):
-                value = value.detach()
-            values.append(value)
-        return qt_type(*values)
+    def __init__(self, value, *args, **kwargs):
+        # Subclasses should NOT call super().__init__() with args;
+        # metadata is set by subclass __init__ methods.
+        pass
 
-    def contiguous(self):
-        qt_type = type(self)
-        values = []
+    @property
+    def value(self):
+        # The tensor itself IS the value.
+        # Return a plain Tensor view to avoid infinite recursion in operations.
+        # Use as_subclass to preserve grad_fn and requires_grad.
+        return Tensor.as_subclass(self, Tensor)
+
+    @property
+    def tensor(self):
+        return self.value
+
+    # Mapping from _fields names to constructor parameter names.
+    # Override in subclasses where they differ (e.g. groupwise: scale_ -> scale).
+    _field_to_constructor_param = {}
+
+    def _get_constructor_kwargs(self):
+        """Return a dict of constructor_param_name -> value for all metadata fields."""
+        result = {}
         for field in self._fields:
-            value = getattr(self, field)
-            if isinstance(value, Tensor):
-                value = value.contiguous()
-            values.append(value)
-        return qt_type(*values)
+            param_name = self._field_to_constructor_param.get(field, field)
+            result[param_name] = getattr(self, field)
+        return result
 
     def set(self, **kwargs):
-        return self._replace(**kwargs)
+        """Create a new QuantTensor with some fields replaced.
+        Equivalent to NamedTuple._replace()."""
+        value = kwargs.pop('value', None)
+        value_ = kwargs.pop('value_', None)
+        ctor_kwargs = self._get_constructor_kwargs()
+        # Map any field-name kwargs to constructor param names
+        mapped_kwargs = {}
+        for k, v in kwargs.items():
+            param_name = self._field_to_constructor_param.get(k, k)
+            mapped_kwargs[param_name] = v
+        ctor_kwargs.update(mapped_kwargs)
+        # Remove value/value_ from kwargs dict (they're positional)
+        ctor_kwargs.pop('value', None)
+        ctor_kwargs.pop('value_', None)
+        if value is not None:
+            new_value = value
+        elif value_ is not None:
+            new_value = value_
+        else:
+            if hasattr(self, '_is_groupwise') and self._is_groupwise:
+                new_value = self._value_
+            else:
+                new_value = self.value
+        return type(self)(new_value, **ctor_kwargs)
+
+    def detach_(self):
+        super().detach_()
+        for field in self._fields:
+            val = getattr(self, field)
+            if isinstance(val, Tensor):
+                val.detach_()
+
+    def detach(self):
+        ctor_kwargs = self._get_constructor_kwargs()
+        for k, v in ctor_kwargs.items():
+            if isinstance(v, Tensor):
+                ctor_kwargs[k] = v.detach()
+        new_value = self.value.detach() if not (
+            hasattr(self, '_is_groupwise') and self._is_groupwise) else self._value_.detach()
+        ctor_kwargs.pop('value', None)
+        ctor_kwargs.pop('value_', None)
+        return type(self)(new_value, **ctor_kwargs)
+
+    def contiguous(self):
+        ctor_kwargs = self._get_constructor_kwargs()
+        for k, v in ctor_kwargs.items():
+            if isinstance(v, Tensor):
+                ctor_kwargs[k] = v.contiguous()
+        new_value = self.value.contiguous() if not (
+            hasattr(self, '_is_groupwise') and self._is_groupwise) else self._value_.contiguous()
+        ctor_kwargs.pop('value', None)
+        ctor_kwargs.pop('value_', None)
+        return type(self)(new_value, **ctor_kwargs)
 
     @property
     def shape(self):
@@ -59,34 +121,40 @@ class QuantTensor:
         return self + other
 
     def to(self, *args, **kwargs):
-        qt_type = type(self)
-        values = []
-        for field in self._fields:
-            value = getattr(self, field)
-            if isinstance(value, Tensor):
-                value = value.to(*args, **kwargs)
-            values.append(value)
-        return qt_type(*values)
+        ctor_kwargs = self._get_constructor_kwargs()
+        for k, v in ctor_kwargs.items():
+            if isinstance(v, Tensor):
+                ctor_kwargs[k] = v.to(*args, **kwargs)
+        new_value = self.value.to(
+            *args, **kwargs) if not (hasattr(self, '_is_groupwise') and
+                                     self._is_groupwise) else self._value_.to(*args, **kwargs)
+        ctor_kwargs.pop('value', None)
+        ctor_kwargs.pop('value_', None)
+        return type(self)(new_value, **ctor_kwargs)
 
     def cuda(self, *args, **kwargs):
-        qt_type = type(self)
-        values = []
-        for field in self._fields:
-            value = getattr(self, field)
-            if isinstance(value, Tensor):
-                value = value.cuda(*args, **kwargs)
-            values.append(value)
-        return qt_type(*values)
+        ctor_kwargs = self._get_constructor_kwargs()
+        for k, v in ctor_kwargs.items():
+            if isinstance(v, Tensor):
+                ctor_kwargs[k] = v.cuda(*args, **kwargs)
+        new_value = self.value.cuda(
+            *args, **kwargs) if not (hasattr(self, '_is_groupwise') and
+                                     self._is_groupwise) else self._value_.cuda(*args, **kwargs)
+        ctor_kwargs.pop('value', None)
+        ctor_kwargs.pop('value_', None)
+        return type(self)(new_value, **ctor_kwargs)
 
     def cpu(self, *args, **kwargs):
-        qt_type = type(self)
-        values = []
-        for field in self._fields:
-            value = getattr(self, field)
-            if isinstance(value, Tensor):
-                value = value.cpu(*args, **kwargs)
-            values.append(value)
-        return qt_type(*values)
+        ctor_kwargs = self._get_constructor_kwargs()
+        for k, v in ctor_kwargs.items():
+            if isinstance(v, Tensor):
+                ctor_kwargs[k] = v.cpu(*args, **kwargs)
+        new_value = self.value.cpu(
+            *args, **kwargs) if not (hasattr(self, '_is_groupwise') and
+                                     self._is_groupwise) else self._value_.cpu(*args, **kwargs)
+        ctor_kwargs.pop('value', None)
+        ctor_kwargs.pop('value_', None)
+        return type(self)(new_value, **ctor_kwargs)
 
     def __radd__(self, other):
         return self.__add__(other)
@@ -106,58 +174,6 @@ class QuantTensor:
     @staticmethod
     def is_zero_zero_point(tensor):
         return (tensor.zero_point == 0.).all()
-
-
-class IntQuantTensorBase(NamedTuple):
-    value: Tensor
-    scale: Tensor
-    zero_point: Tensor
-    bit_width: Tensor
-    signed_t: Tensor
-    training_t: Tensor
-
-
-class FloatQuantTensorBase(NamedTuple):
-    value: Tensor
-    scale: Tensor
-    zero_point: Tensor
-    exponent_bit_width: Tensor
-    mantissa_bit_width: Tensor
-    exponent_bias: Tensor
-    saturating_t: Tensor
-    inf_values: List[str]
-    nan_values: List[str]
-    signed_t: Tensor
-    training_t: Tensor
-
-
-class GroupwiseFloatQuantTensorBase(NamedTuple):
-    value_: Tensor
-    scale_: Tensor
-    zero_point_: Tensor
-    group_size: Tensor
-    group_dim: Tensor
-    exponent_bit_width: Tensor
-    mantissa_bit_width: Tensor
-    exponent_bias: Tensor
-    saturating_t: Tensor
-    inf_values: List[str]
-    nan_values: List[str]
-    signed_t: Tensor
-    training_t: Tensor
-    dequant_shape: Optional[Tuple] = None
-
-
-class GroupwisIntQuantTensorBase(NamedTuple):
-    value_: Tensor
-    scale_: Tensor
-    zero_point_: Tensor
-    group_size: Tensor
-    group_dim: Tensor
-    bit_width: Tensor
-    signed_t: Tensor
-    training_t: Tensor
-    dequant_shape: Optional[Tuple] = None
 
 
 class IntMixin:
@@ -373,7 +389,7 @@ class FloatMixin:
 
     @property
     def device(self):
-        value_device = self.value_.device
+        value_device = self.value.device
         is_same_device = True
         for t in [self.scale,
                   self.zero_point,

--- a/src/brevitas/quant_tensor/float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/float_quant_tensor.py
@@ -4,7 +4,6 @@
 import torch
 
 from brevitas.quant_tensor import _unpack_quant_tensor
-from brevitas.quant_tensor import FloatQuantTensorBase
 from brevitas.quant_tensor import QuantTensor
 from brevitas.quant_tensor.base_quant_tensor import FloatMixin
 
@@ -12,7 +11,19 @@ from .float_torch_handler import FLOAT_QUANT_TENSOR_FN_HANDLER
 from .torch_handler import QUANT_TENSOR_FN_HANDLER
 
 
-class FloatQuantTensor(FloatQuantTensorBase, FloatMixin, QuantTensor):
+class FloatQuantTensor(FloatMixin, QuantTensor):
+
+    _fields = (
+        'scale',
+        'zero_point',
+        'exponent_bit_width',
+        'mantissa_bit_width',
+        'exponent_bias',
+        'saturating',
+        'inf_values',
+        'nan_values',
+        'signed',
+        'training')
 
     def __new__(
             cls,
@@ -27,7 +38,24 @@ class FloatQuantTensor(FloatQuantTensorBase, FloatMixin, QuantTensor):
             nan_values,
             signed,
             training):
+        if not isinstance(value, torch.Tensor):
+            value = torch.tensor(value, dtype=torch.float)
+        # Use as_subclass to preserve grad_fn and requires_grad
+        return value.as_subclass(cls)
 
+    def __init__(
+            self,
+            value,
+            scale,
+            zero_point,
+            exponent_bit_width,
+            mantissa_bit_width,
+            exponent_bias,
+            saturating,
+            inf_values,
+            nan_values,
+            signed,
+            training):
         if not isinstance(scale, torch.Tensor):
             scale = torch.tensor(scale, dtype=torch.float)
         if not isinstance(zero_point, torch.Tensor):
@@ -44,20 +72,72 @@ class FloatQuantTensor(FloatQuantTensorBase, FloatMixin, QuantTensor):
             signed = torch.tensor(signed, dtype=torch.bool)
         if not isinstance(training, torch.Tensor):
             training = torch.tensor(training, dtype=torch.bool)
-        quant_tensor = super().__new__(
-            cls,
-            value,
-            scale,
-            zero_point,
-            exponent_bit_width,
-            mantissa_bit_width,
-            exponent_bias,
-            saturating,
-            inf_values,
-            nan_values,
-            signed,
-            training)
-        return quant_tensor
+        self._scale = scale
+        self._zero_point = zero_point
+        self._exponent_bit_width = exponent_bit_width
+        self._mantissa_bit_width = mantissa_bit_width
+        self._exponent_bias = exponent_bias
+        self.saturating_t = saturating
+        self._inf_values = inf_values
+        self._nan_values = nan_values
+        self.signed_t = signed
+        self.training_t = training
+
+    @property
+    def scale(self):
+        return self._scale
+
+    @scale.setter
+    def scale(self, value):
+        self._scale = value
+
+    @property
+    def zero_point(self):
+        return self._zero_point
+
+    @zero_point.setter
+    def zero_point(self, value):
+        self._zero_point = value
+
+    @property
+    def exponent_bit_width(self):
+        return self._exponent_bit_width
+
+    @exponent_bit_width.setter
+    def exponent_bit_width(self, value):
+        self._exponent_bit_width = value
+
+    @property
+    def mantissa_bit_width(self):
+        return self._mantissa_bit_width
+
+    @mantissa_bit_width.setter
+    def mantissa_bit_width(self, value):
+        self._mantissa_bit_width = value
+
+    @property
+    def exponent_bias(self):
+        return self._exponent_bias
+
+    @exponent_bias.setter
+    def exponent_bias(self, value):
+        self._exponent_bias = value
+
+    @property
+    def inf_values(self):
+        return self._inf_values
+
+    @inf_values.setter
+    def inf_values(self, value):
+        self._inf_values = value
+
+    @property
+    def nan_values(self):
+        return self._nan_values
+
+    @nan_values.setter
+    def nan_values(self, value):
+        self._nan_values = value
 
     @property
     def signed(self):
@@ -87,10 +167,6 @@ class FloatQuantTensor(FloatQuantTensorBase, FloatMixin, QuantTensor):
             args = _unpack_quant_tensor(args)
             kwargs = _unpack_quant_tensor(kwargs)
             return func(*args, **kwargs)
-
-    @property
-    def tensor(self):
-        return self.value
 
     @staticmethod
     def check_input_type(tensor):

--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -5,14 +5,30 @@ import torch
 
 from brevitas.quant_tensor import _unpack_quant_tensor
 from brevitas.quant_tensor.base_quant_tensor import FloatMixin
-from brevitas.quant_tensor.base_quant_tensor import GroupwiseFloatQuantTensorBase
 from brevitas.quant_tensor.base_quant_tensor import QuantTensor
 
 from .float_torch_handler import FLOAT_QUANT_TENSOR_FN_HANDLER
 from .torch_handler import QUANT_TENSOR_FN_HANDLER
 
 
-class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, QuantTensor):
+class GroupwiseFloatQuantTensor(FloatMixin, QuantTensor):
+
+    _fields = (
+        'scale_',
+        'zero_point_',
+        'group_size',
+        'group_dim',
+        'exponent_bit_width',
+        'mantissa_bit_width',
+        'exponent_bias',
+        'saturating',
+        'inf_values',
+        'nan_values',
+        'signed',
+        'training',
+        'dequant_shape')
+    _field_to_constructor_param = {'scale_': 'scale', 'zero_point_': 'zero_point'}
+    _is_groupwise = True
 
     def __new__(
             cls,
@@ -30,7 +46,27 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, Quant
             signed,
             training,
             dequant_shape=None):
+        if not isinstance(value, torch.Tensor):
+            value = torch.tensor(value, dtype=torch.float)
+        # Use as_subclass to preserve grad_fn and requires_grad
+        return value.as_subclass(cls)
 
+    def __init__(
+            self,
+            value,
+            scale,
+            zero_point,
+            group_size,
+            group_dim,
+            exponent_bit_width,
+            mantissa_bit_width,
+            exponent_bias,
+            saturating,
+            inf_values,
+            nan_values,
+            signed,
+            training,
+            dequant_shape=None):
         if not isinstance(scale, torch.Tensor):
             scale = torch.tensor(scale, dtype=torch.float)
         if not isinstance(zero_point, torch.Tensor):
@@ -47,23 +83,74 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, Quant
             signed = torch.tensor(signed, dtype=torch.bool)
         if not isinstance(training, torch.Tensor):
             training = torch.tensor(training, dtype=torch.bool)
-        quant_tensor = super().__new__(
-            cls,
-            value,
-            scale,
-            zero_point,
-            group_size,
-            group_dim,
-            exponent_bit_width,
-            mantissa_bit_width,
-            exponent_bias,
-            saturating,
-            inf_values,
-            nan_values,
-            signed,
-            training,
-            dequant_shape)
-        return quant_tensor
+        # Store raw (grouped) versions with trailing underscore
+        self._value_ = value if isinstance(value, torch.Tensor) else torch.tensor(
+            value, dtype=torch.float)
+        self.scale_ = scale
+        self.zero_point_ = zero_point
+        self._group_size = group_size
+        self._group_dim = group_dim
+        self._exponent_bit_width = exponent_bit_width
+        self._mantissa_bit_width = mantissa_bit_width
+        self._exponent_bias = exponent_bias
+        self.saturating_t = saturating
+        self._inf_values = inf_values
+        self._nan_values = nan_values
+        self.signed_t = signed
+        self.training_t = training
+        self._dequant_shape = dequant_shape
+
+    @property
+    def group_size(self):
+        return self._group_size
+
+    @property
+    def group_dim(self):
+        return self._group_dim
+
+    @property
+    def exponent_bit_width(self):
+        return self._exponent_bit_width
+
+    @exponent_bit_width.setter
+    def exponent_bit_width(self, value):
+        self._exponent_bit_width = value
+
+    @property
+    def mantissa_bit_width(self):
+        return self._mantissa_bit_width
+
+    @mantissa_bit_width.setter
+    def mantissa_bit_width(self, value):
+        self._mantissa_bit_width = value
+
+    @property
+    def exponent_bias(self):
+        return self._exponent_bias
+
+    @exponent_bias.setter
+    def exponent_bias(self, value):
+        self._exponent_bias = value
+
+    @property
+    def inf_values(self):
+        return self._inf_values
+
+    @inf_values.setter
+    def inf_values(self, value):
+        self._inf_values = value
+
+    @property
+    def nan_values(self):
+        return self._nan_values
+
+    @nan_values.setter
+    def nan_values(self, value):
+        self._nan_values = value
+
+    @property
+    def dequant_shape(self):
+        return self._dequant_shape
 
     @property
     def signed(self):
@@ -91,7 +178,7 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, Quant
     def expand(self):
         from brevitas.utils.quant_utils import groupwise_dequant_expand
         return groupwise_dequant_expand(
-            self.value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
+            self._value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
 
     @staticmethod
     def from_expanded(value, group_size, group_dim, compress=False):
@@ -183,7 +270,7 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, Quant
             return GroupwiseFloatQuantTensor(
                 value=neg_value,
                 scale=scale,
-                zero_point=self.zero_point,
+                zero_point=self.zero_point_,
                 group_size=self.group_size,
                 group_dim=self.group_dim,
                 exponent_bit_width=self.exponent_bit_width,
@@ -216,8 +303,8 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, Quant
                 scale, self.group_size, self.group_dim, compress=True)
             return GroupwiseFloatQuantTensor(
                 value=abs_value,
-                scale=self.scale,
-                zero_point=self.zero_point,
+                scale=self.scale_,
+                zero_point=self.zero_point_,
                 group_size=self.group_size,
                 group_dim=self.group_dim,
                 exponent_bit_width=self.exponent_bit_width,

--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -194,10 +194,6 @@ class GroupwiseFloatQuantTensor(FloatMixin, QuantTensor):
         return new_value
 
     @property
-    def tensor(self):
-        return self.value
-
-    @property
     def value(self):
         new_value, new_scale, new_zp = self.expand()
         return new_value

--- a/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
@@ -5,7 +5,6 @@ import torch
 
 from brevitas.function.ops_ste import round_ste
 from brevitas.quant_tensor import _unpack_quant_tensor
-from brevitas.quant_tensor.base_quant_tensor import GroupwisIntQuantTensorBase
 from brevitas.quant_tensor.base_quant_tensor import IntMixin
 from brevitas.quant_tensor.base_quant_tensor import QuantTensor
 from brevitas.utils.torch_utils import float_internal_scale
@@ -14,7 +13,19 @@ from .int_torch_handler import INT_QUANT_TENSOR_FN_HANDLER
 from .torch_handler import QUANT_TENSOR_FN_HANDLER
 
 
-class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor):
+class GroupwiseIntQuantTensor(IntMixin, QuantTensor):
+
+    _fields = (
+        'scale_',
+        'zero_point_',
+        'group_size',
+        'group_dim',
+        'bit_width',
+        'signed',
+        'training',
+        'dequant_shape')
+    _field_to_constructor_param = {'scale_': 'scale', 'zero_point_': 'zero_point'}
+    _is_groupwise = True
 
     def __new__(
             cls,
@@ -27,7 +38,22 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
             signed,
             training,
             dequant_shape=None):
+        if not isinstance(value, torch.Tensor):
+            value = torch.tensor(value, dtype=torch.float)
+        # Use as_subclass to preserve grad_fn and requires_grad
+        return value.as_subclass(cls)
 
+    def __init__(
+            self,
+            value,
+            scale,
+            zero_point,
+            group_size,
+            group_dim,
+            bit_width,
+            signed,
+            training,
+            dequant_shape=None):
         if not isinstance(scale, torch.Tensor):
             scale = torch.tensor(scale, dtype=torch.float)
         if not isinstance(zero_point, torch.Tensor):
@@ -38,18 +64,37 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
             signed = torch.tensor(signed, dtype=torch.bool)
         if not isinstance(training, torch.Tensor):
             training = torch.tensor(training, dtype=torch.bool)
-        quant_tensor = super().__new__(
-            cls,
-            value,
-            scale,
-            zero_point,
-            group_size,
-            group_dim,
-            bit_width,
-            signed,
-            training,
-            dequant_shape)
-        return quant_tensor
+        # Store raw (grouped) versions with trailing underscore
+        self._value_ = value if isinstance(value, torch.Tensor) else torch.tensor(
+            value, dtype=torch.float)
+        self.scale_ = scale
+        self.zero_point_ = zero_point
+        self._group_size = group_size
+        self._group_dim = group_dim
+        self._bit_width = bit_width
+        self.signed_t = signed
+        self.training_t = training
+        self._dequant_shape = dequant_shape
+
+    @property
+    def group_size(self):
+        return self._group_size
+
+    @property
+    def group_dim(self):
+        return self._group_dim
+
+    @property
+    def bit_width(self):
+        return self._bit_width
+
+    @bit_width.setter
+    def bit_width(self, value):
+        self._bit_width = value
+
+    @property
+    def dequant_shape(self):
+        return self._dequant_shape
 
     @property
     def signed(self):
@@ -58,10 +103,6 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
     @property
     def training(self):
         return self.training_t.item()
-
-    @property
-    def saturating(self):
-        return self.saturating_t.item()
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
@@ -78,7 +119,7 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
     def expand(self):
         from brevitas.utils.quant_utils import groupwise_dequant_expand
         return groupwise_dequant_expand(
-            self.value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
+            self._value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
 
     @staticmethod
     def from_expanded(value, group_size, group_dim, compress=False):
@@ -114,13 +155,9 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
 
     @property
     def device(self):
-        value_device = self.value_.device
+        value_device = self._value_.device
         is_same_device = True
-        for t in [self.scale,
-                  self.zero_point,
-                  self.exponent_bit_width,
-                  self.mantissa_bit_width,
-                  self.exponent_bias]:
+        for t in [self.scale_, self.zero_point_, self._bit_width]:
             is_same_device &= value_device == t.device
         if not is_same_device:
             raise RuntimeError("Value and metadata are on different devices")
@@ -161,13 +198,12 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
             return GroupwiseIntQuantTensor(
                 value=neg_value,
                 scale=scale,
-                zero_point=self.zero_point,
+                zero_point=self.zero_point_,
                 group_size=self.group_size,
                 group_dim=self.group_dim,
                 bit_width=self.bit_width,
                 signed=self.signed,
-                training=self.training,
-                saturating=self.saturating)
+                training=self.training)
         else:
             # TODO: implement
             raise NotImplementedError
@@ -211,13 +247,12 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
                 scale, self.group_size, self.group_dim, compress=True)
             return GroupwiseIntQuantTensor(
                 value=abs_value,
-                scale=self.scale,
-                zero_point=self.zero_point,
+                scale=self.scale_,
+                zero_point=self.zero_point_,
                 group_size=self.group_size,
                 group_dim=self.group_dim,
                 bit_width=self.bit_width,
                 signed=False,
-                training=self.training,
-                saturating=self.saturating)
+                training=self.training)
         else:
             return self

--- a/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
@@ -135,10 +135,6 @@ class GroupwiseIntQuantTensor(IntMixin, QuantTensor):
         return new_value
 
     @property
-    def tensor(self):
-        return self.value
-
-    @property
     def value(self):
         new_value, new_scale, new_zp = self.expand()
         return new_value

--- a/src/brevitas/quant_tensor/int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/int_quant_tensor.py
@@ -8,7 +8,6 @@ from brevitas.function.ops import min_int
 from brevitas.function.ops_ste import ceil_ste
 from brevitas.function.ops_ste import round_ste
 from brevitas.quant_tensor import _unpack_quant_tensor
-from brevitas.quant_tensor import IntQuantTensorBase
 from brevitas.quant_tensor import QuantTensor
 from brevitas.quant_tensor.base_quant_tensor import IntMixin
 
@@ -16,10 +15,17 @@ from .int_torch_handler import INT_QUANT_TENSOR_FN_HANDLER
 from .torch_handler import QUANT_TENSOR_FN_HANDLER
 
 
-class IntQuantTensor(IntQuantTensorBase, IntMixin, QuantTensor):
+class IntQuantTensor(IntMixin, QuantTensor):
+
+    _fields = ('scale', 'zero_point', 'bit_width', 'signed', 'training')
 
     def __new__(cls, value, scale, zero_point, bit_width, signed, training):
+        if not isinstance(value, torch.Tensor):
+            value = torch.tensor(value, dtype=torch.float)
+        # Use as_subclass to preserve grad_fn and requires_grad
+        return value.as_subclass(cls)
 
+    def __init__(self, value, scale, zero_point, bit_width, signed, training):
         if not isinstance(scale, torch.Tensor):
             scale = torch.tensor(scale, dtype=torch.float)
         if not isinstance(zero_point, torch.Tensor):
@@ -30,8 +36,35 @@ class IntQuantTensor(IntQuantTensorBase, IntMixin, QuantTensor):
             signed = torch.tensor(signed, dtype=torch.bool)
         if not isinstance(training, torch.Tensor):
             training = torch.tensor(training, dtype=torch.bool)
-        quant_tensor = super().__new__(cls, value, scale, zero_point, bit_width, signed, training)
-        return quant_tensor
+        self._scale = scale
+        self._zero_point = zero_point
+        self._bit_width = bit_width
+        self.signed_t = signed
+        self.training_t = training
+
+    @property
+    def scale(self):
+        return self._scale
+
+    @scale.setter
+    def scale(self, value):
+        self._scale = value
+
+    @property
+    def zero_point(self):
+        return self._zero_point
+
+    @zero_point.setter
+    def zero_point(self, value):
+        self._zero_point = value
+
+    @property
+    def bit_width(self):
+        return self._bit_width
+
+    @bit_width.setter
+    def bit_width(self, value):
+        self._bit_width = value
 
     @property
     def signed(self):
@@ -53,10 +86,6 @@ class IntQuantTensor(IntQuantTensorBase, IntMixin, QuantTensor):
             args = _unpack_quant_tensor(args)
             kwargs = _unpack_quant_tensor(kwargs)
             return func(*args, **kwargs)
-
-    @property
-    def tensor(self):
-        return self.value
 
     @property
     def device(self):

--- a/src/brevitas/utils/quant_utils.py
+++ b/src/brevitas/utils/quant_utils.py
@@ -20,7 +20,7 @@ class _CachedIO:
         self.shape = quant_tensor.value.shape
         if metadata_only:
             self.value = None
-            self.quant_tensor = quant_tensor.set(value=None)
+            self.quant_tensor = quant_tensor.set(value=torch.empty(0))
         else:
             self.quant_tensor = quant_tensor
             # torch.compile compatibility
@@ -47,7 +47,7 @@ class _CachedIOFloat:
         self.shape = quant_tensor.value.shape
         if metadata_only:
             self.value = None
-            self.quant_tensor = quant_tensor.set(value=None)
+            self.quant_tensor = quant_tensor.set(value=torch.empty(0))
         else:
             self.quant_tensor = quant_tensor
             # torch.compile compatibility
@@ -94,7 +94,7 @@ class _CachedIOGroupwiseFloat:
         self.shape = quant_tensor.value.shape
         if metadata_only:
             self.value = None
-            self.quant_tensor = quant_tensor.set(value_=None)
+            self.quant_tensor = quant_tensor.set(value_=torch.empty(0))
         else:
             self.quant_tensor = quant_tensor
             # torch.compile compatibility
@@ -146,7 +146,7 @@ class _CachedIOGroupwiseInt:
         self.shape = quant_tensor.value.shape
         if metadata_only:
             self.value = None
-            self.quant_tensor = quant_tensor.set(value_=None)
+            self.quant_tensor = quant_tensor.set(value_=torch.empty(0))
         else:
             self.quant_tensor = quant_tensor
             # torch.compile compatibility

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -79,9 +79,9 @@ def test_qt_structure():
         torch.randn(10), torch.randn(1), torch.tensor(0.), torch.tensor(8.), True, False)
     assert isinstance(qt, IntQuantTensor)
     assert isinstance(qt, QuantTensor)
-    assert isinstance(qt, tuple)
+    assert isinstance(qt, torch.Tensor)
     assert hasattr(qt, '_fields')
-    assert len(qt._fields) == 6
+    assert len(qt._fields) == 5
 
 
 def test_quant_tensor_init():

--- a/tests/brevitas/quant_tensor/test_quant_tensor_subclass.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor_subclass.py
@@ -1,0 +1,513 @@
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for QuantTensor as a torch.Tensor subclass.
+
+These tests cover the behaviors introduced by converting QuantTensor from
+a NamedTuple to a torch.Tensor subclass:
+  - isinstance relationships
+  - .value returns plain Tensor and preserves grad_fn
+  - set() creates a new QuantTensor with replaced fields
+  - __iadd__, __imul__, __isub__ semantics (non-in-place)
+  - __torch_function__ fallback (no infinite recursion)
+  - detach / contiguous / to preserve type and metadata
+  - _unpack_quant_tensor returns plain Tensor
+  - __radd__ / __rmul__ right-hand operators
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from brevitas.nn import QuantIdentity
+from brevitas.quant.experimental.float import Fp8e4m3ActPerTensorFloat
+from brevitas.quant.experimental.float_quant_ocp import Fp8e5m2OCPActPerTensorFloat
+from brevitas.quant.experimental.mx_quant_ocp import MXFloat8e4m3Act
+from brevitas.quant_tensor import _unpack_quant_tensor
+from brevitas.quant_tensor import FloatQuantTensor
+from brevitas.quant_tensor import GroupwiseFloatQuantTensor
+from brevitas.quant_tensor import IntQuantTensor
+from brevitas.quant_tensor import QuantTensor
+from brevitas.quant_tensor.groupwise_int_quant_tensor import GroupwiseIntQuantTensor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_int_qt(shape=(4, 4), bit_width=8):
+    mod = QuantIdentity(bit_width=bit_width, return_quant_tensor=True)
+    return mod(torch.randn(shape))
+
+
+def _make_float_qt(shape=(4, 4)):
+    mod = QuantIdentity(
+        bit_width=8,
+        exponent_bit_width=4,
+        mantissa_bit_width=3,
+        return_quant_tensor=True,
+        act_quant=Fp8e5m2OCPActPerTensorFloat)
+    return mod(torch.randn(shape))
+
+
+def _make_mx_qt(shape=(1, 32)):
+    mod = QuantIdentity(
+        bit_width=8,
+        group_size=32,
+        group_dim=1,
+        exponent_bit_width=4,
+        mantissa_bit_width=3,
+        return_quant_tensor=True,
+        act_quant=MXFloat8e4m3Act)
+    return mod(torch.randn(shape))
+
+
+# ---------------------------------------------------------------------------
+# 1. isinstance relationships
+# ---------------------------------------------------------------------------
+
+
+class TestIsInstance:
+
+    def test_int_quant_tensor_is_tensor(self):
+        qt = _make_int_qt()
+        assert isinstance(qt, torch.Tensor)
+        assert isinstance(qt, QuantTensor)
+        assert isinstance(qt, IntQuantTensor)
+
+    def test_float_quant_tensor_is_tensor(self):
+        qt = _make_float_qt()
+        assert isinstance(qt, torch.Tensor)
+        assert isinstance(qt, QuantTensor)
+        assert isinstance(qt, FloatQuantTensor)
+
+    def test_mx_quant_tensor_is_tensor(self):
+        qt = _make_mx_qt()
+        assert isinstance(qt, torch.Tensor)
+        assert isinstance(qt, QuantTensor)
+        assert isinstance(qt, GroupwiseFloatQuantTensor)
+
+    def test_manually_constructed_int_qt(self):
+        qt = IntQuantTensor(
+            torch.randn(10), torch.randn(1), torch.tensor(0.), torch.tensor(8.), True, False)
+        assert isinstance(qt, torch.Tensor)
+        assert isinstance(qt, QuantTensor)
+
+
+# ---------------------------------------------------------------------------
+# 2. .value returns plain Tensor and preserves grad_fn
+# ---------------------------------------------------------------------------
+
+
+class TestValueProperty:
+
+    def test_value_is_plain_tensor(self):
+        qt = _make_int_qt()
+        v = qt.value
+        assert type(v) is torch.Tensor
+        assert not isinstance(v, QuantTensor)
+
+    def test_value_same_data(self):
+        qt = _make_int_qt()
+        v = qt.value
+        assert torch.equal(v, qt)
+
+    def test_value_preserves_grad_fn(self):
+        x = torch.randn(4, 4, requires_grad=True)
+        y = x * 2  # y has a grad_fn
+        qt = IntQuantTensor(y, torch.tensor(1.0), torch.tensor(0.0), torch.tensor(8.0), True, False)
+        assert qt.grad_fn is not None
+        v = qt.value
+        assert v.grad_fn is not None
+
+    def test_value_preserves_requires_grad(self):
+        x = torch.randn(4, 4, requires_grad=True)
+        qt = IntQuantTensor(x, torch.tensor(1.0), torch.tensor(0.0), torch.tensor(8.0), True, False)
+        assert qt.value.requires_grad is True
+
+    def test_tensor_alias(self):
+        qt = _make_int_qt()
+        assert torch.equal(qt.tensor, qt.value)
+
+    def test_float_qt_value_is_plain_tensor(self):
+        qt = _make_float_qt()
+        v = qt.value
+        assert type(v) is torch.Tensor
+        assert not isinstance(v, QuantTensor)
+
+
+# ---------------------------------------------------------------------------
+# 3. set() method
+# ---------------------------------------------------------------------------
+
+
+class TestSetMethod:
+
+    def test_set_replaces_scale(self):
+        qt = _make_int_qt()
+        new_scale = torch.tensor(0.5)
+        qt2 = qt.set(scale=new_scale)
+        assert isinstance(qt2, IntQuantTensor)
+        assert torch.equal(qt2.scale, new_scale)
+        # Other metadata preserved
+        assert torch.equal(qt2.zero_point, qt.zero_point)
+        assert torch.equal(qt2.bit_width, qt.bit_width)
+
+    def test_set_replaces_value(self):
+        qt = _make_int_qt()
+        new_value = torch.ones(4, 4)
+        qt2 = qt.set(value=new_value)
+        assert isinstance(qt2, IntQuantTensor)
+        assert torch.allclose(qt2.value, new_value)
+        assert torch.equal(qt2.scale, qt.scale)
+
+    def test_set_no_args_copies(self):
+        qt = _make_int_qt()
+        qt2 = qt.set()
+        assert isinstance(qt2, IntQuantTensor)
+        assert torch.allclose(qt2.value, qt.value)
+        assert torch.equal(qt2.scale, qt.scale)
+
+    def test_set_returns_same_type(self):
+        qt = _make_float_qt()
+        qt2 = qt.set(scale=torch.tensor(1.0))
+        assert type(qt2) is FloatQuantTensor
+
+
+# ---------------------------------------------------------------------------
+# 4. In-place augmented assignment operators
+# ---------------------------------------------------------------------------
+
+
+class TestInPlaceOperators:
+
+    def test_iadd_returns_valid_result(self):
+        qt = _make_int_qt()
+        original_value = qt.value.clone()
+        other = _make_int_qt()
+        qt += other
+        # += should produce a result (not crash), and result should be a tensor
+        assert isinstance(qt, torch.Tensor)
+
+    def test_imul_returns_valid_result(self):
+        qt = _make_int_qt()
+        # Multiply by a scalar tensor
+        qt *= torch.tensor(2.0)
+        assert isinstance(qt, torch.Tensor)
+
+    def test_isub_returns_valid_result(self):
+        qt = _make_int_qt()
+        other = _make_int_qt()
+        qt -= other
+        assert isinstance(qt, torch.Tensor)
+
+    def test_iadd_preserves_quant_tensor_type(self):
+        qa = _make_int_qt()
+        qb = _make_int_qt()
+        result_add = qa + qb
+        qa_copy = _make_int_qt()
+        # Use fresh tensors from same distribution
+        qa_copy += qb
+        # Both should be IntQuantTensor
+        assert isinstance(result_add, IntQuantTensor)
+        assert isinstance(qa_copy, IntQuantTensor)
+
+
+# ---------------------------------------------------------------------------
+# 5. __torch_function__ fallback (no infinite recursion)
+# ---------------------------------------------------------------------------
+
+
+class TestTorchFunctionFallback:
+
+    def test_unhandled_function_returns_plain_tensor(self):
+        """Functions not in the handler map should unpack and return plain tensor."""
+        qt = _make_int_qt()
+        result = torch.sum(qt)
+        # sum is not in any handler map, so it should fallback
+        assert isinstance(result, torch.Tensor)
+        # Should not be a QuantTensor
+        assert not isinstance(result, QuantTensor)
+
+    def test_mean_fallback(self):
+        qt = _make_int_qt()
+        result = torch.mean(qt)
+        assert isinstance(result, torch.Tensor)
+        assert not isinstance(result, QuantTensor)
+
+    def test_clamp_fallback(self):
+        qt = _make_int_qt()
+        result = torch.clamp(qt, min=0.0, max=1.0)
+        assert isinstance(result, torch.Tensor)
+        assert not isinstance(result, QuantTensor)
+
+    def test_abs_on_float_qt_fallback(self):
+        """torch.abs not in float handler, should fallback cleanly."""
+        qt = _make_float_qt()
+        # FloatQuantTensor has __abs__ which calls minifloat; torch.abs is different
+        # Using torch.sum which is definitely not in the handler
+        result = torch.sum(qt)
+        assert isinstance(result, torch.Tensor)
+        assert not isinstance(result, QuantTensor)
+
+    def test_no_recursion_with_multiple_qt_args(self):
+        """Ensure no recursion when multiple QuantTensors are passed."""
+        qa = _make_int_qt()
+        qb = _make_int_qt()
+        # torch.stack is not in any handler
+        result = torch.stack([qa.value, qb.value])
+        assert isinstance(result, torch.Tensor)
+
+    def test_handled_function_relu(self):
+        """F.relu IS in the handler map, should return QuantTensor."""
+        qt = _make_int_qt()
+        result = F.relu(qt)
+        assert isinstance(result, IntQuantTensor)
+
+    def test_handled_function_max_pool2d(self):
+        """F.max_pool2d IS in the handler map, should return QuantTensor."""
+        qt = _make_int_qt(shape=(1, 1, 4, 4))
+        result = F.max_pool2d(qt, kernel_size=2)
+        assert isinstance(result, IntQuantTensor)
+
+
+# ---------------------------------------------------------------------------
+# 6. detach / contiguous / to
+# ---------------------------------------------------------------------------
+
+
+class TestTensorOps:
+
+    def test_detach_preserves_type_and_metadata(self):
+        qt = _make_int_qt()
+        d = qt.detach()
+        assert isinstance(d, IntQuantTensor)
+        assert d.grad_fn is None
+        assert torch.equal(d.scale, qt.scale)
+        assert torch.equal(d.zero_point, qt.zero_point)
+        assert torch.equal(d.bit_width, qt.bit_width)
+
+    def test_contiguous_preserves_type_and_metadata(self):
+        qt = _make_int_qt()
+        c = qt.contiguous()
+        assert isinstance(c, IntQuantTensor)
+        assert torch.equal(c.scale, qt.scale)
+        assert torch.equal(c.bit_width, qt.bit_width)
+
+    def test_to_dtype_preserves_type_and_metadata(self):
+        qt = _make_int_qt()
+        qt16 = qt.to(torch.float16)
+        assert isinstance(qt16, IntQuantTensor)
+        assert qt16.value.dtype == torch.float16
+        # Metadata should also be converted
+        assert qt16.scale.dtype == torch.float16
+
+    def test_float_qt_detach(self):
+        qt = _make_float_qt()
+        d = qt.detach()
+        assert isinstance(d, FloatQuantTensor)
+        assert d.grad_fn is None
+        assert torch.equal(d.scale, qt.scale)
+
+
+# ---------------------------------------------------------------------------
+# 7. _unpack_quant_tensor
+# ---------------------------------------------------------------------------
+
+
+class TestUnpackQuantTensor:
+
+    def test_unpack_int_qt(self):
+        qt = _make_int_qt()
+        v = _unpack_quant_tensor(qt)
+        assert type(v) is torch.Tensor
+        assert not isinstance(v, QuantTensor)
+        assert torch.equal(v, qt.value)
+
+    def test_unpack_float_qt(self):
+        qt = _make_float_qt()
+        v = _unpack_quant_tensor(qt)
+        assert type(v) is torch.Tensor
+        assert not isinstance(v, QuantTensor)
+
+    def test_unpack_plain_tensor_passthrough(self):
+        t = torch.randn(4, 4)
+        v = _unpack_quant_tensor(t)
+        assert v is t
+
+    def test_unpack_tuple(self):
+        qt = _make_int_qt()
+        t = torch.randn(4, 4)
+        result = _unpack_quant_tensor((qt, t))
+        assert isinstance(result, tuple)
+        assert type(result[0]) is torch.Tensor
+        assert result[1] is t
+
+    def test_unpack_dict(self):
+        qt = _make_int_qt()
+        result = _unpack_quant_tensor({'a': qt, 'b': 42})
+        assert type(result['a']) is torch.Tensor
+        assert result['b'] == 42
+
+    def test_unpack_nested(self):
+        qt = _make_int_qt()
+        result = _unpack_quant_tensor([qt, (qt, qt)])
+        assert isinstance(result, list)
+        assert type(result[0]) is torch.Tensor
+        assert isinstance(result[1], tuple)
+        assert type(result[1][0]) is torch.Tensor
+
+
+# ---------------------------------------------------------------------------
+# 8. Right-hand operators
+# ---------------------------------------------------------------------------
+
+
+class TestRightHandOperators:
+
+    def test_radd_plain_tensor_plus_int_qt(self):
+        qt = _make_int_qt()
+        t = torch.ones(4, 4)
+        result = t + qt
+        assert isinstance(result, torch.Tensor)
+
+    def test_rmul_plain_tensor_times_int_qt(self):
+        qt = _make_int_qt()
+        t = torch.ones(4, 4) * 2.0
+        result = t * qt
+        assert isinstance(result, torch.Tensor)
+
+
+# ---------------------------------------------------------------------------
+# 9. _fields attribute
+# ---------------------------------------------------------------------------
+
+
+class TestFields:
+
+    def test_int_qt_fields(self):
+        qt = _make_int_qt()
+        assert hasattr(qt, '_fields')
+        assert set(qt._fields) == {'scale', 'zero_point', 'bit_width', 'signed', 'training'}
+
+    def test_float_qt_fields(self):
+        qt = _make_float_qt()
+        assert hasattr(qt, '_fields')
+        expected = {
+            'scale',
+            'zero_point',
+            'exponent_bit_width',
+            'mantissa_bit_width',
+            'exponent_bias',
+            'saturating',
+            'inf_values',
+            'nan_values',
+            'signed',
+            'training'}
+        assert set(qt._fields) == expected
+
+    def test_groupwise_float_qt_fields(self):
+        qt = _make_mx_qt()
+        assert hasattr(qt, '_fields')
+        assert 'scale_' in qt._fields
+        assert 'group_size' in qt._fields
+        assert 'group_dim' in qt._fields
+
+
+# ---------------------------------------------------------------------------
+# 10. shape / size / dim
+# ---------------------------------------------------------------------------
+
+
+class TestShapeSizeDim:
+
+    def test_shape(self):
+        qt = _make_int_qt(shape=(2, 3, 4))
+        assert qt.shape == torch.Size([2, 3, 4])
+
+    def test_size(self):
+        qt = _make_int_qt(shape=(2, 3, 4))
+        assert qt.size() == torch.Size([2, 3, 4])
+        assert qt.size(0) == 2
+        assert qt.size(1) == 3
+
+    def test_dim(self):
+        qt = _make_int_qt(shape=(2, 3, 4))
+        assert qt.dim() == 3
+
+
+# ---------------------------------------------------------------------------
+# 11. Construction from non-Tensor input
+# ---------------------------------------------------------------------------
+
+
+class TestConstructionFromNonTensor:
+
+    def test_from_float(self):
+        qt = IntQuantTensor(
+            1.0, torch.tensor(1.0), torch.tensor(0.0), torch.tensor(8.0), True, False)
+        assert isinstance(qt, IntQuantTensor)
+        assert isinstance(qt, torch.Tensor)
+
+    def test_from_list(self):
+        qt = IntQuantTensor([1.0, 2.0, 3.0],
+                            torch.tensor(1.0),
+                            torch.tensor(0.0),
+                            torch.tensor(8.0),
+                            True,
+                            False)
+        assert isinstance(qt, IntQuantTensor)
+        assert qt.shape == torch.Size([3])
+
+
+# ---------------------------------------------------------------------------
+# 12. Dynamo export: cache_class backup/restore
+# ---------------------------------------------------------------------------
+
+
+class TestDynamoExportCacheClass:
+
+    def test_cache_class_cleared_and_restored(self):
+        """QONNXDynamoManager.set_export_mode should clear cache_class on enable
+        and restore it on disable, to prevent QuantTensor reconstruction
+        from FakeTensors during torch.export tracing."""
+        from brevitas.export.manager import ExportContext
+        from brevitas.export.onnx.qonnx.manager import QONNXDynamoManager
+        from brevitas.nn.quant_avg_pool import TruncAvgPool2d
+
+        class Model(torch.nn.Module):
+
+            def __init__(self):
+                super().__init__()
+                self.inp_quant = QuantIdentity(return_quant_tensor=True)
+                self.pool = TruncAvgPool2d(kernel_size=2, return_quant_tensor=False)
+
+            def forward(self, x):
+                return self.pool(self.inp_quant(x))
+
+        inp = torch.randn(2, 8, 4, 4)
+        model = Model()
+        model(inp)  # populate cache
+        model.eval()
+
+        with torch.no_grad():
+            with ExportContext(QONNXDynamoManager):
+                # Set up handlers and cache
+                model.apply(QONNXDynamoManager.set_export_handler)
+                QONNXDynamoManager._cache_inp_out(model, inp)
+
+                # Verify cache_class is set after cache_inp_out
+                assert model.pool.cache_class is not None
+                original_cache = model.pool.cache_class
+
+                # Enable export mode
+                QONNXDynamoManager.set_export_mode(model, enabled=True)
+
+                # cache_class should be cleared
+                assert model.pool.cache_class is None
+
+                # Disable export mode
+                QONNXDynamoManager.set_export_mode(model, enabled=False)
+
+                # cache_class should be restored
+                assert model.pool.cache_class is original_cache

--- a/tests/brevitas/quant_tensor/test_quant_tensor_subclass.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor_subclass.py
@@ -125,9 +125,9 @@ class TestValueProperty:
         qt = IntQuantTensor(x, torch.tensor(1.0), torch.tensor(0.0), torch.tensor(8.0), True, False)
         assert qt.value.requires_grad is True
 
-    def test_tensor_alias(self):
+    def test_value_is_not_subclass(self):
         qt = _make_int_qt()
-        assert torch.equal(qt.tensor, qt.value)
+        assert type(qt.value) is torch.Tensor
 
     def test_float_qt_value_is_plain_tensor(self):
         qt = _make_float_qt()

--- a/tests/brevitas_finn/brevitas/test_brevitas_avg_pool_export.py
+++ b/tests/brevitas_finn/brevitas/test_brevitas_avg_pool_export.py
@@ -77,7 +77,7 @@ def test_brevitas_avg_pool_export(
     model = model.transform(InferDataTypes())
 
     # reference brevitas output
-    ref_output_array = model_brevitas(inp).tensor.detach().numpy()
+    ref_output_array = model_brevitas(inp).value.detach().numpy()
     # finn output
     idict = {model.graph.input[0].name: inp.detach().numpy()}
     odict = oxe.execute_onnx(model, idict, True)


### PR DESCRIPTION
## Summary

This PR converts all `QuantTensor` types (`IntQuantTensor`, `FloatQuantTensor`,
`GroupwiseIntQuantTensor`, `GroupwiseFloatQuantTensor`) from `NamedTuple` subclasses
to proper `torch.Tensor` subclasses. The underlying tensor data now *is* the
dequantized `value`; quantization metadata (scale, zero_point, bit_width, etc.) are
stored as regular Python attributes exposed through property accessors.

---

## Motivation

The previous `NamedTuple`-based design had several practical limitations:

- **Tuple-decay in tracing**: during ONNX export and `torch.jit.trace`, a `QuantTensor`
  could silently decay to a plain `tuple`, requiring a fragile `get_quant_tensor_class`
  reconstruction heuristic keyed on tuple length.
- **No real Tensor semantics**: `isinstance(qt, torch.Tensor)` was `False`, so any
  PyTorch API that dispatches on tensor type (e.g. `torch.onnx.export` argument
  handling, `torch.compile` graph tracing) had to be worked around with special cases.
- **`torch.compile` / dynamo friction**: metadata-only caching required storing `None`
  as the value placeholder, which is not compatible with tensor graph tracing.

Moving to a `torch.Tensor` subclass resolves all of the above cleanly:
`QuantTensor` instances are real tensors, participate naturally in PyTorch dispatch,
and no reconstruction heuristics are needed in tracing paths.

---

## Changes

### Core base class (`src/brevitas/quant_tensor/base_quant_tensor.py`)

- `QuantTensor` now subclasses `torch.Tensor` directly.
- `__new__` creates the instance via `value.as_subclass(cls)`, preserving `grad_fn`
  and `requires_grad`.
- `value` property returns a plain-`Tensor` view of `self` via
  `Tensor.as_subclass(self, Tensor)` to prevent infinite recursion in operations.
- Added `_field_to_constructor_param` class attribute for field-name → constructor-param
  mapping (used by groupwise types where e.g. `scale_` maps to `scale`).
- Added `_get_constructor_kwargs()` helper that collects current metadata into a dict
  suitable for passing back to the constructor.
- `set()` is reimplemented (previously delegated to `NamedTuple._replace()`); it now
  builds a fresh instance via `_get_constructor_kwargs()` and handles the
  `value`/`value_` distinction for groupwise types.
- `detach()`, `contiguous()`, `to()`, `cuda()`, `cpu()` are all reimplemented to
  iterate over `_get_constructor_kwargs()` and return a new instance of the same type
  with metadata tensors transformed accordingly.
- `detach_()` calls `super().detach_()` in addition to detaching each metadata tensor.
- Added `__iadd__`, `__imul__`, `__isub__` (non-mutating; return a new value).
- **Removed** the four `NamedTuple` base classes: `IntQuantTensorBase`,
  `FloatQuantTensorBase`, `GroupwiseFloatQuantTensorBase`, `GroupwisIntQuantTensorBase`.

### `IntQuantTensor` (`src/brevitas/quant_tensor/int_quant_tensor.py`)

- No longer inherits from `IntQuantTensorBase`.
- Declares `_fields = ('scale', 'zero_point', 'bit_width', 'signed', 'training')`.
  Note: `value` is no longer a field — it is the tensor itself.
- `__new__` performs `value.as_subclass(cls)`; all metadata coercion moves to
  `__init__`, which stores `_scale`, `_zero_point`, `_bit_width`, `signed_t`,
  `training_t`.
- `scale`, `zero_point`, `bit_width` exposed as property getters/setters.
### `FloatQuantTensor` (`src/brevitas/quant_tensor/float_quant_tensor.py`)

- No longer inherits from `FloatQuantTensorBase`.
- Declares `_fields` for all 10 metadata attributes (value excluded).
- Same `__new__`/`__init__` split pattern as `IntQuantTensor`.
- All metadata attributes (`scale`, `zero_point`, `exponent_bit_width`,
  `mantissa_bit_width`, `exponent_bias`,   `inf_values`, `nan_values`) exposed as
  property getters/setters.

### `GroupwiseIntQuantTensor` (`src/brevitas/quant_tensor/groupwise_int_quant_tensor.py`)

- No longer inherits from `GroupwisIntQuantTensorBase`.
- Declares `_fields` (8 entries, using `scale_`/`zero_point_` names for the grouped
  tensors) and `_field_to_constructor_param = {'scale_': 'scale', 'zero_point_': 'zero_point'}`.
- Sets `_is_groupwise = True` so that `set()`/`detach()`/etc. in the base class use
  `_value_` instead of `value`.
- The raw grouped value is stored as `self._value_`; `self` (as a tensor) holds the
  dequantized/expanded representation used by `.value`.
- `group_size`, `group_dim`, `bit_width`, `dequant_shape` exposed as properties.
- Fixed `__neg__` and `__abs__` to reference `self.zero_point_` / `self.scale_`
  instead of the removed `self.zero_point` / `self.scale`.
- Removed incorrect `saturating` property that was accidentally inherited.

### `GroupwiseFloatQuantTensor` (`src/brevitas/quant_tensor/groupwise_float_quant_tensor.py`)

- Same structural changes as `GroupwiseIntQuantTensor`.
- `_fields` covers 13 metadata attributes.
- All float metadata (`exponent_bit_width`, `mantissa_bit_width`, `exponent_bias`,
  `inf_values`, `nan_values`, `dequant_shape`) exposed as property getters/setters.
- Fixed `__neg__` and `__abs__` to use `self.zero_point_` / `self.scale_`.

### `__init__.py` (`src/brevitas/quant_tensor/__init__.py`)

- Changed from `from .base_quant_tensor import *` (which exported the now-deleted
  NamedTuple base classes) to explicit named imports of `_unpack_quant_tensor` and
  `QuantTensor`.

### NN mixin (`src/brevitas/nn/mixin/base.py`)

- Removed `get_quant_tensor_class()` — the tuple-length heuristic for reconstructing
  a `QuantTensor` from a decayed tuple is no longer needed.
- Removed the tracing-state tuple-decay workaround in `unpack_input()`. Since
  `QuantTensor` is now a real `Tensor`, it does not decay to a plain tuple during
  tracing.
- Removed unused imports of `FloatQuantTensor`, `GroupwiseFloatQuantTensor`,
  `GroupwiseIntQuantTensor` from this module.

### ONNX export (`src/brevitas/export/onnx/manager.py`)

- Simplified the `isinstance(args, tuple)` guard: previously it was
  `isinstance(args, tuple) and not isinstance(args, QuantTensor)` because
  `QuantTensor` was a `NamedTuple` (hence a `tuple`). This exclusion is no longer
  needed.

### Proxy (`src/brevitas/proxy/parameter_quant.py`)

- Updated the cached-activation fallback check from
  `isinstance(quant_input, Tensor)` to `not isinstance(quant_input, IntQuantTensor)`,
  since `IntQuantTensor` is now itself a `Tensor` subclass and the old check would
  always be `True`.

### Caching utilities (`src/brevitas/utils/quant_utils.py`)

- `_CachedIO`, `_CachedIOFloat`, `_CachedIOGroupwiseFloat`, `_CachedIOGroupwiseInt`:
  metadata-only caching now stores `torch.empty(0)` as the value placeholder instead
  of `None`. A `None` value is not valid inside a `torch.Tensor` subclass and breaks
  `torch.compile` graph tracing.

### Notebook (`notebooks/minifloat_mx_tutorial.ipynb`)

- Minor output cell refresh (3 lines updated).

---

## Behavioral / Migration Notes

Code that worked with the old `NamedTuple`-based `QuantTensor` may need updates in
the following areas:

| Old behaviour | New behaviour |
|---|---|
| `isinstance(qt, tuple)` → `True` | `isinstance(qt, tuple)` → `False` |
| `isinstance(qt, torch.Tensor)` → `False` | `isinstance(qt, torch.Tensor)` → `True` |
| `len(qt._fields) == 6` for `IntQuantTensor` | `len(qt._fields) == 5` (`value` is no longer a field) |
| `qt._replace(scale=s)` (NamedTuple API) | `qt.set(scale=s)` (already the public API) |
| `qt.tensor` (alias for `.value`) | Removed; use `.value` directly |
| `qt.set(value=None)` for metadata-only caching | `qt.set(value=torch.empty(0))` |
| `qt[0]`, `qt[1]`, … index access | Not supported; use named properties instead |
| `QuantTensor` decays to `tuple` during tracing | Does not decay; tracing treats it as a `Tensor` |

The public `.value`, `.scale`, `.zero_point`, `.bit_width` (and float equivalents)
property API is unchanged.

---

## Testing

- **`tests/brevitas/quant_tensor/test_quant_tensor.py`** — updated assertions:
  `isinstance(qt, torch.Tensor)` (was `tuple`); `len(qt._fields) == 5` (was 6).

- **`tests/brevitas/quant_tensor/test_quant_tensor_subclass.py`** (new, 513 lines) —
  comprehensive test suite covering the new subclass behaviour:
  - `TestIsInstance` — `IntQuantTensor`, `FloatQuantTensor`, `GroupwiseFloatQuantTensor`
    are all `isinstance` of `torch.Tensor` and `QuantTensor`.
  - `TestValueProperty` — `.value` returns a plain `torch.Tensor` (not a subclass);
    `.value` and `self` share data; `grad_fn` and `requires_grad` are preserved.
  - `TestSetMethod` — `set()` replaces fields correctly, preserves type, no-args copy.
  - `TestInPlaceOperators` — `+=`, `*=`, `-=` return valid results and preserve type.
  - `TestTorchFunctionFallback` — unhandled functions fall back to plain tensor output
    without recursion; handled functions (`relu`, `max_pool2d`) route correctly.
  - `TestTensorOps` — `detach()`, `contiguous()`, `to(dtype)` preserve type and metadata.
  - `TestUnpackQuantTensor` — plain tensor passthrough; tuple/dict/nested unpacking.
  - `TestRightHandOperators` — `__radd__`, `__rmul__` with plain-tensor LHS.
  - `TestFields` — `_fields` contents for `Int`, `Float`, `GroupwiseFloat` variants.
  - `TestShapeSizeDim` — `.shape`, `.size()`, `.dim()` delegate correctly.
  - `TestConstructionFromNonTensor` — construction from Python float or list.
  - `TestDynamoExportCacheClass` — `_CachedIO` metadata-only path works end-to-end.
