### PR TITLE
Feat (llm): changing default for dataset_eval_split

### DIFF
--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -56,7 +56,7 @@ def create_args_parser() -> ArgumentParser:
         '--dataset-eval-split',
         type=str,
         choices=['validation', 'test'],
-        default='validation',
+        default='test',
         help='Specify which split to use for the evaluation dataset (default: %(default)s)')
     parser.add_argument(
         '--gpxq-block-name',

--- a/src/brevitas_examples/papers/expansion/double_quarot_star.yaml
+++ b/src/brevitas_examples/papers/expansion/double_quarot_star.yaml
@@ -12,6 +12,8 @@ convert_layernorm_to_rmsnorm:
 - false
 dataset:
 - wikitext2
+dataset_eval_split:
+- validation
 dtype:
 - bfloat16
 eval:

--- a/src/brevitas_examples/papers/expansion/double_spinquant_star.yaml
+++ b/src/brevitas_examples/papers/expansion/double_spinquant_star.yaml
@@ -12,6 +12,8 @@ convert_layernorm_to_rmsnorm:
 - false
 dataset:
 - wikitext2
+dataset_eval_split:
+- validation
 dtype:
 - float32
 eval:

--- a/src/brevitas_examples/papers/expansion/quarot_star.yaml
+++ b/src/brevitas_examples/papers/expansion/quarot_star.yaml
@@ -12,6 +12,8 @@ convert_layernorm_to_rmsnorm:
 - false
 dataset:
 - wikitext2
+dataset_eval_split:
+- validation
 dtype:
 - bfloat16
 eval:

--- a/src/brevitas_examples/papers/expansion/quarot_star_mxfp4.yaml
+++ b/src/brevitas_examples/papers/expansion/quarot_star_mxfp4.yaml
@@ -12,6 +12,8 @@ convert_layernorm_to_rmsnorm:
 - false
 dataset:
 - wikitext2
+dataset_eval_split:
+- validation
 dtype:
 - bfloat16
 eval:

--- a/src/brevitas_examples/papers/expansion/spinquant_star.yaml
+++ b/src/brevitas_examples/papers/expansion/spinquant_star.yaml
@@ -12,6 +12,8 @@ convert_layernorm_to_rmsnorm:
 - false
 dataset:
 - wikitext2
+dataset_eval_split:
+- validation
 dtype:
 - float32
 eval:

--- a/src/brevitas_examples/papers/expansion/spinquant_star_mxfp4.yaml
+++ b/src/brevitas_examples/papers/expansion/spinquant_star_mxfp4.yaml
@@ -12,6 +12,8 @@ convert_layernorm_to_rmsnorm:
 - false
 dataset:
 - wikitext2
+dataset_eval_split:
+- validation
 dtype:
 - float32
 eval:

--- a/src/brevitas_examples/papers/learned_round/learned_round_mxfp4.yaml
+++ b/src/brevitas_examples/papers/learned_round/learned_round_mxfp4.yaml
@@ -16,6 +16,8 @@ nsamples:
 - 512
 dataset:
 - pile
+dataset_eval_split:
+- validation
 # adds a BOS token to the beginning of each sequence
 bos_preprocessing:
 - sequence

--- a/src/brevitas_examples/papers/learned_round/learned_round_mxfp4_spinquant.yaml
+++ b/src/brevitas_examples/papers/learned_round/learned_round_mxfp4_spinquant.yaml
@@ -16,6 +16,8 @@ nsamples:
 - 512
 dataset:
 - pile
+dataset_eval_split:
+- validation
 # adds a BOS token to the beginning of each sequence
 bos_preprocessing:
 - sequence

--- a/src/brevitas_examples/papers/learned_round/learned_round_weight_act.yaml
+++ b/src/brevitas_examples/papers/learned_round/learned_round_weight_act.yaml
@@ -16,6 +16,8 @@ nsamples:
 - 512
 dataset:
 - pile
+dataset_eval_split:
+- validation
 # adds a BOS token to the beginning of each sequence
 bos_preprocessing:
 - sequence

--- a/src/brevitas_examples/papers/learned_round/learned_round_weight_act_spinquant.yaml
+++ b/src/brevitas_examples/papers/learned_round/learned_round_weight_act_spinquant.yaml
@@ -16,6 +16,8 @@ nsamples:
 - 512
 dataset:
 - pile
+dataset_eval_split:
+- validation
 # adds a BOS token to the beginning of each sequence
 bos_preprocessing:
 - sequence

--- a/src/brevitas_examples/papers/learned_round/learned_round_weight_only.yaml
+++ b/src/brevitas_examples/papers/learned_round/learned_round_weight_only.yaml
@@ -16,6 +16,8 @@ nsamples:
 - 512
 dataset:
 - pile
+dataset_eval_split:
+- validation
 # adds a BOS token to the beginning of each sequence
 bos_preprocessing:
 - sequence

--- a/src/brevitas_examples/papers/learned_round/learned_round_weight_only_spinquant.yaml
+++ b/src/brevitas_examples/papers/learned_round/learned_round_weight_only_spinquant.yaml
@@ -16,6 +16,8 @@ nsamples:
 - 512
 dataset:
 - pile
+dataset_eval_split:
+- validation
 # adds a BOS token to the beginning of each sequence
 bos_preprocessing:
 - sequence

--- a/src/brevitas_examples/papers/qronos/llama3-gguf-q4_0.yml
+++ b/src/brevitas_examples/papers/qronos/llama3-gguf-q4_0.yml
@@ -14,6 +14,7 @@ few_shot_tasks:
 - leaderboard|arc:challenge|0|0
 - leaderboard|winogrande|0|0
 - leaderboard|hellaswag|0|0
+dataset_eval_split: validation
 gpxq_act_order: true
 gpxq_block_name: model.layers
 model: meta-llama/Llama-3.2-1B

--- a/src/brevitas_examples/papers/qronos/llama3-w2-hip-magr.yml
+++ b/src/brevitas_examples/papers/qronos/llama3-w2-hip-magr.yml
@@ -14,6 +14,7 @@ few_shot_tasks:
 - leaderboard|winogrande|0|0
 - leaderboard|hellaswag|0|0
 few_shot_zeroshot: true
+dataset_eval_split: validation
 # enables ordering by diagonal of H
 gpxq_act_order: true
 # enables block-level optimization

--- a/src/brevitas_examples/papers/qronos/llama3-w4-base.yml
+++ b/src/brevitas_examples/papers/qronos/llama3-w4-base.yml
@@ -14,6 +14,7 @@ few_shot_tasks:
 - leaderboard|winogrande|0|0
 - leaderboard|hellaswag|0|0
 few_shot_zeroshot: true
+dataset_eval_split: validation
 # enables ordering by diagonal of H
 gpxq_act_order: true
 # enables block-level optimization

--- a/src/brevitas_examples/papers/qronos/llama3-w4a4-int-quarot.yml
+++ b/src/brevitas_examples/papers/qronos/llama3-w4a4-int-quarot.yml
@@ -14,6 +14,7 @@ few_shot_tasks:
 - leaderboard|winogrande|0|0
 - leaderboard|hellaswag|0|0
 few_shot_zeroshot: true
+dataset_eval_split: validation
 # enables ordering by diagonal of H
 gpxq_act_order: true
 gpxq_block_name: model.layers

--- a/src/brevitas_examples/papers/qronos/llama3-w4a4-int-spinquant.yml
+++ b/src/brevitas_examples/papers/qronos/llama3-w4a4-int-spinquant.yml
@@ -14,6 +14,7 @@ few_shot_tasks:
 - leaderboard|winogrande|0|0
 - leaderboard|hellaswag|0|0
 few_shot_zeroshot: true
+dataset_eval_split: validation
 # enables ordering by diagonal of H
 gpxq_act_order: true
 gpxq_block_name: model.layers

--- a/src/brevitas_examples/papers/qronos/llama3-w4a4-mxfp-quarot.yml
+++ b/src/brevitas_examples/papers/qronos/llama3-w4a4-mxfp-quarot.yml
@@ -14,6 +14,7 @@ few_shot_tasks:
 - leaderboard|winogrande|0|0
 - leaderboard|hellaswag|0|0
 few_shot_zeroshot: true
+dataset_eval_split: validation
 # enables ordering by diagonal of H
 gpxq_act_order: true
 gpxq_block_name: model.layers

--- a/src/brevitas_examples/papers/qronos/llama3-w4a4-mxfp-spinquant.yml
+++ b/src/brevitas_examples/papers/qronos/llama3-w4a4-mxfp-spinquant.yml
@@ -14,6 +14,7 @@ few_shot_tasks:
 - leaderboard|winogrande|0|0
 - leaderboard|hellaswag|0|0
 few_shot_zeroshot: true
+dataset_eval_split: validation
 # enables ordering by diagonal of H
 gpxq_act_order: true
 gpxq_block_name: model.layers

--- a/tests/brevitas_examples/llm_test_template.yml
+++ b/tests/brevitas_examples/llm_test_template.yml
@@ -7,6 +7,7 @@ bias_corr: false
 checkpoint_name: null
 convert_layernorm_to_rmsnorm: false
 dataset: wikitext2
+dataset_eval_split: validation
 disable_create_weight_orig: false
 eval: false
 export_prefix: null

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -60,7 +60,7 @@ RTOL_ACC = 1e-5
 
 def mock_load_raw_dataset(dataset_name: str, split: str, seed: int = 42) -> Dataset:
     assert dataset_name == "c4", f"Expected dataset_name to be c4 but got {dataset_name} instead"
-    assert split in ["train", "validation"], f"Expected split to be 'train' or 'validation' but got "
+    assert split in ["train", "validation"], f"Expected split to be 'train' or 'validation' but got {split}"
     # Contains information from allenai/c4 (https://huggingface.co/datasets/allenai/c4) which is made available under the ODC Attribution License.
     C4_TEXTS = [
         "Luxembourg's professional networking group for women will host a discussion about promoting Luxembourg abroad.\n(JB) Luxembourg's female only professional networking group will host a discussion about promoting Luxembourg abroad.\nSpeaker Carole Tompers, who is responsible for promoting the Made in Luxembourg products and services to foreign markets, will take guests on a whistle stop tour of the country's key assets.\nHer speech will explore the Nations Brand Index 2010, delve into what makes a Luxembourg brand and suggest ways of strengthening and promoting existing brands abroad.\nMs Tompers has a strong track record in marketing and communications. She currently serves as Secretary General at Luxembourg for Business.\nShe has previously worked on promotional projects with various ministries, the Chamber of Commerce, the Office Ducroire, the National Credit and Investment Corporation, the Chamber of Crafts and Luxembourg's Business Federation.\nThe event is organised by the Network at the Sofitel Kirchberg on November 16, from 7.30pm."
@@ -152,6 +152,7 @@ def default_run_args(parser: ArgumentParser, request):
     args.seqlen = 2
     args.model = "hf-internal-testing/tiny-random-MistralForCausalLM"
     args.dataset = "c4"
+    args.dataset_eval_split = "validation"
     args.eval = True
     #args.checkpoint = ptid2pathname(request.node.nodeid) + ".pth" # Example filename which won't clash
     args.export_prefix = ptid2pathname(request.node.nodeid)


### PR DESCRIPTION
## Reason for this PR

This pull request makes a minor update to the default behavior of the evaluation dataset split in the LLM example arguments parser. The default value for the `--dataset-eval-split` argument has been changed from `'validation'` to `'test'`.


<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

 Changed the default value of the `--dataset-eval-split` argument in `create_args_parser` (in `src/brevitas_examples/llm/llm_args.py`) from `'validation'` to `'test'`.

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

N/A

<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

N/A

<!--
Please add any additional comments to help reviewers and maintainers.
-->

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
