### PR TITLE
Fix (Qronos): Align G matrix convention with GPFQ

### DIFF
--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -65,10 +65,10 @@ class Qronos(GPFQ):
             inp_processed /= math.sqrt(
                 self.nsamples)  # NOTE: quant_input is normalized before, in the H update
             if self.use_intermediate_buffer:
-                self.B.copy_(inp_processed.bmm(self.quant_input.transpose(2, 1)))
+                self.B.copy_(self.quant_input.bmm(inp_processed.transpose(2, 1)))
                 self.G += self.B
             else:
-                self.G += inp_processed.bmm(self.quant_input.transpose(2, 1))
+                self.G += self.quant_input.bmm(inp_processed.transpose(2, 1))
             self.quant_input = None  # NOTE: set back to None now that we've used it
         else:
             # Computing the normalized H matrix
@@ -191,7 +191,7 @@ class Qronos(GPFQ):
             q: Tensor = q_groups[group_index].to(self.dtype)
             v: Tensor = weight[group_index, :, perm].to(self.dtype)
             w: Tensor = weight_orig[group_index, :, perm].to(self.dtype)
-            Gw = w.matmul(self.G[group_index, :, 0] * Dhi[group_index, 0])
+            Gw = w.matmul(self.G[group_index, 0, :] * Dhi[group_index, 0])
             Uv = v.matmul(Uh[group_index, 0, :] * Dhi[group_index, 0])
             q_arg = Gw - Uv
             assert (q_arg >= dtype_min).all() and (q_arg <= dtype_max).all()
@@ -211,7 +211,7 @@ class Qronos(GPFQ):
             q: Tensor = q_groups[group_index].to(self.dtype)
             w: Tensor = weight_orig[group_index, :, perm].to(self.dtype)
             Ih = torch.diag(torch.full((self.columns,), damp[group_index], device=dev))
-            Gh = self.G[group_index] + Ih
+            Gh = self.G[group_index].mT + Ih
             Gw = w.matmul(Gh[:, 1:] @ self.iH[group_index])
             Hq = q.matmul(self.H[group_index, :1, 1:] @ self.iH[group_index])
             weight[group_index, :, perm[1:]] = (Gw - Hq).to(dtype)


### PR DESCRIPTION
## Reason for this PR

The `G` covariance matrix in Qronos is computed as the transpose of the `G` matrix in GPFQ (`G = X_f @ X_q^T` vs `G = X_q @ X_f^T`), despite both being the same conceptual quantity. Since GPFQ is the base class and its convention is shared by A2GPFQ, this inconsistency hurts readability and makes it harder to reason about the code across algorithms.

## Changes Made in this PR

Aligned Qronos's `G` matrix convention with GPFQ's so that `G = X_q @ X_f^T` consistently across all algorithms.

Three changes in `src/brevitas/graph/qronos.py`:

1. **`update_batch`**: Swapped `bmm` operands from `inp_processed.bmm(self.quant_input.transpose(2, 1))` to `self.quant_input.bmm(inp_processed.transpose(2, 1))`, matching GPFQ.
2. **`single_layer_update` (first loop of step step 1)**: Changed `self.G[group_index, :, 0]` (column access) to `self.G[group_index, 0, :]` (row access) to account for the transposed storage.
3. **`single_layer_update` (third loop of step 1)**: Changed `self.G[group_index] + Ih` to `self.G[group_index].mT + Ih`, explicitly transposing where the original math requires the old convention.

All other `self.G` accesses (scaling, permutation, NaN checks, device moves, cleanup) are convention-agnostic and required no changes. No changes were needed in GPFQ or A2GPFQ.

## Testing Summary

- Tests run locally.
- Ran an experiment for both the previous and updated Qronos versions quantizing a Llama 1B model to int4. Both achieved the same result, a quantized perplexity of 16.625.