### PR TITLE
  Fix (Qronos): replace in-place input normalization in update_batch

### DIFF
--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -62,7 +62,7 @@ class Qronos(GPFQ):
         if not is_quant_enabled:
             # Computing the normalized G matrix
             self.G *= (self.nsamples - batch_size) / self.nsamples
-            inp_processed /= math.sqrt(
+            inp_processed = inp_processed / math.sqrt(
                 self.nsamples)  # NOTE: quant_input is normalized before, in the H update
             if self.use_intermediate_buffer:
                 self.B.copy_(inp_processed.bmm(self.quant_input.transpose(2, 1)))
@@ -74,7 +74,7 @@ class Qronos(GPFQ):
             # Computing the normalized H matrix
             self.nsamples += batch_size  # NOTE: only increment with quant inputs
             self.H *= (self.nsamples - batch_size) / self.nsamples
-            inp_processed /= math.sqrt(self.nsamples)
+            inp_processed = inp_processed / math.sqrt(self.nsamples)
             if self.use_intermediate_buffer:
                 self.B.copy_(inp_processed.bmm(inp_processed.transpose(2, 1)))
                 self.H += self.B

--- a/tests/brevitas/graph/test_gpxq.py
+++ b/tests/brevitas/graph/test_gpxq.py
@@ -14,6 +14,8 @@ from brevitas.graph.gpfq import gpfq_mode
 from brevitas.graph.gptq import gptq_mode
 from brevitas.graph.magr import magr_mode
 from brevitas.graph.qronos import Qronos
+import brevitas.nn as qnn
+from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 
 from .equalization_fixtures import *
 
@@ -80,6 +82,116 @@ def apply_gptq(
 
 
 apply_gpxq_func_map = {"gpfq": apply_gpfq, "gptq": apply_gptq, "qronos": apply_qronos}
+
+
+class TestQronosUpdateBatch:
+    """Tests for Qronos.update_batch verifying correct H and G normalization."""
+
+    INP = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+
+    @staticmethod
+    def _make_model():
+        """Two QuantLinear layers (2→3→4) with hardcoded weights."""
+
+        class Model(nn.Module):
+
+            def __init__(self):
+                super().__init__()
+                self.linear_0 = qnn.QuantLinear(
+                    2, 3, bias=False, weight_quant=Int8WeightPerTensorFloat)
+                self.linear_1 = qnn.QuantLinear(
+                    3, 4, bias=False, weight_quant=Int8WeightPerTensorFloat)
+
+            def forward(self, x):
+                return self.linear_1(self.linear_0(x))
+
+        model = Model()
+        with torch.no_grad():
+            model.linear_0.weight.copy_(torch.tensor([[0.1, 0.2], [0.3, -0.1], [-0.2, 0.4]]))
+            model.linear_1.weight.copy_(
+                torch.tensor([[0.5, -0.3, 0.1], [0.2, 0.4, -0.2], [-0.1, 0.3, 0.5],
+                              [0.4, -0.1, 0.2]]))
+        return model
+
+    @staticmethod
+    def _calibrate(model, calib_loader):
+        """Run Qronos calibration, return {layer_name: (H, G)} for each layer."""
+        results = {}
+        with torch.no_grad():
+            with gpfq_mode(model, act_order=False, algorithm_impl=Qronos) as algo:
+                for _ in range(algo.num_layers):
+                    for data, _ in calib_loader:
+                        algo.model(data)
+                    for name in algo.current_layer.layer_names:
+                        layer = algo.gpxq_layers[name]
+                        results[name] = (layer.H.clone(), layer.G.clone())
+                    algo.update()
+        return results
+
+    def _make_loader(self, batch_size):
+        dataset = TensorDataset(self.INP, self.INP)
+        return DataLoader(dataset, batch_size=batch_size, shuffle=False)
+
+    def _init_model(self):
+        model = self._make_model()
+        model.eval()
+        model(self.INP)  # collect scaling factors
+        return model
+
+    def test_h_and_g_values(self):
+        """Verify H and G have the correct analytical values.
+
+        For linear_0 (first layer), the input is the known external input in both the
+        quant and float passes (since input_quant=None), so H == G == X @ X.T / N.
+
+        For linear_1, intermediate activations differ between the quant and float passes
+        (weights are quantized in one, float in the other), so H != G in general.
+        We verify H is symmetric (X̂ @ X̂.T) and that G is non-zero.
+
+        Current convention on dev: G = X @ X̂.T / N (float @ quant.T).
+        TODO: If https://github.com/Xilinx/brevitas/pull/1501 is merged, G convention
+        changes to X̂ @ X.T / N (quant @ float.T) and this test must be updated.
+        """
+        results = self._calibrate(self._init_model(), self._make_loader(batch_size=4))
+
+        # linear_0: no input quant, so quant_input == float_input == X
+        x = self.INP.t().unsqueeze(0).float()  # [1, in_features, N]
+        expected = x.bmm(x.transpose(2, 1)) / 4  # X @ X.T / N
+        H0, G0 = results['linear_0']
+        torch.testing.assert_close(H0, expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(G0, expected, atol=1e-5, rtol=1e-5)
+
+        # linear_1: H should be symmetric, both H and G should be non-zero
+        H1, G1 = results['linear_1']
+        torch.testing.assert_close(H1, H1.transpose(1, 2), atol=1e-6, rtol=1e-6)
+        assert H1.abs().sum() > 0
+        assert G1.abs().sum() > 0
+
+    def test_multi_batch_normalization(self):
+        """Runs calibration with 1 batch of 4 vs 2 batches of 2 and asserts H and G
+        are identical for both layers, verifies that the running-average normalization
+        is batch-size invariant."""
+        results_single = self._calibrate(self._init_model(), self._make_loader(batch_size=4))
+        results_multi = self._calibrate(self._init_model(), self._make_loader(batch_size=2))
+
+        for name in results_single:
+            H_s, G_s = results_single[name]
+            H_m, G_m = results_multi[name]
+            torch.testing.assert_close(H_s, H_m, atol=1e-5, rtol=1e-5)
+            torch.testing.assert_close(G_s, G_m, atol=1e-5, rtol=1e-5)
+
+    def test_no_inplace_input_mutation(self):
+        """Clones the input before each forward pass and asserts it was not modified,
+        catching any in-place normalization (e.g. /=) in update_batch that would
+        corrupt inputs."""
+        model = self._init_model()
+        with torch.no_grad():
+            with gpfq_mode(model, act_order=False, algorithm_impl=Qronos) as algo:
+                for _ in range(algo.num_layers):
+                    for data, _ in self._make_loader(batch_size=2):
+                        data_before = data.clone()
+                        algo.model(data)
+                        torch.testing.assert_close(data, data_before)
 
 
 @pytest.mark.parametrize("act_order", [True, False])


### PR DESCRIPTION
## Reason for this PR

`Qronos.update_batch` uses in-place division (`/=`) to normalize the processed input tensor. Since `process_input` can return a view of the original input, in such cases the in-place operation mutates the tensor for subsequent passes/computation of the G matrix.

This bug was introduced in https://github.com/Xilinx/brevitas/pull/1440.

## Changes Made in this PR

**Bug fix (`src/brevitas/graph/qronos.py`):**
- Replaced two in-place normalizations (`inp_processed /= math.sqrt(...)`) with out-of-place versions (`inp_processed = inp_processed / math.sqrt(...)`) in both the quant and float branches of `update_batch`. This prevents mutation of shared input tensors.

**Tests (`tests/brevitas/graph/test_gpxq.py`):**
- Added `TestQronosUpdateBatch` class with a minimal two-layer `QuantLinear` model (2→3→4) using hardcoded weights, and three tests:
  - `test_h_and_g_values`: Verifies H and G match the analytical `X @ X.T / N` for the first layer (where quant and float inputs are identical), and checks structural properties (symmetry, non-zero) for the second layer.
  - `test_multi_batch_normalization`: Runs calibration with a single batch of 4 vs two batches of 2, asserts H and G are identical for both layers, proving the running-average normalization is batch-size invariant.
  - `test_no_inplace_input_mutation`: Clones the input before each forward pass and asserts it was not modified, directly catching the in-place `/=` bug.

## Testing Summary

- All 3 new tests pass locally.
- All 190 tests in `test_gpxq.py` pass (187 existing + 3 new).
- Verified the tests correctly fail when the in-place `/=` bug is reintroduced.

## Risk Highlight

- If https://github.com/Xilinx/brevitas/pull/1501 is merged (which changes the G matrix convention from `X @ X̂.T` to `X̂ @ X.T`), `test_h_and_g_values` will need to be updated. This is noted as a TODO in the test code.