### PR TITLE
Feat (utils): replace weights with quantized ones

### DIFF
--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -98,25 +98,23 @@ def merge_quant_weights(
 
     hooks: List[RemovableHandle] = []
     proxy_list: List[WeightQuantProxyFromInjectorBase] = []
+    module_tensor_id_mapping: Dict = {}
 
     def hook(module: WeightQuantProxyFromInjectorBase, args: Tuple[Any, ...], output: Any) -> None:
-        module_tensor_id_mapping: Dict = {}
         input_tensor = args[0]
         with torch.no_grad():
             for m in module.tracked_module_list:
                 # We match the module based on its weights and the ID of the tensor to quantize
                 if id(m.weight.data) == id(input_tensor.data):
-                    # We track how many modules have been converted
-                    module_tensor_id_mapping[m] = [output.value.data]
-
-            if len(module_tensor_id_mapping) == len(module.tracked_module_list):
-                for quant_module, new_weights in module_tensor_id_mapping.items():
                     quant_module.weight.data = output.value.data
-                proxy_list.append(module)
-            else:
-                warnings.warn(
-                    "Could not match all the modules to their weights, skipping quantizer")
+                    # We track how many modules have been converted
+                    if module not in module_tensor_id_mapping:
+                        module_tensor_id_mapping[module] = 1
+                    else:
+                        module_tensor_id_mapping[module] += 1
+            proxy_list.append(module)
 
+    
     # Register Proxy hooks
     for module in model.modules():
         if not isinstance(module, WeightQuantProxyFromInjectorBase):
@@ -133,10 +131,13 @@ def merge_quant_weights(
         for h in hooks:
             h.remove()
         hooks.clear()
+    
 
     # Reset quantizers from LEARNED_ROUND to ROUND
     with torch.no_grad():
         for module in proxy_list:
+            if module_tensor_id_mapping[module] < len(module.tracked_module_list):
+                raise RuntimeError("Not all weights associated to this quantizer were replaced")
             _reset_quantizer(module)
 
 

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -108,15 +108,15 @@ def merge_quant_weights(
                 if id(m.weight.data) == id(input_tensor.data):
                     # We track how many modules have been converted
                     module_tensor_id_mapping[m] = [output.value.data]
-            
+
             if len(module_tensor_id_mapping) == len(module.tracked_module_list):
-                for quant_module, new_weights in module_tensor_id_mapping:
+                for quant_module, new_weights in module_tensor_id_mapping.items():
                     quant_module.weight.data = output.value.data
                 proxy_list.append(module)
             else:
                 warnings.warn(
                     "Could not match all the modules to their weights, skipping quantizer")
-            
+
     # Register Proxy hooks
     for module in model.modules():
         if not isinstance(module, WeightQuantProxyFromInjectorBase):

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -99,8 +99,7 @@ def merge_quant_weights(
     hooks: List[RemovableHandle] = []
     module_tensor_id_mapping: Dict = {}
 
-    def hook(
-            module: WeightQuantProxyFromInjectorBase, args: Tuple[Any, ...], output: Any) -> None:
+    def hook(module: WeightQuantProxyFromInjectorBase, args: Tuple[Any, ...], output: Any) -> None:
         input_tensor = args[0]
         with torch.no_grad():
             for m in module.tracked_module_list:

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -10,10 +11,8 @@ from torch.nn import Parameter
 from torch.utils.hooks import RemovableHandle
 
 from brevitas import config
-from brevitas.core.function_wrapper.learned_round import LearnedRoundSte
 from brevitas.inject.enum import FloatToIntImplType
 from brevitas.inject.enum import ScalingImplType
-from brevitas.quant_tensor import _unpack_quant_tensor
 from brevitas.utils.torch_utils import compute_channel_view_shape
 
 
@@ -70,115 +69,104 @@ def rename_state_dict_by_postfix(old_postfix, new_postfix, state_dict):
         state_dict[keys_map[old_key]] = state_dict.pop(old_key)
 
 
-class merge_quant_weights:
-    """Context manager that merges quantized weights into model weights.
+def merge_quant_weights(
+        model: torch.nn.Module,
+        example_input: torch.Tensor,
+        preserve_original_weights: bool = False) -> None:
+    """Merge quantized weights into model weights.
 
     This could be useful for example with Learned Round.
     After learned round training, the rounding decision for each weight element is
-    deterministic. This context manager uses forward hooks to discover the association
+    deterministic. This function uses forward hooks to discover the association
     between weight tensors and its quantized counterparts, and update the module's weights.
+    A single forward pass is performed using ``example_input``.
 
     Usage::
 
         model.eval()
-        with merge_learned_round(model):
-            model(sample_input)
+        merge_quant_weights(model, sample_input)
         # Weights are now merged and rounding mode is ROUND.
 
     Args:
         model: A model containing quantised layers with learned round quantisers.
+        example_input: A single example input tensor used to run the forward pass.
+        preserve_original_weights: If ``True``, the original weights are saved to
+            ``m.weight_orig`` before overwriting (default ``False``).
     """
+    # Imported here to avoid a circular import
+    from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjectorBase
 
-    def __init__(
-            self,
-            model: torch.nn.Module,
-            disable_quant: bool = True,
-            preserve_original_weights: bool = False) -> None:
-        self._model = model
-        self._hooks: List[RemovableHandle] = []
-        self._module_tensor_id_mapping = {}
-        self.disable_quant = disable_quant
-        self.hook_check = False
-        self.preserve_original_weights = preserve_original_weights
+    hooks: List[RemovableHandle] = []
+    module_tensor_id_mapping: Dict = {}
 
-    def __enter__(self) -> 'merge_quant_weights':
-        # Imported here to avoid a circular import
-        from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjectorBase
-
-        def model_hook(module, args, output):
-            if self.hook_check:
-                raise RuntimeError(
-                    "Calling multiple forward pass within the context manager is not supported")
-            self.hook_check = True
-
-        def hook(module, args, output):
-            input_tensor = args[0]
-            with torch.no_grad():
-                for m in module.tracked_module_list:
-                    # We match the module based on its weights and the ID of the tensor to quantize
-                    if id(m.weight.data) == id(input_tensor.data):
-                        if self.preserve_original_weights:
-                            m.weight_orig = m.weight.data.cpu()
-                        m.weight.data = output.value.data
-                        # We track how many modules have been converted
-                        if module not in self._module_tensor_id_mapping:
-                            self._module_tensor_id_mapping[module] = [id(m.weight.data)]
-                        else:
-                            self._module_tensor_id_mapping[module].append(id(m.weight.data))
-
-        # Register Proxy hooks
-        for module in self._model.modules():
-            if not isinstance(module, WeightQuantProxyFromInjectorBase):
-                continue
-            self.change_scale_impl_type(module)
-            handle = module.register_forward_hook(hook)
-            self._hooks.append(handle)
-
-        # Register Model hook
-        handle = self._model.register_forward_hook(model_hook)
-        self._hooks.append(handle)
-
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        for hook in self._hooks:
-            hook.remove()
-        self._hooks.clear()
-
+    def hook(
+            module: 'WeightQuantProxyFromInjectorBase', args: Tuple[Any, ...], output: Any) -> None:
+        input_tensor = args[0]
         with torch.no_grad():
-            for module in self._module_tensor_id_mapping:
-                self._reset_quantizer(module)
+            for m in module.tracked_module_list:
+                # We match the module based on its weights and the ID of the tensor to quantize
+                if id(m.weight.data) == id(input_tensor.data):
+                    if preserve_original_weights:
+                        m.weight_orig = m.weight.data.cpu()
+                    m.weight.data = output.value.data
+                    # We track how many modules have been converted
+                    if module not in module_tensor_id_mapping:
+                        module_tensor_id_mapping[module] = [id(m.weight.data)]
+                    else:
+                        module_tensor_id_mapping[module].append(id(m.weight.data))
 
-    def change_scale_impl_type(self, proxy) -> None:
-        reinit_on_state_dict = config.REINIT_ON_STATE_DICT_LOAD
-        ignore_missing_key = config.IGNORE_MISSING_KEYS
-        config.REINIT_ON_STATE_DICT_LOAD = False
-        config.IGNORE_MISSING_KEYS = True
-        state_dict = proxy.state_dict()
-        proxy.quant_injector = proxy.quant_injector.let(
-            scaling_impl_type=ScalingImplType.PARAMETER_FROM_STATS)
-        proxy.init_tensor_quant()
-        proxy.load_state_dict(state_dict, strict=False)
-        config.IGNORE_MISSING_KEYS = ignore_missing_key
-        config.REINIT_ON_STATE_DICT_LOAD = reinit_on_state_dict
+    # Register Proxy hooks
+    for module in model.modules():
+        if not isinstance(module, WeightQuantProxyFromInjectorBase):
+            continue
+        _change_scale_impl_type(module)
+        handle = module.register_forward_hook(hook)
+        hooks.append(handle)
 
-    @staticmethod
-    def _reset_quantizer(proxy) -> None:
-        """Switch a weight quant proxy from LearnedRound back to standard Round."""
-        reinit_on_state_dict = config.REINIT_ON_STATE_DICT_LOAD
-        ignore_missing_key = config.IGNORE_MISSING_KEYS
-        config.REINIT_ON_STATE_DICT_LOAD = False
-        config.IGNORE_MISSING_KEYS = True
-        state_dict = {
-            k: v for k,
-            v in proxy.state_dict().items() if not k.endswith('float_to_int_impl.value')}
+    # Run a single forward pass to trigger the hooks
+    try:
+        model(example_input)
+    finally:
+        # Remove all hooks
+        for h in hooks:
+            h.remove()
+        hooks.clear()
 
-        proxy.quant_injector = proxy.quant_injector.let(
-            float_to_int_impl_type=FloatToIntImplType.ROUND)
-        proxy.init_tensor_quant()
-        proxy.load_state_dict(state_dict, strict=False)
-        config.IGNORE_MISSING_KEYS = ignore_missing_key
-        config.REINIT_ON_STATE_DICT_LOAD = reinit_on_state_dict
+    # Reset quantizers from LEARNED_ROUND to ROUND
+    with torch.no_grad():
+        for module in module_tensor_id_mapping:
+            _reset_quantizer(module)
+
+
+def _change_scale_impl_type(proxy) -> None:
+    """Change the scaling implementation type to PARAMETER_FROM_STATS."""
+    reinit_on_state_dict = config.REINIT_ON_STATE_DICT_LOAD
+    ignore_missing_key = config.IGNORE_MISSING_KEYS
+    config.REINIT_ON_STATE_DICT_LOAD = False
+    config.IGNORE_MISSING_KEYS = True
+    state_dict = proxy.state_dict()
+    proxy.quant_injector = proxy.quant_injector.let(
+        scaling_impl_type=ScalingImplType.PARAMETER_FROM_STATS)
+    proxy.init_tensor_quant()
+    proxy.load_state_dict(state_dict, strict=False)
+    config.IGNORE_MISSING_KEYS = ignore_missing_key
+    config.REINIT_ON_STATE_DICT_LOAD = reinit_on_state_dict
+
+
+def _reset_quantizer(proxy) -> None:
+    """Switch a weight quant proxy from LearnedRound back to standard Round."""
+    reinit_on_state_dict = config.REINIT_ON_STATE_DICT_LOAD
+    ignore_missing_key = config.IGNORE_MISSING_KEYS
+    config.REINIT_ON_STATE_DICT_LOAD = False
+    config.IGNORE_MISSING_KEYS = True
+    state_dict = {
+        k: v for k, v in proxy.state_dict().items() if not k.endswith('float_to_int_impl.value')}
+
+    proxy.quant_injector = proxy.quant_injector.let(float_to_int_impl_type=FloatToIntImplType.ROUND)
+    proxy.init_tensor_quant()
+    proxy.load_state_dict(state_dict, strict=False)
+    config.IGNORE_MISSING_KEYS = ignore_missing_key
+    config.REINIT_ON_STATE_DICT_LOAD = reinit_on_state_dict
 
 
 def check_tensors_same_ptr(tensor_list):

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -100,7 +100,7 @@ def merge_quant_weights(
     module_tensor_id_mapping: Dict = {}
 
     def hook(
-            module: 'WeightQuantProxyFromInjectorBase', args: Tuple[Any, ...], output: Any) -> None:
+            module: WeightQuantProxyFromInjectorBase, args: Tuple[Any, ...], output: Any) -> None:
         input_tensor = args[0]
         with torch.no_grad():
             for m in module.tracked_module_list:

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -106,7 +106,7 @@ def merge_quant_weights(
             for m in module.tracked_module_list:
                 # We match the module based on its weights and the ID of the tensor to quantize
                 if id(m.weight.data) == id(input_tensor.data):
-                    quant_module.weight.data = output.value.data
+                    m.weight.data = output.value.data
                     # We track how many modules have been converted
                     if module not in module_tensor_id_mapping:
                         module_tensor_id_mapping[module] = 1

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -114,7 +114,6 @@ def merge_quant_weights(
                         module_tensor_id_mapping[module] += 1
             proxy_list.append(module)
 
-    
     # Register Proxy hooks
     for module in model.modules():
         if not isinstance(module, WeightQuantProxyFromInjectorBase):
@@ -131,7 +130,6 @@ def merge_quant_weights(
         for h in hooks:
             h.remove()
         hooks.clear()
-    
 
     # Reset quantizers from LEARNED_ROUND to ROUND
     with torch.no_grad():

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -97,23 +97,25 @@ def merge_quant_weights(
     from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjectorBase
 
     hooks: List[RemovableHandle] = []
-    module_tensor_id_mapping: Dict = {}
+    proxy_list: List[WeightQuantProxyFromInjectorBase] = []
 
     def hook(module: WeightQuantProxyFromInjectorBase, args: Tuple[Any, ...], output: Any) -> None:
+        module_tensor_id_mapping: Dict = {}
         input_tensor = args[0]
         with torch.no_grad():
             for m in module.tracked_module_list:
                 # We match the module based on its weights and the ID of the tensor to quantize
                 if id(m.weight.data) == id(input_tensor.data):
-                    if preserve_original_weights:
-                        m.weight_orig = m.weight.data.cpu()
-                    m.weight.data = output.value.data
                     # We track how many modules have been converted
-                    if module not in module_tensor_id_mapping:
-                        module_tensor_id_mapping[module] = [id(m.weight.data)]
-                    else:
-                        module_tensor_id_mapping[module].append(id(m.weight.data))
-
+                    module_tensor_id_mapping[m] = [output.value.data]
+            
+            if len(module_tensor_id_mapping == len(module.tracked_module_list)):
+                for quant_module, new_weights in module_tensor_id_mapping:
+                    quant_module.weight.data = output.value.data
+                proxy_list.append(module)
+            else:
+                warnings.warn("Could not match all the modules to their weights, skipping quantizer")
+            
     # Register Proxy hooks
     for module in model.modules():
         if not isinstance(module, WeightQuantProxyFromInjectorBase):
@@ -133,7 +135,7 @@ def merge_quant_weights(
 
     # Reset quantizers from LEARNED_ROUND to ROUND
     with torch.no_grad():
-        for module in module_tensor_id_mapping:
+        for module in proxy_list:
             _reset_quantizer(module)
 
 

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -1,9 +1,17 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from typing import Dict
+from typing import List
+from typing import Tuple
+
 import torch
 from torch.nn import Parameter
+from torch.utils.hooks import RemovableHandle
 
+from brevitas import config
+from brevitas.core.function_wrapper.learned_round import LearnedRoundSte
+from brevitas.inject.enum import FloatToIntImplType
 from brevitas.utils.torch_utils import compute_channel_view_shape
 
 
@@ -58,6 +66,81 @@ def rename_state_dict_by_postfix(old_postfix, new_postfix, state_dict):
             keys_map[k] = new_key
     for old_key in keys_map.keys():
         state_dict[keys_map[old_key]] = state_dict.pop(old_key)
+
+
+class merge_quant_weights:
+    """Context manager that merges quantized weights into model weights.
+
+    This could be useful for example with Learned Round.
+    After learned round training, the rounding decision for each weight element is
+    deterministic. This context manager uses forward hooks to discover the association
+    between weight tensors and its quantized counterparts, and update the module's weights.
+
+    Usage::
+
+        model.eval()
+        with merge_learned_round(model):
+            model(sample_input)
+        # Weights are now merged and rounding mode is ROUND.
+
+    Args:
+        model: A model containing quantised layers with learned round quantisers.
+    """
+
+    def __init__(self, model: torch.nn.Module) -> None:
+        self._model = model
+        self._hooks: List[RemovableHandle] = []
+        self._modules_list = []
+
+    def __enter__(self) -> 'merge_learned_round':
+        # Imported here to avoid a circular import
+        from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjectorBase
+
+        def hook(module, args, output):
+            input_tensor = args[0]
+            with torch.no_grad():
+                for m in module.tracked_module_list:
+                    if id(m.weight.data) == id(input_tensor.data):
+                        m.weight.data = output[0].data
+
+        for module in self._model.modules():
+            if not isinstance(module, WeightQuantProxyFromInjectorBase):
+                continue
+
+            hook = module.register_forward_hook(hook)
+            self._hooks.append(hook)
+            self._modules_list.append(module)
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        for hook in self._hooks:
+            hook.remove()
+        self._hooks.clear()
+
+        with torch.no_grad():
+            for module in self._modules_list:
+                self._reset_quantizer(module)
+
+    @staticmethod
+    def _reset_quantizer(proxy) -> None:
+        """Switch a weight quant proxy from LearnedRound back to standard Round."""
+        reinit_on_state_dict = config.REINIT_ON_STATE_DICT_LOAD
+        ignore_missing_key = config.IGNORE_MISSING_KEYS
+        config.REINIT_ON_STATE_DICT_LOAD = False
+        config.IGNORE_MISSING_KEYS = True
+        try:
+            state_dict = {
+                k: v for k,
+                v in proxy.state_dict().items() if not k.endswith('float_to_int_impl.value')}
+
+            proxy.quant_injector = proxy.quant_injector.let(
+                float_to_int_impl_type=FloatToIntImplType.ROUND,)
+            proxy.init_tensor_quant()
+            proxy.load_state_dict(state_dict, strict=False)
+        finally:
+            config.IGNORE_MISSING_KEYS = ignore_missing_key
+            config.REINIT_ON_STATE_DICT_LOAD = reinit_on_state_dict
 
 
 def check_tensors_same_ptr(tensor_list):

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -12,6 +12,7 @@ from torch.utils.hooks import RemovableHandle
 from brevitas import config
 from brevitas.core.function_wrapper.learned_round import LearnedRoundSte
 from brevitas.inject.enum import FloatToIntImplType
+from brevitas.inject.enum import ScalingImplType
 from brevitas.quant_tensor import _unpack_quant_tensor
 from brevitas.utils.torch_utils import compute_channel_view_shape
 
@@ -88,14 +89,19 @@ class merge_quant_weights:
         model: A model containing quantised layers with learned round quantisers.
     """
 
-    def __init__(self, model: torch.nn.Module, disable_quant: bool = True) -> None:
+    def __init__(
+            self,
+            model: torch.nn.Module,
+            disable_quant: bool = True,
+            preserve_original_weights: bool = False) -> None:
         self._model = model
         self._hooks: List[RemovableHandle] = []
         self._module_tensor_id_mapping = {}
         self.disable_quant = disable_quant
         self.hook_check = False
+        self.preserve_original_weights = preserve_original_weights
 
-    def __enter__(self) -> 'merge_learned_round':
+    def __enter__(self) -> 'merge_quant_weights':
         # Imported here to avoid a circular import
         from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjectorBase
 
@@ -111,8 +117,9 @@ class merge_quant_weights:
                 for m in module.tracked_module_list:
                     # We match the module based on its weights and the ID of the tensor to quantize
                     if id(m.weight.data) == id(input_tensor.data):
-                        # This could be a Tensor or a QuantTensor
-                        m.weight.data = _unpack_quant_tensor(output).data
+                        if self.preserve_original_weights:
+                            m.weight_orig = m.weight.data.cpu()
+                        m.weight.data = output.value.data
                         # We track how many modules have been converted
                         if module not in self._module_tensor_id_mapping:
                             self._module_tensor_id_mapping[module] = [id(m.weight.data)]
@@ -123,13 +130,13 @@ class merge_quant_weights:
         for module in self._model.modules():
             if not isinstance(module, WeightQuantProxyFromInjectorBase):
                 continue
-
-            hook = module.register_forward_hook(hook)
-            self._hooks.append(hook)
+            self.change_scale_impl_type(module)
+            handle = module.register_forward_hook(hook)
+            self._hooks.append(handle)
 
         # Register Model hook
-        hook = self._model.register_forward_hook(model_hook)
-        self._hooks.append(hook)
+        handle = self._model.register_forward_hook(model_hook)
+        self._hooks.append(handle)
 
         return self
 
@@ -142,6 +149,19 @@ class merge_quant_weights:
             for module in self._module_tensor_id_mapping:
                 self._reset_quantizer(module)
 
+    def change_scale_impl_type(self, proxy) -> None:
+        reinit_on_state_dict = config.REINIT_ON_STATE_DICT_LOAD
+        ignore_missing_key = config.IGNORE_MISSING_KEYS
+        config.REINIT_ON_STATE_DICT_LOAD = False
+        config.IGNORE_MISSING_KEYS = True
+        state_dict = proxy.state_dict()
+        proxy.quant_injector = proxy.quant_injector.let(
+            scaling_impl_type=ScalingImplType.PARAMETER_FROM_STATS)
+        proxy.init_tensor_quant()
+        proxy.load_state_dict(state_dict, strict=False)
+        config.IGNORE_MISSING_KEYS = ignore_missing_key
+        config.REINIT_ON_STATE_DICT_LOAD = reinit_on_state_dict
+
     @staticmethod
     def _reset_quantizer(proxy) -> None:
         """Switch a weight quant proxy from LearnedRound back to standard Round."""
@@ -149,18 +169,16 @@ class merge_quant_weights:
         ignore_missing_key = config.IGNORE_MISSING_KEYS
         config.REINIT_ON_STATE_DICT_LOAD = False
         config.IGNORE_MISSING_KEYS = True
-        try:
-            state_dict = {
-                k: v for k,
-                v in proxy.state_dict().items() if not k.endswith('float_to_int_impl.value')}
+        state_dict = {
+            k: v for k,
+            v in proxy.state_dict().items() if not k.endswith('float_to_int_impl.value')}
 
-            proxy.quant_injector = proxy.quant_injector.let(
-                float_to_int_impl_type=FloatToIntImplType.ROUND,)
-            proxy.init_tensor_quant()
-            proxy.load_state_dict(state_dict, strict=False)
-        finally:
-            config.IGNORE_MISSING_KEYS = ignore_missing_key
-            config.REINIT_ON_STATE_DICT_LOAD = reinit_on_state_dict
+        proxy.quant_injector = proxy.quant_injector.let(
+            float_to_int_impl_type=FloatToIntImplType.ROUND)
+        proxy.init_tensor_quant()
+        proxy.load_state_dict(state_dict, strict=False)
+        config.IGNORE_MISSING_KEYS = ignore_missing_key
+        config.REINIT_ON_STATE_DICT_LOAD = reinit_on_state_dict
 
 
 def check_tensors_same_ptr(tensor_list):

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -109,12 +109,13 @@ def merge_quant_weights(
                     # We track how many modules have been converted
                     module_tensor_id_mapping[m] = [output.value.data]
             
-            if len(module_tensor_id_mapping == len(module.tracked_module_list)):
+            if len(module_tensor_id_mapping) == len(module.tracked_module_list):
                 for quant_module, new_weights in module_tensor_id_mapping:
                     quant_module.weight.data = output.value.data
                 proxy_list.append(module)
             else:
-                warnings.warn("Could not match all the modules to their weights, skipping quantizer")
+                warnings.warn(
+                    "Could not match all the modules to their weights, skipping quantizer")
             
     # Register Proxy hooks
     for module in model.modules():

--- a/src/brevitas/nn/utils.py
+++ b/src/brevitas/nn/utils.py
@@ -12,6 +12,7 @@ from torch.utils.hooks import RemovableHandle
 from brevitas import config
 from brevitas.core.function_wrapper.learned_round import LearnedRoundSte
 from brevitas.inject.enum import FloatToIntImplType
+from brevitas.quant_tensor import _unpack_quant_tensor
 from brevitas.utils.torch_utils import compute_channel_view_shape
 
 
@@ -87,29 +88,48 @@ class merge_quant_weights:
         model: A model containing quantised layers with learned round quantisers.
     """
 
-    def __init__(self, model: torch.nn.Module) -> None:
+    def __init__(self, model: torch.nn.Module, disable_quant: bool = True) -> None:
         self._model = model
         self._hooks: List[RemovableHandle] = []
-        self._modules_list = []
+        self._module_tensor_id_mapping = {}
+        self.disable_quant = disable_quant
+        self.hook_check = False
 
     def __enter__(self) -> 'merge_learned_round':
         # Imported here to avoid a circular import
         from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjectorBase
 
+        def model_hook(module, args, output):
+            if self.hook_check:
+                raise RuntimeError(
+                    "Calling multiple forward pass within the context manager is not supported")
+            self.hook_check = True
+
         def hook(module, args, output):
             input_tensor = args[0]
             with torch.no_grad():
                 for m in module.tracked_module_list:
+                    # We match the module based on its weights and the ID of the tensor to quantize
                     if id(m.weight.data) == id(input_tensor.data):
-                        m.weight.data = output[0].data
+                        # This could be a Tensor or a QuantTensor
+                        m.weight.data = _unpack_quant_tensor(output).data
+                        # We track how many modules have been converted
+                        if module not in self._module_tensor_id_mapping:
+                            self._module_tensor_id_mapping[module] = [id(m.weight.data)]
+                        else:
+                            self._module_tensor_id_mapping[module].append(id(m.weight.data))
 
+        # Register Proxy hooks
         for module in self._model.modules():
             if not isinstance(module, WeightQuantProxyFromInjectorBase):
                 continue
 
             hook = module.register_forward_hook(hook)
             self._hooks.append(hook)
-            self._modules_list.append(module)
+
+        # Register Model hook
+        hook = self._model.register_forward_hook(model_hook)
+        self._hooks.append(hook)
 
         return self
 
@@ -119,7 +139,7 @@ class merge_quant_weights:
         self._hooks.clear()
 
         with torch.no_grad():
-            for module in self._modules_list:
+            for module in self._module_tensor_id_mapping:
                 self._reset_quantizer(module)
 
     @staticmethod

--- a/tests/brevitas/nn/test_merge_learned_round.py
+++ b/tests/brevitas/nn/test_merge_learned_round.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
@@ -16,6 +16,9 @@ from brevitas.nn.utils import merge_quant_weights
 SEED = 123456
 IN_FEATURES = 8
 OUT_FEATURES = 16
+
+LEARNED_ROUND_OPTIONS = [
+    LearnedRoundImplType.HARD_SIGMOID, LearnedRoundImplType.SIGMOID, LearnedRoundImplType.IDENTITY]
 
 
 def _insert_learned_round(model, learned_round_param):
@@ -50,11 +53,7 @@ def _get_quant_weights(model):
     return results
 
 
-@pytest.mark.parametrize(
-    "learned_round_param", [
-        LearnedRoundImplType.HARD_SIGMOID,
-        LearnedRoundImplType.SIGMOID,
-        LearnedRoundImplType.IDENTITY,])
+@pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
 def test_merge_quant_weights_preserves_quantised_weights(learned_round_param):
     """After merging, standard round should produce the same quantised weights."""
     torch.manual_seed(SEED)
@@ -93,11 +92,7 @@ def test_merge_quant_weights_preserves_quantised_weights(learned_round_param):
             f"Quantised weights differ for {name} after merge"
 
 
-@pytest.mark.parametrize(
-    "learned_round_param", [
-        LearnedRoundImplType.HARD_SIGMOID,
-        LearnedRoundImplType.SIGMOID,
-        LearnedRoundImplType.IDENTITY,])
+@pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
 def test_merge_quant_weights_rounding_mode_reset(learned_round_param):
     """After merging, the rounding mode should be ROUND."""
     torch.manual_seed(SEED)
@@ -113,11 +108,7 @@ def test_merge_quant_weights_rounding_mode_reset(learned_round_param):
     assert model.weight_quant.rounding_mode == "ROUND"
 
 
-@pytest.mark.parametrize(
-    "learned_round_param", [
-        LearnedRoundImplType.HARD_SIGMOID,
-        LearnedRoundImplType.SIGMOID,
-        LearnedRoundImplType.IDENTITY,])
+@pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
 def test_merge_quant_weights_forward_equivalence(learned_round_param):
     """The model forward output should be identical before and after merging."""
     torch.manual_seed(SEED)

--- a/tests/brevitas/nn/test_merge_learned_round.py
+++ b/tests/brevitas/nn/test_merge_learned_round.py
@@ -1,0 +1,145 @@
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import torch
+
+from brevitas.core.function_wrapper.learned_round import LearnedRoundHardSigmoid
+from brevitas.core.function_wrapper.learned_round import LearnedRoundIdentity
+from brevitas.core.function_wrapper.learned_round import LearnedRoundSigmoid
+from brevitas.core.function_wrapper.learned_round import LearnedRoundSte
+from brevitas.inject.enum import FloatToIntImplType
+from brevitas.inject.enum import LearnedRoundImplType
+from brevitas.nn import QuantLinear
+from brevitas.nn.utils import merge_quant_weights
+
+SEED = 123456
+IN_FEATURES = 8
+OUT_FEATURES = 16
+
+
+def _insert_learned_round(model, learned_round_param):
+    """Insert learned round quantisers into a model (simplified version for testing)."""
+    from brevitas.nn.quant_layer import QuantWeightBiasInputOutputLayer as QuantWBIOL
+    for module in model.modules():
+        if isinstance(module, QuantWBIOL):
+            # Compute init value for the learned round parameter
+            if learned_round_param in (LearnedRoundImplType.HARD_SIGMOID,
+                                       LearnedRoundImplType.SIGMOID):
+                floor_weight = torch.floor(module.weight.data / module.quant_weight().scale)
+                delta = (module.weight.data / module.quant_weight().scale) - floor_weight
+                value = -torch.log((1.1 - (-0.1)) / (delta - (-0.1)) - 1)
+            else:
+                value = torch.zeros_like(module.weight.data)
+
+            module.weight_quant.quant_injector = module.weight_quant.quant_injector.let(
+                float_to_int_impl_type=FloatToIntImplType.LEARNED_ROUND,
+                learned_round_impl_type=learned_round_param,
+                learned_round_init=value,
+            )
+            module.weight_quant.init_tensor_quant(preserve_state_dict=True)
+
+
+def _get_quant_weights(model):
+    """Get the quantised weight outputs for all QuantLinear layers in the model."""
+    results = {}
+    for name, module in model.named_modules():
+        if isinstance(module, QuantLinear):
+            quant_weight = module.quant_weight()
+            results[name] = quant_weight.value.detach().clone()
+    return results
+
+
+@pytest.mark.parametrize(
+    "learned_round_param", [
+        LearnedRoundImplType.HARD_SIGMOID,
+        LearnedRoundImplType.SIGMOID,
+        LearnedRoundImplType.IDENTITY,])
+def test_merge_quant_weights_preserves_quantised_weights(learned_round_param):
+    """After merging, standard round should produce the same quantised weights."""
+    torch.manual_seed(SEED)
+    model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
+    model.eval()
+
+    # Insert learned round quantisers
+    _insert_learned_round(model, learned_round_param)
+
+    # Simulate training by randomising the learned round values
+    for module in model.modules():
+        if isinstance(module, LearnedRoundSte):
+            module.value.data = torch.randn_like(module.value.data)
+
+    model.eval()
+
+    # Get quantised weights with learned round active
+    quant_before = _get_quant_weights(model)
+
+    # Merge learned round into weights via context manager
+    x = torch.randn(4, IN_FEATURES)
+    with merge_quant_weights(model):
+        model(x)
+
+    # Verify that learned round has been removed
+    for module in model.modules():
+        assert not isinstance(module, LearnedRoundSte), \
+            "LearnedRoundSte should be removed after merge"
+
+    # Get quantised weights with standard round
+    quant_after = _get_quant_weights(model)
+
+    # The quantised outputs should match
+    for name in quant_before:
+        assert torch.allclose(quant_before[name], quant_after[name], atol=1e-6), \
+            f"Quantised weights differ for {name} after merge"
+
+
+@pytest.mark.parametrize(
+    "learned_round_param", [
+        LearnedRoundImplType.HARD_SIGMOID,
+        LearnedRoundImplType.SIGMOID,
+        LearnedRoundImplType.IDENTITY,])
+def test_merge_quant_weights_rounding_mode_reset(learned_round_param):
+    """After merging, the rounding mode should be ROUND."""
+    torch.manual_seed(SEED)
+    model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
+    model.eval()
+
+    _insert_learned_round(model, learned_round_param)
+    assert model.weight_quant.rounding_mode == "LEARNED_ROUND"
+
+    x = torch.randn(4, IN_FEATURES)
+    with merge_quant_weights(model):
+        model(x)
+    assert model.weight_quant.rounding_mode == "ROUND"
+
+
+@pytest.mark.parametrize(
+    "learned_round_param", [
+        LearnedRoundImplType.HARD_SIGMOID,
+        LearnedRoundImplType.SIGMOID,
+        LearnedRoundImplType.IDENTITY,])
+def test_merge_quant_weights_forward_equivalence(learned_round_param):
+    """The model forward output should be identical before and after merging."""
+    torch.manual_seed(SEED)
+    model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=True)
+    model.eval()
+
+    _insert_learned_round(model, learned_round_param)
+    for module in model.modules():
+        if isinstance(module, LearnedRoundSte):
+            module.value.data = torch.randn_like(module.value.data)
+
+    model.eval()
+    x = torch.randn(4, IN_FEATURES)
+
+    with torch.no_grad():
+        out_before = model(x).clone()
+
+    with merge_quant_weights(model):
+        model(x)
+
+    with torch.no_grad():
+        out_after = model(x)
+
+    assert torch.allclose(out_before, out_after, atol=1e-5), \
+        "Model outputs differ after merge"

--- a/tests/brevitas/nn/test_merge_quant_weights.py
+++ b/tests/brevitas/nn/test_merge_quant_weights.py
@@ -62,55 +62,8 @@ def _randomise_learned_round(model):
 
 @pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
 def test_merge_quant_weights_preserves_quantised_weights(learned_round_param):
-    """After merging, standard round should produce the same quantised weights."""
-    torch.manual_seed(SEED)
-    model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
-    model.eval()
-
-    _insert_learned_round(model, learned_round_param)
-    _randomise_learned_round(model)
-    model.eval()
-
-    # Get quantised weights with learned round active
-    quant_before = _get_quant_weights(model)
-
-    # Merge learned round into weights via context manager
-    x = torch.randn(4, IN_FEATURES)
-    with merge_quant_weights(model):
-        model(x)
-
-    # Verify that learned round has been removed
-    for module in model.modules():
-        assert not isinstance(module, LearnedRoundSte), \
-            "LearnedRoundSte should be removed after merge"
-
-    # The quantised outputs should match
-    quant_after = _get_quant_weights(model)
-    for name in quant_before:
-        assert torch.allclose(quant_before[name], quant_after[name], atol=1e-6), \
-            f"Quantised weights differ for {name} after merge"
-
-
-@pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
-def test_merge_quant_weights_errors_on_multiple_forward_passes(learned_round_param):
-    """Multiple forward passes inside merge_quant_weights should raise RuntimeError."""
-    torch.manual_seed(SEED)
-    model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
-    model.eval()
-
-    _insert_learned_round(model, learned_round_param)
-    _randomise_learned_round(model)
-    model.eval()
-
-    x = torch.randn(4, IN_FEATURES)
-    with pytest.raises(RuntimeError), merge_quant_weights(model):
-        for _ in range(3):
-            model(x)
-
-
-@pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
-def test_merge_quant_weights_reset(learned_round_param):
-    """After merging, the rounding mode should be ROUND."""
+    """After merging, standard round should preserve the quantised weights, remove learned
+    round and its forward hooks, and reset the rounding mode to ROUND."""
     torch.manual_seed(SEED)
     model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
     model.eval()
@@ -118,12 +71,36 @@ def test_merge_quant_weights_reset(learned_round_param):
     _insert_learned_round(model, learned_round_param)
     assert model.weight_quant.rounding_mode == "LEARNED_ROUND"
 
+    _randomise_learned_round(model)
+    model.eval()
+
+    # Get quantised weights with learned round active
+    quant_before = _get_quant_weights(model)
+    hooks_before = len(model._forward_hooks)
+
+    # Merge learned round into weights
     x = torch.randn(4, IN_FEATURES)
-    with merge_quant_weights(model):
-        model(x)
+    merge_quant_weights(model, x)
+
+    # Verify that learned round has been removed
+    for module in model.modules():
+        assert not isinstance(module, LearnedRoundSte), \
+            "LearnedRoundSte should be removed after merge"
+
+    # Verify that the merge's forward hooks were cleaned up
+    hooks_after = len(model._forward_hooks)
+    assert hooks_after == hooks_before, "Forward hooks were not cleaned up after merge"
+
+    # Verify that the rounding mode has been reset to standard round
     assert isinstance(
         model.weight_quant.tensor_quant.scaling_impl, ParameterFromStatsFromParameterScaling)
     assert model.weight_quant.rounding_mode == "ROUND"
+
+    # The quantised outputs should match
+    quant_after = _get_quant_weights(model)
+    for name in quant_before:
+        assert torch.allclose(quant_before[name], quant_after[name], atol=1e-6), \
+            f"Quantised weights differ for {name} after merge"
 
 
 @pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
@@ -142,8 +119,7 @@ def test_merge_quant_weights_forward_equivalence(learned_round_param):
     with torch.no_grad():
         out_before = model(x).clone()
 
-    with merge_quant_weights(model):
-        model(x)
+    merge_quant_weights(model, x)
 
     with torch.no_grad():
         out_after = model(x)

--- a/tests/brevitas/nn/test_merge_quant_weights.py
+++ b/tests/brevitas/nn/test_merge_quant_weights.py
@@ -4,16 +4,14 @@
 import pytest
 import torch
 
-from brevitas.core.function_wrapper.learned_round import LearnedRoundHardSigmoid
-from brevitas.core.function_wrapper.learned_round import LearnedRoundIdentity
-from brevitas.core.function_wrapper.learned_round import LearnedRoundSigmoid
 from brevitas.core.function_wrapper.learned_round import LearnedRoundSte
 from brevitas.inject.enum import FloatToIntImplType
 from brevitas.inject.enum import LearnedRoundImplType
 from brevitas.nn import QuantLinear
 from brevitas.nn.utils import merge_quant_weights
+from brevitas.quant_tensor import QuantTensor
+from tests.conftest import SEED
 
-SEED = 123456
 IN_FEATURES = 8
 OUT_FEATURES = 16
 
@@ -38,8 +36,7 @@ def _insert_learned_round(model, learned_round_param):
             module.weight_quant.quant_injector = module.weight_quant.quant_injector.let(
                 float_to_int_impl_type=FloatToIntImplType.LEARNED_ROUND,
                 learned_round_impl_type=learned_round_param,
-                learned_round_init=value,
-            )
+                learned_round_init=value)
             module.weight_quant.init_tensor_quant(preserve_state_dict=True)
 
 
@@ -49,8 +46,17 @@ def _get_quant_weights(model):
     for name, module in model.named_modules():
         if isinstance(module, QuantLinear):
             quant_weight = module.quant_weight()
-            results[name] = quant_weight.value.detach().clone()
+            if isinstance(quant_weight, QuantTensor):
+                quant_weight = quant_weight.value
+            results[name] = quant_weight.detach().clone()
     return results
+
+
+def _randomise_learned_round(model):
+    """Randomise learned round values to simulate training."""
+    for module in model.modules():
+        if isinstance(module, LearnedRoundSte):
+            module.value.data = torch.randn_like(module.value.data)
 
 
 @pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
@@ -60,14 +66,8 @@ def test_merge_quant_weights_preserves_quantised_weights(learned_round_param):
     model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
     model.eval()
 
-    # Insert learned round quantisers
     _insert_learned_round(model, learned_round_param)
-
-    # Simulate training by randomising the learned round values
-    for module in model.modules():
-        if isinstance(module, LearnedRoundSte):
-            module.value.data = torch.randn_like(module.value.data)
-
+    _randomise_learned_round(model)
     model.eval()
 
     # Get quantised weights with learned round active
@@ -83,13 +83,28 @@ def test_merge_quant_weights_preserves_quantised_weights(learned_round_param):
         assert not isinstance(module, LearnedRoundSte), \
             "LearnedRoundSte should be removed after merge"
 
-    # Get quantised weights with standard round
-    quant_after = _get_quant_weights(model)
-
     # The quantised outputs should match
+    quant_after = _get_quant_weights(model)
     for name in quant_before:
         assert torch.allclose(quant_before[name], quant_after[name], atol=1e-6), \
             f"Quantised weights differ for {name} after merge"
+
+
+@pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
+def test_merge_quant_weights_errors_on_multiple_forward_passes(learned_round_param):
+    """Multiple forward passes inside merge_quant_weights should raise RuntimeError."""
+    torch.manual_seed(SEED)
+    model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
+    model.eval()
+
+    _insert_learned_round(model, learned_round_param)
+    _randomise_learned_round(model)
+    model.eval()
+
+    x = torch.randn(4, IN_FEATURES)
+    with pytest.raises(RuntimeError), merge_quant_weights(model):
+        for _ in range(3):
+            model(x)
 
 
 @pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
@@ -116,9 +131,7 @@ def test_merge_quant_weights_forward_equivalence(learned_round_param):
     model.eval()
 
     _insert_learned_round(model, learned_round_param)
-    for module in model.modules():
-        if isinstance(module, LearnedRoundSte):
-            module.value.data = torch.randn_like(module.value.data)
+    _randomise_learned_round(model)
 
     model.eval()
     x = torch.randn(4, IN_FEATURES)

--- a/tests/brevitas/nn/test_merge_quant_weights.py
+++ b/tests/brevitas/nn/test_merge_quant_weights.py
@@ -11,6 +11,8 @@ from brevitas.inject.enum import LearnedRoundImplType
 from brevitas.nn import QuantLinear
 from brevitas.nn.utils import merge_quant_weights
 from brevitas.quant_tensor import QuantTensor
+from brevitas_examples.common.learned_round.learned_round_method import \
+    insert_learned_round_quantizers
 from tests.conftest import SEED
 
 IN_FEATURES = 8
@@ -18,27 +20,6 @@ OUT_FEATURES = 16
 
 LEARNED_ROUND_OPTIONS = [
     LearnedRoundImplType.HARD_SIGMOID, LearnedRoundImplType.SIGMOID, LearnedRoundImplType.IDENTITY]
-
-
-def _insert_learned_round(model, learned_round_param):
-    """Insert learned round quantisers into a model (simplified version for testing)."""
-    from brevitas.nn.quant_layer import QuantWeightBiasInputOutputLayer as QuantWBIOL
-    for module in model.modules():
-        if isinstance(module, QuantWBIOL):
-            # Compute init value for the learned round parameter
-            if learned_round_param in (LearnedRoundImplType.HARD_SIGMOID,
-                                       LearnedRoundImplType.SIGMOID):
-                floor_weight = torch.floor(module.weight.data / module.quant_weight().scale)
-                delta = (module.weight.data / module.quant_weight().scale) - floor_weight
-                value = -torch.log((1.1 - (-0.1)) / (delta - (-0.1)) - 1)
-            else:
-                value = torch.zeros_like(module.weight.data)
-
-            module.weight_quant.quant_injector = module.weight_quant.quant_injector.let(
-                float_to_int_impl_type=FloatToIntImplType.LEARNED_ROUND,
-                learned_round_impl_type=learned_round_param,
-                learned_round_init=value)
-            module.weight_quant.init_tensor_quant(preserve_state_dict=True)
 
 
 def _get_quant_weights(model):
@@ -67,8 +48,7 @@ def test_merge_quant_weights_preserves_quantised_weights(learned_round_param):
     torch.manual_seed(SEED)
     model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
     model.eval()
-
-    _insert_learned_round(model, learned_round_param)
+    insert_learned_round_quantizers(model, learned_round_param)
     assert model.weight_quant.rounding_mode == "LEARNED_ROUND"
 
     _randomise_learned_round(model)
@@ -110,7 +90,7 @@ def test_merge_quant_weights_forward_equivalence(learned_round_param):
     model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=True)
     model.eval()
 
-    _insert_learned_round(model, learned_round_param)
+    insert_learned_round_quantizers(model, learned_round_param)
     _randomise_learned_round(model)
 
     model.eval()

--- a/tests/brevitas/nn/test_merge_quant_weights.py
+++ b/tests/brevitas/nn/test_merge_quant_weights.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from brevitas.core.function_wrapper.learned_round import LearnedRoundSte
+from brevitas.core.scaling import ParameterFromStatsFromParameterScaling
 from brevitas.inject.enum import FloatToIntImplType
 from brevitas.inject.enum import LearnedRoundImplType
 from brevitas.nn import QuantLinear
@@ -108,7 +109,7 @@ def test_merge_quant_weights_errors_on_multiple_forward_passes(learned_round_par
 
 
 @pytest.mark.parametrize("learned_round_param", LEARNED_ROUND_OPTIONS)
-def test_merge_quant_weights_rounding_mode_reset(learned_round_param):
+def test_merge_quant_weights_reset(learned_round_param):
     """After merging, the rounding mode should be ROUND."""
     torch.manual_seed(SEED)
     model = QuantLinear(in_features=IN_FEATURES, out_features=OUT_FEATURES, bias=False)
@@ -120,6 +121,8 @@ def test_merge_quant_weights_rounding_mode_reset(learned_round_param):
     x = torch.randn(4, IN_FEATURES)
     with merge_quant_weights(model):
         model(x)
+    assert isinstance(
+        model.weight_quant.tensor_quant.scaling_impl, ParameterFromStatsFromParameterScaling)
     assert model.weight_quant.rounding_mode == "ROUND"
 
 


### PR DESCRIPTION
## Reason for this PR

In certain instances, like learned round, the weight tensors has extra parameters attached to it that could make export somewhat complicated.


## Changes Made in this PR

We perform a destructive replacement of the original weight tensor with its quantized counterparts. This allows for easier exports in many scenarios.

There is an optional flag to keeep track of the original weights.

After merging, we reset the quantizers, including setting rounding mode to _round_, which is what is most commonly supported during export process.

What is missing:
- [ ] Integration in the LLM entrypoint.
- [ ] Handling the WeightWithInputQuantizer (i.e., the one required by A2Q and A2Q+)

## Testing Summary

New tests added.

