### PR TITLE
Feat (ex/llm): custom quantizer plugin allows to modify quant model

### DIFF
--- a/src/brevitas_examples/common/generative/quantizers.py
+++ b/src/brevitas_examples/common/generative/quantizers.py
@@ -76,6 +76,10 @@ class BaseQuantizer:
                 quantizers_dict[key] = value
         return quantizers_dict
 
+    @classmethod
+    def modify_quantized_model(cls: "BaseQuantizer", model: nn.Module) -> nn.Module:
+        return model
+
 
 # Registry for custom quantizers
 QUANTIZERS_REGISTRY = Registry[Type[BaseQuantizer]](registry_name="QuantizersRegistry")

--- a/src/brevitas_examples/common/generative/quantizers.py
+++ b/src/brevitas_examples/common/generative/quantizers.py
@@ -77,7 +77,7 @@ class BaseQuantizer:
         return quantizers_dict
 
     @classmethod
-    def modify_quantized_model(cls: "BaseQuantizer", model: nn.Module) -> nn.Module:
+    def post_process_quant_model(cls: "BaseQuantizer", model: nn.Module) -> nn.Module:
         return model
 
 

--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -23,7 +23,7 @@ def create_args_parser() -> ArgumentParser:
         type=str,
         default=None,
         help=
-        'Override the quantization list with custom user defined quantizers. This must be a .py file with a list of seven quantizers. Default: None.'
+        'Override the quantization list and/or post-process the quantized model with a user-defined quantization plugin. The plugin can be a registered name or a .py file path followed by :plugin_name. Default: None.'
     )
     parser.add_argument(
         '--dtype',

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -4,7 +4,7 @@
 from contextlib import nullcontext
 from copy import deepcopy
 import functools
-import importlib
+import importlib.util
 import os
 from pathlib import Path
 import pprint
@@ -456,6 +456,7 @@ def quantize_llm(args, extra_args=None):
 
     if not args.no_quantize:
         name_blacklist = []
+        custom_quantizer = None
         print("Applying model quantization...")
         # When AWQ is enabled, the scaling_impl_type for the weights needs to be 'stats', as the
         # scaling factor that multiplies the weights is optimized
@@ -531,6 +532,9 @@ def quantize_llm(args, extra_args=None):
 
         model = layerwise_quantize(
             model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
+
+        if custom_quantizer is not None:
+            model = custom_quantizer.modify_quantized_model(model)
 
         # Just to be sure
         model.eval()

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -4,7 +4,7 @@
 from contextlib import nullcontext
 from copy import deepcopy
 import functools
-import importlib.util
+import importlib
 import os
 from pathlib import Path
 import pprint
@@ -534,7 +534,7 @@ def quantize_llm(args, extra_args=None):
             model=model, compute_layer_map=layer_map, name_blacklist=name_blacklist)
 
         if custom_quantizer is not None:
-            model = custom_quantizer.modify_quantized_model(model)
+            model = custom_quantizer.post_process_quant_model(model)
 
         # Just to be sure
         model.eval()

--- a/tests/brevitas_examples/llm_example_quantizer.py
+++ b/tests/brevitas_examples/llm_example_quantizer.py
@@ -1,5 +1,6 @@
 from torch import nn
 
+from brevitas.quant.scaled_int import Int8ActPerTensorFloat
 from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 from brevitas.utils.python_utils import Registry
 from brevitas_examples.common.generative.quantizers import BaseQuantizer
@@ -23,8 +24,25 @@ class ExampleModelAdjuster(BaseQuantizer):
 @Registry.register(QUANTIZERS_REGISTRY, "example_quant_and_model_adjuster")
 class ExampleQuantAndModelAdjuster(BaseQuantizer):
     weight_quant = Int8WeightPerTensorFloat.let(bit_width=4)
+    linear_input_quant = Int8ActPerTensorFloat
 
     @classmethod
     def modify_quantized_model(cls, model: nn.Module) -> nn.Module:
         model.example_quant_and_model_adjuster_applied = True
+        for m in model.model.layers:
+            # Tie input_quant
+            base_quant_qkv = m.self_attn.q_proj.input_quant
+            m.self_attn.v_proj.input_quant = base_quant_qkv
+            m.self_attn.k_proj.input_quant = base_quant_qkv
+
+            base_quant_up_gate = m.mlp.gate_proj.input_quant
+            m.mlp.up_proj.input_quant = base_quant_up_gate
+
+            # Tie weight_quant
+            base_quant_qkv = m.self_attn.q_proj.weight_quant
+            m.self_attn.v_proj.weight_quant = base_quant_qkv
+            m.self_attn.k_proj.weight_quant = base_quant_qkv
+
+            base_quant_up_gate = m.mlp.gate_proj.weight_quant
+            m.mlp.up_proj.weight_quant = base_quant_up_gate
         return model

--- a/tests/brevitas_examples/llm_example_quantizer.py
+++ b/tests/brevitas_examples/llm_example_quantizer.py
@@ -16,7 +16,7 @@ class ExampleInt8WeightQuantizer(BaseQuantizer):
 class ExampleModelAdjuster(BaseQuantizer):
 
     @classmethod
-    def modify_quantized_model(cls, model: nn.Module) -> nn.Module:
+    def post_process_quant_model(cls, model: nn.Module) -> nn.Module:
         model.example_model_adjuster_applied = True
         return model
 
@@ -27,7 +27,7 @@ class ExampleQuantAndModelAdjuster(BaseQuantizer):
     linear_input_quant = Int8ActPerTensorFloat
 
     @classmethod
-    def modify_quantized_model(cls, model: nn.Module) -> nn.Module:
+    def post_process_quant_model(cls, model: nn.Module) -> nn.Module:
         model.example_quant_and_model_adjuster_applied = True
         for m in model.model.layers:
             # Tie input_quant

--- a/tests/brevitas_examples/llm_example_quantizer.py
+++ b/tests/brevitas_examples/llm_example_quantizer.py
@@ -1,3 +1,5 @@
+from torch import nn
+
 from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 from brevitas.utils.python_utils import Registry
 from brevitas_examples.common.generative.quantizers import BaseQuantizer
@@ -7,3 +9,22 @@ from brevitas_examples.common.generative.quantizers import QUANTIZERS_REGISTRY
 @Registry.register(QUANTIZERS_REGISTRY, "example_int4_weight_quant")
 class ExampleInt8WeightQuantizer(BaseQuantizer):
     weight_quant = Int8WeightPerTensorFloat.let(bit_width=4)
+
+
+@Registry.register(QUANTIZERS_REGISTRY, "example_model_adjuster")
+class ExampleModelAdjuster(BaseQuantizer):
+
+    @classmethod
+    def modify_quantized_model(cls, model: nn.Module) -> nn.Module:
+        model.example_model_adjuster_applied = True
+        return model
+
+
+@Registry.register(QUANTIZERS_REGISTRY, "example_quant_and_model_adjuster")
+class ExampleQuantAndModelAdjuster(BaseQuantizer):
+    weight_quant = Int8WeightPerTensorFloat.let(bit_width=4)
+
+    @classmethod
+    def modify_quantized_model(cls, model: nn.Module) -> nn.Module:
+        model.example_quant_and_model_adjuster_applied = True
+        return model

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -239,6 +239,17 @@ def test_custom_quantizer_file_can_override_quantizers_and_modify_quantized_mode
         if hasattr(module, 'weight_quant') and module.weight_quant is not None:
             weight_proxies.append(module.weight_quant)
 
+    for m in model.model.layers:
+        # Check input_quant are tied
+        assert id(m.self_attn.q_proj.input_quant) == id(m.self_attn.k_proj.input_quant) == id(
+            m.self_attn.v_proj.input_quant)
+        assert id(m.mlp.up_proj.input_quant) == id(m.mlp.gate_proj.input_quant)
+
+        # Check weight_quant are tied
+        assert id(m.self_attn.q_proj.weight_quant) == id(m.self_attn.k_proj.weight_quant) == id(
+            m.self_attn.v_proj.weight_quant)
+        assert id(m.mlp.up_proj.weight_quant) == id(m.mlp.gate_proj.weight_quant)
+
     assert weight_proxies
     assert any(
         hasattr(proxy, 'bit_width') and proxy.bit_width() is not None and

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -27,6 +27,9 @@ from brevitas import config
 from brevitas import torch_version
 from brevitas.graph.equalize import _compute_rotations
 from brevitas.graph.equalize import Region
+from brevitas.utils.python_utils import Registry
+from brevitas_examples.common.generative.quantizers import BaseQuantizer
+from brevitas_examples.common.generative.quantizers import QUANTIZERS_REGISTRY
 from brevitas_examples.llm.llm_args import create_args_parser
 from brevitas_examples.llm.llm_quant.ln_affine_merge import rmsnorm_patch
 from brevitas_examples.llm.main import fx_required
@@ -194,6 +197,52 @@ def test_small_models_quant_layer_types_count(caplog, args_and_layer_types_count
     args, extra_args, exp_metrics = args_and_layer_types_count
     _, model = main(args, extra_args)
     assert_layer_types_count(model, exp_metrics["exp_layer_types_count"])
+
+
+@pytest.mark.llm
+def test_custom_quantizer_can_modify_quantized_model(caplog, default_run_args, main):
+    caplog.set_level(logging.INFO)
+
+    @Registry.register(QUANTIZERS_REGISTRY, "example_inline_model_adjuster")
+    class ExampleInlineModelAdjuster(BaseQuantizer):
+
+        @classmethod
+        def modify_quantized_model(cls, model: nn.Module) -> nn.Module:
+            model.example_inline_model_adjuster_applied = True
+            return model
+
+    args = default_run_args
+    args.model = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+    args.custom_quantizer = "example_inline_model_adjuster"
+
+    _, model = main(args)
+
+    assert getattr(model, "example_inline_model_adjuster_applied", False)
+
+
+@pytest.mark.llm
+def test_custom_quantizer_file_can_override_quantizers_and_modify_quantized_model(
+        caplog, default_run_args, main):
+    caplog.set_level(logging.INFO)
+
+    args = default_run_args
+    args.model = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+    args.custom_quantizer = (
+        "tests/brevitas_examples/llm_example_quantizer.py:example_quant_and_model_adjuster")
+
+    _, model = main(args)
+
+    assert getattr(model, "example_quant_and_model_adjuster_applied", False)
+
+    weight_proxies = []
+    for module in model.modules():
+        if hasattr(module, 'weight_quant') and module.weight_quant is not None:
+            weight_proxies.append(module.weight_quant)
+
+    assert weight_proxies
+    assert any(
+        hasattr(proxy, 'bit_width') and proxy.bit_width() is not None and
+        proxy.bit_width().item() == 4 for proxy in weight_proxies)
 
 
 @pytest_cases.fixture(

--- a/tests/brevitas_examples/test_llm.py
+++ b/tests/brevitas_examples/test_llm.py
@@ -200,14 +200,14 @@ def test_small_models_quant_layer_types_count(caplog, args_and_layer_types_count
 
 
 @pytest.mark.llm
-def test_custom_quantizer_can_modify_quantized_model(caplog, default_run_args, main):
+def test_custom_quantizer_post_process(caplog, default_run_args, main):
     caplog.set_level(logging.INFO)
 
     @Registry.register(QUANTIZERS_REGISTRY, "example_inline_model_adjuster")
     class ExampleInlineModelAdjuster(BaseQuantizer):
 
         @classmethod
-        def modify_quantized_model(cls, model: nn.Module) -> nn.Module:
+        def post_process_quant_model(cls, model: nn.Module) -> nn.Module:
             model.example_inline_model_adjuster_applied = True
             return model
 
@@ -221,8 +221,7 @@ def test_custom_quantizer_can_modify_quantized_model(caplog, default_run_args, m
 
 
 @pytest.mark.llm
-def test_custom_quantizer_file_can_override_quantizers_and_modify_quantized_model(
-        caplog, default_run_args, main):
+def test_custom_quantizer_file_override_and_post_process(caplog, default_run_args, main):
     caplog.set_level(logging.INFO)
 
     args = default_run_args


### PR DESCRIPTION
## Reason for this PR

In certain scenarios it is useful to have fine-grained control over what happens on your model once quantization has been  applied.

This could be useful to share quantizers in scenarios like exporting to vLLM, where for certain quantization configuration it is mondatory to have Q/K/V quantizers shared, as well as Gate Proj/Up Proj.


## Changes Made in this PR

Extend the current mechanism to define custom quantizer so that it also allows to define a custom function to modify the quant model.


If inheriting from BaseQuantizer, it is possible to only override one of the two methods while preserving the default behaviour (no-op) for the other one.

## Testing Summary

Added tests
