### PR TITLE
Setup: min version for transformers

### DIFF
--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -9,4 +9,4 @@ pandas
 pydantic
 torch>=2.4
 tqdm
-transformers[sentencepiece]<5.0
+transformers[sentencepiece]>=4.52,<5.0


### PR DESCRIPTION
## Reason for this PR

We [need](https://github.com/Xilinx/brevitas/blob/a49ab4da694abc25f44dc490f8382e75838b2c19/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py#L6) [TorchExportableModuleForDecoderOnlyLM](https://github.com/huggingface/transformers/blob/v4.52.0/src/transformers/integrations/executorch.py) which does not exist in transformers 4.51 but it does in 4.52



## Changes Made in this PR

Set minimum transformers version.

## Testing Summary

NA