### PR TITLE
Fix (llm): restore `model_cache_implementation` in `make_dynamo_compatible`

### DIFF
--- a/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
+++ b/src/brevitas_examples/llm/llm_quant/prepare_for_quantize.py
@@ -88,7 +88,8 @@ class make_dynamo_compatible:
         return self
 
     def __exit__(self, *args, **kwargs):
-        # Restore configuration
+        # Restore configuration. Always restore cache_implementation: HF's default is None,
+        # so guarding on `is not None` would leak "static" into downstream generation
+        # (which then triggers torch.compile + StaticCache recompiles in lighteval).
         self.model.config = self.model_config
-        if self.model_cache_implementation is not None:
-            self.model.generation_config.cache_implementation = self.model_cache_implementation
+        self.model.generation_config.cache_implementation = self.model_cache_implementation


### PR DESCRIPTION
## Reason for this PR

`make_dynamo_compatible` (in `brevitas_examples/llm/llm_quant/prepare_for_quantize.py`) leaks `generation_config.cache_implementation = "static"` into the model after the context manager exits. This causes severe slowdowns and noisy CUDA-graph warnings during downstream `lighteval` generation tasks (e.g. `gsm8k`).

### Symptom

Running `brevitas_ptq_llm` with `rotation: fused_no_fx` on Qwen3-8B and `few_shot_eval: lighteval` (gsm8k included) produced a recompile cascade during greedy generation:

```
[__recompiles] Recompiling function torch_dynamo_resume_in_forward_at_238 in transformers/models/llama/modeling_llama.py:238
    triggered by the following guard failure(s):
    - 43/N: L['self'].layer_idx == N
        # keys, values = self.layers[layer_idx].update(...)
        # transformers/cache_utils.py:776 in update
[__recompiles] Recompiling function quant_weight in brevitas/nn/mixin/parameter.py:45
    - tensor 'L['self']._parameters['weight']' size mismatch ... (4096 → 1024 → 14336)
      Guard failed on a parameter, consider using
      torch._dynamo.config.force_parameter_static_shapes = False ...
```

followed by hundreds of:

```
UserWarning: The CUDA Graph is empty. This usually means that the graph
was attempted to be captured on wrong device or stream.
```

### Root cause

`make_dynamo_compatible.__enter__` sets `generation_config.cache_implementation = "static"` for dynamo tracing inside `fused_rotation_no_fx`, but `__exit__` only restores it when the saved value `is not None`:

```python
if self.model_cache_implementation is not None:
    self.model.generation_config.cache_implementation = self.model_cache_implementation
```

HF's default is `None`, so the saved value is `None`, the restore is skipped, and `"static"` persists for the rest of the run. Downstream, `lighteval` calls `model.generate(...)`; transformers sees `cache_implementation="static"`, instantiates a `StaticCache`, and (in transformers 5.x) wraps `forward` with `torch.compile`. `StaticCache.update()` then recompiles per `layer_idx`, brevitas's per-layer quant param shapes (q/k/v/up/down with different sizes under GQA) trigger a parameter-shape recompile on every layer, and CUDA-graph capture fails on the brevitas quant ops.

## Changes Made in this PR

In `brevitas_examples/llm/llm_quant/prepare_for_quantize.py::make_dynamo_compatible.__exit__`, drop the `is not None` guard and unconditionally restore the original `generation_config.cache_implementation`:

```python
def __exit__(self, *args, **kwargs):
    self.model.config = self.model_config
    self.model.generation_config.cache_implementation = self.model_cache_implementation
```

This restores `None` (HF's default) when that's what was originally there, so generation goes back to its normal `DynamicCache` path with no implicit `torch.compile`.

### Why this approach

The `__init__` already correctly captures the original value (treating "missing attribute" as `None`). The bug is purely in the restore path — the guard was almost certainly meant to avoid clobbering an existing user setting, but in practice it does the opposite: it preserves brevitas's *own* override forever instead of restoring the user's pre-context state. Removing the guard is the minimal, targeted fix.

## Testing Summary

Reproduced the leak with `TORCH_LOG=recompiles brevitas_ptq_llm` with a Qwen3-8B config with `rotation: fused_no_fx`, `few_shot_eval: lighteval`, and the gsm8k task. Before the fix: `[__recompiles]` cascade on `StaticCache.update` + per-layer brevitas quant ops, followed by sustained `CUDA Graph is empty` warnings during the gsm8k greedy-generation phase. After the fix: generation runs without the recompile cascade or cudagraph warnings.


## Risk Highlight

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

Behavioral note: any user that was *relying* on `make_dynamo_compatible` leaving `cache_implementation="static"` set on the model after exit will now need to set it explicitly. This was almost certainly never intentional, but flagging it.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [x] 1+ reviews given, and any review issues addressed and approved.
- [x] Post-review full CI/CD passing.
