### PR TITLE
Fix (brevitas_examples/llm): Better handling of thinking models

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -176,7 +176,7 @@ def tests_brevitas_examples_llm_lighteval(session, pytorch, jit_status):
     cmd += install_pytorch_cmd(pytorch)
     cmd += install_torchvision_cmd(pytorch)  # Optim um seems to require torchvision
 
-    session.install('-e', '.[test, llm, export]', *cmd, 'lighteval[math]')
+    session.install('-e', '.[test, llm, export, lighteval]', *cmd)
     session.run('pytest', '-n', 'logical', '-m', 'few_shot', 'tests/brevitas_examples/test_llm.py')
 
 

--- a/requirements/requirements-lighteval.txt
+++ b/requirements/requirements-lighteval.txt
@@ -1,0 +1,1 @@
+lighteval[math]==0.13

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "tts": read_requirements('requirements-tts.txt'),
         "stt": read_requirements('requirements-stt.txt'),
         "llm": read_requirements('requirements-llm.txt'),
+        "lighteval": read_requirements('requirements-lighteval.txt'),
         "diffusion": read_requirements('requirements-diffusion.txt'),
         "vision": read_requirements('requirements-vision.txt'),
         "finn_integration": read_requirements('requirements-finn-integration.txt'),

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -38,7 +38,9 @@ from lighteval.pipeline import ParallelismManager
 from lighteval.pipeline import Pipeline
 from lighteval.pipeline import PipelineParameters
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
+from lighteval.tasks.prompt_manager import PromptManager
 from lighteval.tasks.requests import Doc
+from lighteval.tasks.requests import SamplingMethod
 from torch import nn
 from transformers import AutoTokenizer
 
@@ -130,6 +132,74 @@ TASKS_TABLE = [hellaswag_lm_eval, piqa_lm_eval]
 ### End of LightEval custom tasks
 
 
+class BrevitasPromptManager(PromptManager):
+    """Task-type-aware PromptManager that handles reasoning models like Qwen3.
+
+    Reasoning models (e.g. Qwen3) have two problems with lighteval's default PromptManager:
+
+    1. **Loglikelihood tasks**: When a chat template is used, Qwen3's template ends
+       the prompt with ``<|im_start|>assistant\n``, at which point the model's probability
+       distribution heavily favours ``<think>`` as the next token.  Passing
+       ``enable_thinking=False`` makes it worse by injecting an empty
+       ``<think>\\n\\n</think>\\n\\n`` block between context and continuation, corrupting
+       the loglikelihood computation.  Plain-text formatting avoids both issues.
+    2. **Generative tasks** (e.g. GSM8K): Instruct-tuned models need the chat template
+       to produce useful output, but thinking mode must be suppressed so the model does
+       not waste the token budget on ``<think>...</think>`` blocks.
+
+    This subclass inspects ``doc.sampling_methods`` and routes accordingly:
+
+    * ``LOGPROBS`` / ``PERPLEXITY`` → plain-text formatting (no chat template).
+    * ``GENERATIVE`` → chat template with ``enable_thinking=False``.
+
+    For non-reasoning models the ``enable_thinking`` kwarg is silently ignored by Jinja2,
+    so this is safe to use unconditionally.
+    """
+
+    def prepare_prompt(self, doc: Doc) -> str:
+        is_generative = SamplingMethod.GENERATIVE in doc.sampling_methods
+        if is_generative and self.use_chat_template:
+            return self._prepare_chat_template_no_thinking(doc)
+        else:
+            # For loglikelihood / perplexity tasks, always use plain text so
+            # that no thinking block or chat framing interferes with the
+            # probability computation over continuation tokens.
+            return self._prepare_plain_text(doc)
+
+    def _prepare_chat_template_no_thinking(self, doc: Doc) -> str:
+        """Format using the chat template with thinking mode explicitly disabled."""
+        messages = []
+        instruction_used = False
+
+        if self.system_prompt is not None:
+            messages.append({"role": "system", "content": self.system_prompt})
+
+        for ix, fewshot_sample in enumerate(doc.fewshot_samples):
+            query = self._extract_query(fewshot_sample.query, fewshot_sample.instruction)
+            if ix == 0 and doc.instruction is not None:
+                instruction_used = True
+                query = doc.instruction + query
+
+            messages.append({"role": "user", "content": query})
+            messages.append({"role": "assistant", "content": fewshot_sample.get_golds()[0]})
+
+        main_query = self._extract_query(doc.query, doc.instruction)
+
+        if doc.instruction is not None and not instruction_used:
+            main_query = doc.instruction + main_query
+
+        messages.append({"role": "user", "content": main_query})
+
+        assert self.tokenizer is not None, "Tokenizer must be set for chat template formatting."
+
+        return self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+
+
 def filter_results(results, tasks):
     # filter out what we actually want to track
     eval_results = dict()
@@ -174,6 +244,18 @@ class BrevitasPipeline(Pipeline):
         if original_pad_token is not None:
             wrapped_model._tokenizer.pad_token = original_pad_token
 
+        # Replace the prompt manager with a task-type-aware variant.
+        # - Loglikelihood tasks use plain text (no chat template) so that
+        #   thinking tokens / chat framing do not corrupt probability computations.
+        # - Generative tasks use the chat template with thinking mode disabled
+        #   so instruct models get proper formatting without wasting the token
+        #   budget on <think>...</think> blocks.
+        wrapped_model.prompt_manager = BrevitasPromptManager(
+            use_chat_template=wrapped_model.use_chat_template,
+            tokenizer=wrapped_model.tokenizer,
+            system_prompt=model_config.system_prompt,
+        )
+
         return wrapped_model
 
 
@@ -202,11 +284,7 @@ def run_lighteval(
         custom_tasks_directory=full_path)
 
     model_config = TransformersModelConfig(
-        model_name=model_name,
-        dtype=dtype,
-        batch_size=batch_size,
-        model_parallel=True,
-        override_chat_template=False)
+        model_name=model_name, dtype=dtype, batch_size=batch_size, model_parallel=True)
 
     # Pipeline expects a comma-separated list of tasks
     tasks = ",".join(tasks)

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -40,6 +40,7 @@ from lighteval.pipeline import PipelineParameters
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
 from lighteval.tasks.requests import Doc
 from torch import nn
+from transformers import AutoTokenizer
 
 ### LightEval Custom Tasks
 
@@ -156,11 +157,24 @@ class BrevitasPipeline(Pipeline):
         assert model is not None and model_config is not None, "Provide both a model and a model config."
         assert not isinstance(model, LightevalModel), "A LigthevalModel and a model config cannot be provided simultaneously."
 
-        return TransformersModel.from_model(
+        # Retrieve the original pad_token before lighteval overwrites it.
+        # lighteval unconditionally does `tokenizer.pad_token = tokenizer.eos_token`
+        # which is wrong for models like Qwen3 that define a distinct pad_token.
+        tokenizer_name = model_config.tokenizer or model_config.model_name
+        original_tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+        original_pad_token = original_tokenizer.pad_token
+
+        wrapped_model = TransformersModel.from_model(
             model=model,
             config=model_config,
             accelerator=self.accelerator,
         )
+
+        # Restore the original pad_token if the model explicitly defined one
+        if original_pad_token is not None:
+            wrapped_model._tokenizer.pad_token = original_pad_token
+
+        return wrapped_model
 
 
 def run_lighteval(

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -25,6 +25,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from functools import partial
 import os
 import pathlib
 import re
@@ -168,36 +169,12 @@ class BrevitasPromptManager(PromptManager):
 
     def _prepare_chat_template_no_thinking(self, doc: Doc) -> str:
         """Format using the chat template with thinking mode explicitly disabled."""
-        messages = []
-        instruction_used = False
-
-        if self.system_prompt is not None:
-            messages.append({"role": "system", "content": self.system_prompt})
-
-        for ix, fewshot_sample in enumerate(doc.fewshot_samples):
-            query = self._extract_query(fewshot_sample.query, fewshot_sample.instruction)
-            if ix == 0 and doc.instruction is not None:
-                instruction_used = True
-                query = doc.instruction + query
-
-            messages.append({"role": "user", "content": query})
-            messages.append({"role": "assistant", "content": fewshot_sample.get_golds()[0]})
-
-        main_query = self._extract_query(doc.query, doc.instruction)
-
-        if doc.instruction is not None and not instruction_used:
-            main_query = doc.instruction + main_query
-
-        messages.append({"role": "user", "content": main_query})
-
-        assert self.tokenizer is not None, "Tokenizer must be set for chat template formatting."
-
-        return self.tokenizer.apply_chat_template(
-            messages,
-            tokenize=False,
-            add_generation_prompt=True,
-            enable_thinking=False,
-        )
+        orig_apply = self.tokenizer.apply_chat_template
+        try:
+            self.tokenizer.apply_chat_template = partial(orig_apply, enable_thinking=False)
+            return self._prepare_chat_template(doc)
+        finally:
+            self.tokenizer.apply_chat_template = orig_apply
 
 
 def filter_results(results, tasks):

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -202,7 +202,11 @@ def run_lighteval(
         custom_tasks_directory=full_path)
 
     model_config = TransformersModelConfig(
-        model_name=model_name, dtype=dtype, batch_size=batch_size, model_parallel=True)
+        model_name=model_name,
+        dtype=dtype,
+        batch_size=batch_size,
+        model_parallel=True,
+        override_chat_template=False)
 
     # Pipeline expects a comma-separated list of tasks
     tasks = ",".join(tasks)

--- a/src/brevitas_examples/llm/eval_lighteval.py
+++ b/src/brevitas_examples/llm/eval_lighteval.py
@@ -167,7 +167,11 @@ class BrevitasPromptManager(PromptManager):
             return self._prepare_plain_text(doc)
 
     def _prepare_chat_template_no_thinking(self, doc: Doc) -> str:
-        """Format using the chat template with thinking mode explicitly disabled."""
+        """
+        Format using the chat template with thinking mode explicitly disabled.
+        This is copied from: https://github.com/huggingface/lighteval/blob/3fd15266bc8448b797e61462d293aa3fd40b3580/src/lighteval/tasks/prompt_manager.py#L97
+        The only difference is enable_thinking=False when calling the tokenizer.
+        """
         messages = []
         instruction_used = False
 


### PR DESCRIPTION
## Reason for this PR

Lighteval does not handle well model with thinking enabled.
Similarly, there is an issue in how we handle `pad_token`, since they are always over-written to `pad_token`.


Now lighteval is pinned and it should be unpinned when they fix the issue linked below.

## Changes Made in this PR

This PR does two things:
- preserves `pad_token`
- Disables chat_template, which also disables thinking.

## Results

### MXFP8 Qwen 1.7B

Before Fix:

 'arc:challenge:0_acc': 32.08
 'arc:easy:0_acc': 43.45
 'hellaswag_lm_eval:0_acc': 42.83
 'winogrande:0_acc': 55.16


After Fix:

 'arc:challenge:0_acc': 39.76
 'arc:easy:0_acc': 71.42
 'hellaswag_lm_eval:0_acc': 46.06
 'winogrande:0_acc': 56.99

### BF16 Qwen3 0.7B

Before Fix:
 'arc:easy:0_acc':  38.67
'gsm8k:0_extractive_match': 12.59

After Fix:
 'arc:easy:0_acc':  60.48
'gsm8k:0_extractive_match': 52.16


### BF16 Llama 3.2 1B:

Before/After Fix:
 'arc:easy:0_acc':  66.41

### BF16 Llama 3.2 1B Instruct:

Before/After Fix:
'gsm8k:0_extractive_match': 35.94

cc: @pablomlago @i-colbert 