### PR TITLE
Feat (utils): reducing variance on power_iteration func

### DIFF
--- a/src/brevitas/graph/magr.py
+++ b/src/brevitas/graph/magr.py
@@ -14,6 +14,7 @@ from brevitas.graph.gpxq import GPxQ
 from brevitas.graph.gpxq import gpxq_mode
 from brevitas.graph.gpxq import SUPPORTED_CONV_OP
 from brevitas.graph.utils import is_conv_transposed
+from brevitas.graph.utils import power_iteration
 
 
 def _project_onto_l1_ball(x, eps=1.0):
@@ -53,19 +54,6 @@ def _project_onto_l1_ball(x, eps=1.0):
     proj = (torch.abs(x) - theta.unsqueeze(1)).clamp(min=0)
     x = mask * x + (1 - mask) * proj * torch.sign(x)
     return x
-
-
-def _power_iteration(H, steps: int, eps: float = 1e-12):
-    """
-    Power iteration to compute the maximum singular value for the Hessian.
-    """
-    b_k = torch.rand(H.shape[1], device=H.device)
-    for _ in range(steps):
-        b_k1 = torch.mv(H, b_k)  # Calculate the matrix-by-vector product H*b_k
-        b_k1_norm = torch.norm(b_k1)  # Calculate the norm
-        b_k = b_k1 / (b_k1_norm + eps)  # Re normalize the vector
-    max_singular_value = torch.dot(b_k, torch.mv(H, b_k))
-    return max_singular_value
 
 
 class MagR(GPTQ):
@@ -139,7 +127,7 @@ class MagR(GPTQ):
         self.H = self.H.to(dev)
         for group_index in range(self.groups):
             # approximate maximum singular value (ie, matrix L2 norm)
-            eta = 1. / _power_iteration(self.H[group_index], steps=self.power_steps)
+            eta = 1. / power_iteration(self.H[group_index], steps=self.power_steps)
             alpha = self.alpha / (eta * torch.linalg.norm(self.H[group_index], ord=1))
             wk = weight[group_index].to(self.dtype)
             gk = weight_orig[group_index].to(self.dtype)  # ground

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -16,6 +16,7 @@ import warnings
 from brevitas.graph.gpfq import GPFQ
 from brevitas.graph.gpxq import SUPPORTED_CONV_OP
 from brevitas.graph.utils import is_conv_transposed
+from brevitas.graph.utils import power_iteration
 from brevitas.utils.torch_utils import StopFwdException
 
 
@@ -93,7 +94,6 @@ class Qronos(GPFQ):
             raise StopFwdException
 
     def single_layer_update(self, beta: int = 1e4):
-        from brevitas.graph.magr import _power_iteration
         assert not self.layer.weight_quant.requires_quant_input, \
             "Error: Qronos does not support weight quantizers that require metadata from input quantizers."
         assert hasattr(self.layer, 'weight_orig'), \
@@ -166,7 +166,7 @@ class Qronos(GPFQ):
         try:
             for group_index in range(self.groups):
                 # using power iteration to estimate the maximum singular value
-                damp[group_index] = self.alpha * _power_iteration(self.H[group_index], 30)
+                damp[group_index] = self.alpha * power_iteration(self.H[group_index], 30)
                 self.iH[group_index, diag, diag] += damp[group_index]
                 self.iH[group_index] = torch.linalg.cholesky(self.iH[group_index])
                 self.iH[group_index] = torch.cholesky_inverse(self.iH[group_index])

--- a/src/brevitas/graph/utils.py
+++ b/src/brevitas/graph/utils.py
@@ -208,16 +208,20 @@ def power_iteration(
         H: torch.Tensor,
         steps: int,
         eps: float = 1e-12,
-        device: Union[str, torch.device] = 'cpu') -> torch.Tensor:
+        device: Union[str, torch.device] = 'cpu',
+        seed: int = 42) -> torch.Tensor:
     """
     Power iteration to estimate the dominant eigenvalue of the Hessian.
     Accuracy improves with `steps`. Several choices below reduce run-to-run variation.
     """
-    # CPU default: floating-point reductions on CPU tend to be more deterministic than on GPU
-    b_k = torch.ones(H.shape[1], device=device, dtype=H.dtype)
-    # `torch.ones` (vs `torch.randn`) avoids variation with negligible impact on convergence
-    c_k = H.max().abs()
+    # device='cpu' by default; CPU reductions tend to be more deterministic than on GPU
+    if not isinstance(device, torch.device):
+        device = torch.device(device)
+    # fixing generator mitigates run-to-run variation with negligible impact on convergence
+    g = torch.Generator(device=device).manual_seed(seed)
+    b_k = torch.rand(H.shape[1], device=device, dtype=H.dtype, generator=g)
     # normalize H by its absmax for numerical stability; rescale the eigenvalue before returning
+    c_k = H.max().abs()
     H_k = (H / c_k).to(device)
     for _ in range(steps):
         b_k1 = torch.mv(H_k, b_k)

--- a/src/brevitas/graph/utils.py
+++ b/src/brevitas/graph/utils.py
@@ -7,6 +7,7 @@ from typing import Dict
 from typing import Iterable
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 import torch
 from torch import nn
@@ -31,7 +32,8 @@ __all__ = [
     'name_from_module',
     'matches_module_pattern',
     'get_output_channels',
-    'get_output_channel_dim']
+    'get_output_channel_dim',
+    'power_iteration']
 
 CONV_TRANSPOSED = (
     nn.ConvTranspose1d,
@@ -200,3 +202,27 @@ def remove_weight_orig(model: nn.Module):
     for name, module in model.named_modules():
         if hasattr(module, 'weight_orig'):
             del module.weight_orig
+
+
+def power_iteration(
+        H: torch.Tensor,
+        steps: int,
+        eps: float = 1e-12,
+        device: Union[str, torch.device] = 'cpu') -> torch.Tensor:
+    """
+    Power iteration to estimate the dominant eigenvalue of the Hessian.
+    Accuracy improves with `steps`. Several choices below reduce run-to-run variation.
+    """
+    # CPU default: floating-point reductions on CPU tend to be more deterministic than on GPU
+    b_k = torch.ones(H.shape[1], device=device, dtype=H.dtype)
+    # `torch.ones` (vs `torch.randn`) avoids variation with negligible impact on convergence
+    c_k = H.max().abs()
+    # normalize H by its absmax for numerical stability; rescale the eigenvalue before returning
+    H_k = (H / c_k).to(device)
+    for _ in range(steps):
+        b_k1 = torch.mv(H_k, b_k)
+        b_k1_norm = torch.norm(b_k1)
+        b_k = b_k1 / (b_k1_norm + eps)
+    # Rayleigh quotient on the normalized H, then undo the absmax scaling; return on H.device
+    max_eigenval = torch.dot(b_k, torch.mv(H_k, b_k)).to(c_k.device) * c_k
+    return max_eigenval


### PR DESCRIPTION
## Reason for this PR

Qronos was exhibiting run-to-run variation traced to `_power_iteration`. Sources: random init (`torch.rand`) coupled to the global RNG, and non-deterministic GPU floating-point reductions.

## Changes Made in this PR

- Moved `_power_iteration` from `brevitas/graph/magr.py` to `brevitas/graph/utils.py` and renamed to `power_iteration` (now public).
- Updated `magr.py` and `qronos.py` to import from `utils`.
- Determinism / stability improvements in the function:
  - Deterministic init: using local RNG with manual seed for `torch.rand`.
  - Default `device='cpu'` (configurable) — CPU FP reductions are more deterministic than GPU.
  - Normalize `H` by its absmax before iterating; rescale the eigenvalue before returning (numerical stability).
- Return type unchanged (tensor on `H.device`); call sites unchanged.

Notes: 
- `_power_iteration` was module-private; rename to public `power_iteration`. 
- Default device change to CPU may slightly alter numeric results vs prior runs (intentional; trade for determinism).

## Testing Summary

Compared the WikiText2 perplexity before and after the change to verify results are minimally perturbed:

```shell
brevitas_ptq_llm --config=config.yml --model=meta-llama/Llama-3.2-1B
```

where the `config.yml` is based on the Qronos example config [here](https://github.com/Xilinx/brevitas/blob/b106358c4169d8a9b68cb2a531aa795417d74887/src/brevitas_examples/papers/qronos/llama3-w4a4-int-quarot.yml), as given below:

```yaml
bos_preprocessing: sequence
dtype: bfloat16
eval: true
gpxq_act_order: true
gpxq_buffer_device: same
gpxq_block_name: model.layers
input_bit_width: 4
input_quant_granularity: per_row
input_scale_type: dynamic
qronos: true
qronos_alpha: 1e-3
replace_rmsnorm: true
rotation: fused_no_fx
rotation_sdpa_regions: true
rotation_mode: had
rotation_orphan_sink: true
weight_bit_width: 4
weight_param_method: mse
weight_quant_granularity: per_channel
weight_quant_type: sym
```

| model | ref | before | after |
  |---|---|---|---|
  | meta-llama/Llama-3.2-1B | 8.975 | 12.288 | 12.265 |
  | Qwen/Qwen3-1.7B | 15.733 | 24.097 | 24.059 |

- ref = BF16 reference perplexity
- before = the results based on dev (commit = 7f9d515)
- after = this PR (commit = 4af0297)

## Risk Highlight

- [x] There are coverage gaps not covered by tests.

These fixed are known to improve run-to-run variation and should have minimal impact on the convergence of `power_iteration`; however, regressions are possible. Light testing was done on a few models (see above).

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [x] Initial CI/CD passing.
- [x] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.

@nickfraser 
