### PR TITLE
Feat (llm/eval): Standard deviation to perplexity computation

### DIFF
--- a/src/brevitas_examples/llm/benchmark/llm_benchmark.py
+++ b/src/brevitas_examples/llm/benchmark/llm_benchmark.py
@@ -21,16 +21,27 @@ from brevitas_examples.llm.llm_args import validate as validate_llm_args
 class LLMEntryPointUtils(EntryPointUtils):
 
     argument_parser: ArgumentParser = create_llm_args_parser()
-    eval_metrics: List[str] = ["float_ppl", "quant_ppl"]
+    eval_metrics: List[str] = ["float_ppl", "float_ppl_std", "quant_ppl", "quant_ppl_std"]
 
     @staticmethod
     def parse_log(job_log: str) -> Dict[str, Any]:
-        # Find the line containing Float PPL number
-        float_ppl_line = re.search(r"Float perplexity \((.*?)\): (\d+\.\d+)", job_log)
+        # Perplexity lines now include a bootstrap standard deviation in the
+        # form: "<Float|Quantized> perplexity (<dataset>): <ppl> ± <std>".
+        # The "± <std>" group is optional to remain backward-compatible with
+        # logs produced before the stderr was added.
+        ppl_pattern = r"{kind} perplexity \((.*?)\): (\d+\.\d+)(?:\s*±\s*(\d+\.\d+))?"
+        # Find the line containing Float PPL number (and optional stddev)
+        float_ppl_line = re.search(ppl_pattern.format(kind="Float"), job_log)
         float_ppl = float(float_ppl_line.group(2)) if float_ppl_line is not None else None
-        # Find the line containing Quant PPL number
-        quant_ppl_line = re.search(r"Quantized perplexity \((.*?)\): (\d+\.\d+)", job_log)
+        float_ppl_std = (
+            float(float_ppl_line.group(3))
+            if float_ppl_line is not None and float_ppl_line.group(3) is not None else None)
+        # Find the line containing Quant PPL number (and optional stddev)
+        quant_ppl_line = re.search(ppl_pattern.format(kind="Quantized"), job_log)
         quant_ppl = float(quant_ppl_line.group(2)) if quant_ppl_line is not None else None
+        quant_ppl_std = (
+            float(quant_ppl_line.group(3))
+            if quant_ppl_line is not None and quant_ppl_line.group(3) is not None else None)
         # Search for dictionary in log
         few_shot_eval_line = re.findall(r"({.*?})", job_log)
         # Retrieve last dictionary, in case other dictionaries were printed to the log
@@ -38,7 +49,9 @@ class LLMEntryPointUtils(EntryPointUtils):
         # Return the results from the log as a dictionary
         job_log_results = {
             "float_ppl": float_ppl,
+            "float_ppl_std": float_ppl_std,
             "quant_ppl": quant_ppl,
+            "quant_ppl_std": quant_ppl_std,
             **few_shot_eval,}
         return job_log_results
 

--- a/src/brevitas_examples/llm/llm_quant/eval.py
+++ b/src/brevitas_examples/llm/llm_quant/eval.py
@@ -42,13 +42,15 @@ def perplexity_statistic(nlls: np.ndarray) -> float:
     return np.exp(np.mean(nlls)).item()
 
 
-def compute_perplexity_std(nlls: List[torch.Tensor], n_resamples: int = 1000) -> float:
+def compute_perplexity_std(
+        nlls: List[torch.Tensor], n_resamples: int = 1000, seed: int = 0) -> float:
     return bootstrap(
         data=[nlls],
         statistic=perplexity_statistic,
         n_resamples=n_resamples,
         confidence_level=0.95,
         method="BCa",
+        random_state=seed,
     ).standard_error
 
 
@@ -116,6 +118,6 @@ def compute_perplexity(
             nlls.append(loss)
 
     ppl = torch.exp(torch.stack(nlls).mean())
-    ppl_std = compute_perplexity_std(nlls)
+    ppl_std = compute_perplexity_std(nlls, seed=seed)
 
     return ppl.item(), ppl_std

--- a/src/brevitas_examples/llm/llm_quant/eval.py
+++ b/src/brevitas_examples/llm/llm_quant/eval.py
@@ -38,6 +38,20 @@ from tqdm import tqdm
 from brevitas_examples.llm.llm_quant.data_utils import recursive_to_device
 
 
+def perplexity_statistic(nlls: np.ndarray) -> float:
+    return np.exp(np.mean(nlls)).item()
+
+
+def compute_perplexity_std(nlls: List[torch.Tensor], n_resamples: int = 1000) -> float:
+    return bootstrap(
+        data=[nlls],
+        statistic=perplexity_statistic,
+        n_resamples=n_resamples,
+        confidence_level=0.95,
+        method="BCa",
+    ).standard_error
+
+
 def create_validation_dataloader(data, seqlen, device):
     nsamples = data['input_ids'].numel() // seqlen
     val_dataloader = []
@@ -102,12 +116,6 @@ def compute_perplexity(
             nlls.append(loss)
 
     ppl = torch.exp(torch.stack(nlls).mean())
-    ppl_std = bootstrap(
-        data=[nlls],
-        statistic=lambda x: np.exp(np.mean(x)).item(),
-        n_resamples=1000,
-        confidence_level=0.95,
-        method="BCa",
-    ).standard_error
+    ppl_std = compute_perplexity_std(nlls)
 
     return ppl.item(), ppl_std

--- a/src/brevitas_examples/llm/llm_quant/eval.py
+++ b/src/brevitas_examples/llm/llm_quant/eval.py
@@ -25,11 +25,12 @@ SOFTWARE.
 """
 
 import random
-from typing import Any
 from typing import Dict
 from typing import List
+from typing import Tuple
 
 import numpy as np
+from scipy.stats import bootstrap
 import torch
 from torch import nn
 from tqdm import tqdm
@@ -52,9 +53,8 @@ def compute_perplexity(
         model: torch.nn.Module,
         data: List[Dict],
         context_length: int,
-        tokenizer: Any,
         seed: int = 0,
-        dtype: torch.dtype = torch.float32):
+        dtype: torch.dtype = torch.float32) -> Tuple[float, float]:
     random.seed(seed)
     np.random.seed(seed)
     torch.random.manual_seed(seed)
@@ -102,5 +102,12 @@ def compute_perplexity(
             nlls.append(loss)
 
     ppl = torch.exp(torch.stack(nlls).mean())
+    ppl_std = bootstrap(
+        data=[nlls],
+        statistic=lambda x: np.exp(np.mean(x)).item(),
+        n_resamples=1000,
+        confidence_level=0.95,
+        method="BCa",
+    ).standard_error
 
-    return ppl.item()
+    return ppl.item(), ppl_std

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -322,10 +322,10 @@ def quantize_llm(args, extra_args=None):
     if args.eval:
         print("Float model eval...")
         model = offload_model(model)
-        float_ppl = compute_perplexity(
-            model, validation_loader, context_length=args.seqlen // 2, tokenizer=tokenizer)
+        float_ppl, float_ppl_std = compute_perplexity(
+            model, validation_loader, context_length=args.seqlen // 2)
         remove_hooks(model)
-        print(f"Float perplexity ({args.dataset}): {float_ppl:.3f}")
+        print(f"Float perplexity ({args.dataset}): {float_ppl:.3f} ± {float_ppl_std:.3f}")
 
     rmsnorm_classes = ()
     if require_fx:
@@ -710,9 +710,9 @@ def quantize_llm(args, extra_args=None):
             print("Model eval...")
             with torch.no_grad(), quant_inference_mode(model, compile=args.compile_eval):
                 model(**next(iter(calibration_loader)))
-                quant_ppl = compute_perplexity(
-                    model, validation_loader, context_length=args.seqlen // 2, tokenizer=tokenizer)
-            print(f"Quantized perplexity ({args.dataset}): {quant_ppl:.3f}")
+                quant_ppl, quant_ppl_std = compute_perplexity(
+                    model, validation_loader, context_length=args.seqlen // 2)
+            print(f"Quantized perplexity ({args.dataset}): {quant_ppl:.3f} ± {quant_ppl_std:.3f}")
         few_shot_eval_results = dict()
         if args.few_shot_eval == 'lm_eval':
             from lm_eval import evaluator
@@ -765,7 +765,7 @@ def quantize_llm(args, extra_args=None):
             model = model.to(dtype=torch.float32)
             model_export(model, tokenizer, next(iter(calibration_loader)), args, config)
 
-    return {"float_ppl": float_ppl, "quant_ppl": quant_ppl, **few_shot_eval_results}, model
+    return {"float_ppl": float_ppl, "float_ppl_std": float_ppl_std, "quant_ppl": quant_ppl, "quant_ppl_std": quant_ppl_std, **few_shot_eval_results}, model
 
 
 def main():

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -269,8 +269,8 @@ def quantize_llm(args, extra_args=None):
     print("Model loaded.")
     model.eval()
     tokenizer = AutoTokenizer.from_pretrained(args.model)
-    float_ppl = None
-    quant_ppl = None
+    float_ppl = float_ppl_std = None
+    quant_ppl = quant_ppl_std = None
 
     require_fx = fx_required(args)
     if require_fx and args.calibration_batch_size > 1:

--- a/tests/brevitas_examples/test_llm_benchmark.py
+++ b/tests/brevitas_examples/test_llm_benchmark.py
@@ -73,6 +73,48 @@ class TestLLMEntryPointUtils:
         result = LLMEntryPointUtils.parse_log(log)
         assert result["float_ppl"] == pytest.approx(25.123)
         assert result["quant_ppl"] == pytest.approx(30.456)
+        # No stddev present in the log -> std fields should be None
+        assert result["float_ppl_std"] is None
+        assert result["quant_ppl_std"] is None
+
+    @pytest.mark.llm
+    def test_parse_log_float_and_quant_ppl_with_std(self):
+        log = (
+            "Loading model...\n"
+            "Float perplexity (wikitext2): 25.123 ± 0.456\n"
+            "Running quantization...\n"
+            "Quantized perplexity (wikitext2): 30.456 ± 1.234\n")
+        result = LLMEntryPointUtils.parse_log(log)
+        assert result["float_ppl"] == pytest.approx(25.123)
+        assert result["quant_ppl"] == pytest.approx(30.456)
+        assert result["float_ppl_std"] == pytest.approx(0.456)
+        assert result["quant_ppl_std"] == pytest.approx(1.234)
+
+    @pytest.mark.llm
+    def test_parse_log_mixed_ppl_std(self):
+        # Only the float line carries a stddev; the quant line does not.
+        log = (
+            "Float perplexity (wikitext2): 25.123 ± 0.456\n"
+            "Quantized perplexity (wikitext2): 30.456\n")
+        result = LLMEntryPointUtils.parse_log(log)
+        assert result["float_ppl"] == pytest.approx(25.123)
+        assert result["float_ppl_std"] == pytest.approx(0.456)
+        assert result["quant_ppl"] == pytest.approx(30.456)
+        assert result["quant_ppl_std"] is None
+
+    @pytest.mark.llm
+    def test_parse_log_ppl_std_with_few_shot_dict(self):
+        log = (
+            "Float perplexity (wikitext2): 25.0 ± 0.5\n"
+            "Quantized perplexity (wikitext2): 30.0 ± 0.75\n"
+            "Few-shot results: {'task_a': 0.85, 'task_b': 0.72}\n")
+        result = LLMEntryPointUtils.parse_log(log)
+        assert result["float_ppl"] == pytest.approx(25.0)
+        assert result["float_ppl_std"] == pytest.approx(0.5)
+        assert result["quant_ppl"] == pytest.approx(30.0)
+        assert result["quant_ppl_std"] == pytest.approx(0.75)
+        assert result["task_a"] == pytest.approx(0.85)
+        assert result["task_b"] == pytest.approx(0.72)
 
     @pytest.mark.llm
     def test_parse_log_missing_ppl(self):
@@ -80,6 +122,8 @@ class TestLLMEntryPointUtils:
         result = LLMEntryPointUtils.parse_log(log)
         assert result["float_ppl"] is None
         assert result["quant_ppl"] is None
+        assert result["float_ppl_std"] is None
+        assert result["quant_ppl_std"] is None
 
     @pytest.mark.llm
     def test_parse_log_with_few_shot_dict(self):

--- a/tests/brevitas_examples/test_llm_cases.py
+++ b/tests/brevitas_examples/test_llm_cases.py
@@ -130,7 +130,7 @@ class LLMRunCases:
 
 class LLMPerplexityCases:
 
-    METRICS = ["float_ppl", "quant_ppl"]
+    METRICS = ["float_ppl", "float_ppl_std", "quant_ppl", "quant_ppl_std"]
 
     @pytest_cases.parametrize(
         "run_dict",
@@ -140,7 +140,9 @@ class LLMPerplexityCases:
                 "act_equalization": "fx",
                 "bias_corr": True,
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30861.037109375},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30861.037109375,
+                "quant_ppl_std": 601.663665771637},
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
                 "act_equalization": "fx",
@@ -151,20 +153,26 @@ class LLMPerplexityCases:
                 "input_scale_type": "dynamic",
                 "input_quant_type": "sym",
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30793.537109375},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30793.537109375,
+                "quant_ppl_std": 669.3832959738031},
             {
                 "model": "hf-internal-testing/tiny-random-MistralForCausalLM",
                 "act_equalization": "layerwise",
                 "gptq": True,
                 "float_ppl": 30977.689453125,
-                "quant_ppl": 30958.1953125},
+                "float_ppl_std": 1671.032110532286,
+                "quant_ppl": 30958.1953125,
+                "quant_ppl_std": 1691.3981234783435},
             {
                 "model": "hf-internal-testing/tiny-random-OPTForCausalLM",  # Requires PT>=2.4 to run
                 "weight_equalization": True,
                 "ln_affine_merge": True,
                 "quant_sdpa": "fx",
                 "float_ppl": 46088.265625,
-                "quant_ppl": 46327.50390625},
+                "float_ppl_std": 199.9905675546479,
+                "quant_ppl": 46327.50390625,
+                "quant_ppl_std": 136.1585749644498},
             {
                 "model": "hf-internal-testing/tiny-random-OPTForCausalLM",  # Requires PT>=2.4 to run
                 "calibration_batch_size": 2,
@@ -175,13 +183,17 @@ class LLMPerplexityCases:
                 "replace_rmsnorm": True,
                 "rotation": "fx",
                 "float_ppl": 54132.29296875,
-                "quant_ppl": 54140.08984375},
+                "float_ppl_std": 1978.9791772078315,
+                "quant_ppl": 54140.08984375,
+                "quant_ppl_std": 1975.9974768628379},
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
                 "weight_bit_width": 2,
                 "weight_scale_precision": "signed_float_scale",
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30970.068359375},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30970.068359375,
+                "quant_ppl_std": 857.2790883540771},
         ],
         ids=[
         "llama",
@@ -206,7 +218,9 @@ class LLMPerplexityCases:
                 "learned_round_iters": 1,
                 "gpxq_block_name": "model.layers",
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30675.064453125},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30675.064453125,
+                "quant_ppl_std": 710.8173230643938},
             {
                 "model": "hf-internal-testing/tiny-random-MistralForCausalLM",
                 "act_calibration": False,
@@ -216,7 +230,9 @@ class LLMPerplexityCases:
                 "learned_round_iters": 1,
                 "gpxq_block_name": "model.layers",
                 "float_ppl": 30977.689453125,
-                "quant_ppl": 30952.52734375}
+                "float_ppl_std": 1671.032110532286,
+                "quant_ppl": 30952.52734375,
+                "quant_ppl_std": 1725.542824268925}
         ],
         ids=[
         "llama",
@@ -238,7 +254,9 @@ class LLMPerplexityCases:
                 "rotation_orphan_sink": True,
                 "rotation_mode": "ort",
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30991.04296875,},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30991.04296875,
+                "quant_ppl_std": 650.7103167621774,},
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
                 "act_calibration": False,
@@ -249,7 +267,9 @@ class LLMPerplexityCases:
                 "rotation_orphan_sink": False,
                 "rotation_mode": "ort",
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 31010.615234375,},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 31010.615234375,
+                "quant_ppl_std": 642.2877862447889,},
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
                 "act_calibration": False,
@@ -260,7 +280,9 @@ class LLMPerplexityCases:
                 "rotation_orphan_sink": True,
                 "rotation_mode": "had",
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30956.54296875,},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30956.54296875,
+                "quant_ppl_std": 751.3056909728539,},
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
                 "act_calibration": False,
@@ -271,7 +293,9 @@ class LLMPerplexityCases:
                 "rotation_orphan_sink": False,
                 "rotation_mode": "had",
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30836.9140625},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30836.9140625,
+                "quant_ppl_std": 659.8222860924172},
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
                 "act_calibration": False,
@@ -280,7 +304,9 @@ class LLMPerplexityCases:
                 "replace_rmsnorm": True,
                 "rotation": "layerwise",
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30829.4453125,},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30829.4453125,
+                "quant_ppl_std": 622.7214648762634,},
             {
                 "model": "hf-internal-testing/tiny-random-LlamaForCausalLM",
                 "act_calibration": False,
@@ -292,7 +318,9 @@ class LLMPerplexityCases:
                 "rotation_mode": "had",
                 "rotation_layers_to_expand": ["down_proj"],
                 "float_ppl": 30795.76953125,
-                "quant_ppl": 30830.03125,},
+                "float_ppl_std": 662.4800347375229,
+                "quant_ppl": 30830.03125,
+                "quant_ppl_std": 666.6440793569817,},
         ],
         ids=[
         "llama_fused_rotation_ort",
@@ -672,7 +700,9 @@ class LLMRotationOptimizationCases:
                         "--gradient_accumulation_steps",
                         "1"],
                     "float_ppl": 30795.76953125,
+                    "float_ppl_std": 662.4800347375229,
                     "quant_ppl": 30973.669921875,
+                    "quant_ppl_std": 637.1799227775473,
                     "exp_layer_types_count": {
                         "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 4,
                         "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -700,7 +730,9 @@ class LLMRotationOptimizationCases:
                         "--gradient_accumulation_steps",
                         "1"],
                     "float_ppl": 30795.76953125,
+                    "float_ppl_std": 662.4800347375229,
                     "quant_ppl": 30941.7265625,
+                    "quant_ppl_std": 623.6674844824048,
                     "exp_layer_types_count": {
                         "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 0,
                         "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -728,7 +760,9 @@ class LLMRotationOptimizationCases:
                         "--gradient_accumulation_steps",
                         "1"],
                     "float_ppl": 30795.76953125,
+                    "float_ppl_std": 662.4800347375229,
                     "quant_ppl": 30656.814453125,
+                    "quant_ppl_std": 765.8540938415475,
                     "exp_layer_types_count": {
                         "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 4,
                         "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -757,7 +791,9 @@ class LLMRotationOptimizationCases:
                         "--gradient_accumulation_steps",
                         "1"],
                     "float_ppl": 30795.76953125,
+                    "float_ppl_std": 662.4800347375229,
                     "quant_ppl": 30851.2089843750,
+                    "quant_ppl_std": 771.1960722127169,
                     "exp_layer_types_count": {
                         "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 2,
                         "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -787,7 +823,9 @@ class LLMRotationOptimizationCases:
                         "--gradient_accumulation_steps",
                         "1"],
                     "float_ppl": 30795.76953125,
+                    "float_ppl_std": 662.4800347375229,
                     "quant_ppl": 30850.916015625,
+                    "quant_ppl_std": 770.4295013673005,
                     "exp_layer_types_count": {
                         "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 2,
                         "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -815,7 +853,9 @@ class LLMRotationOptimizationCases:
                         "--gradient_accumulation_steps",
                         "1"],
                     "float_ppl": 30795.76953125,
+                    "float_ppl_std": 662.4800347375229,
                     "quant_ppl": 30751.923828125,
+                    "quant_ppl_std": 682.3287912882615,
                     "exp_layer_types_count": {
                         "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 0,
                         "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,
@@ -847,7 +887,9 @@ class LLMRotationOptimizationCases:
                         "--gradient_accumulation_steps",
                         "1"],
                     "float_ppl": 30795.76953125,
+                    "float_ppl_std": 662.4800347375229,
                     "quant_ppl": 30688.232421875,
+                    "quant_ppl_std": 732.6270998786874,
                     "exp_layer_types_count": {
                         "<class 'brevitas.nn.equalized_layer.RotatedModule'>": 0,
                         "<class 'torch.nn.utils.parametrize.ParametrizedLinear'>": 1,


### PR DESCRIPTION
## Reason for this PR

`compute_perplexity` reports a single point estimate, making it hard to tell whether perplexity differences between configurations (float vs. quantized, recipe A vs. B) are meaningful. Other ecosystem tools (lm-eval-harness, lighteval) report a bootstrap stderr alongside perplexity for this reason.

## Changes Made in this PR

- `src/brevitas_examples/llm/llm_quant/eval.py`
  - `compute_perplexity` now returns `Tuple[float, float]`: `(ppl, ppl_std)`.
  - Stderr computed via `scipy.stats.bootstrap` over the per-sequence NLLs with statistic `exp(mean(x))`, `n_resamples=1000`, `method="BCa"`.
- `src/brevitas_examples/llm/main.py`
  - Both call sites unpack the tuple and print `"<X> perplexity (<dataset>): <ppl:.3f> ± <std:.3f>"`.
- `src/brevitas_examples/llm/benchmark/llm_benchmark.py`
  - `eval_metrics` extended with `float_ppl_std` and `quant_ppl_std`.
  - `parse_log` regex updated to capture the new `± <std>` suffix as an optional group, keeping backward compatibility with older logs.

Bootstrap was chosen over a closed-form stderr because perplexity (`exp(mean(nll))`) is non-linear in the NLLs; this matches the lighteval/lm-eval convention.

## Testing Summary

- Sanity import of the new `compute_perplexity` signature.
- Manual float + quantized eval run confirming the new print format and that `parse_log` extracts both ppl and std.
- Verified `parse_log` backward compatibility on logs without the `± <std>` suffix (returns `None` for `_std` fields).

## Risk Highlight

- [x] This PR includes code from another work (please detail).
  - Bootstrap design follows lighteval's `bootstrap_stderr_scipy` (MIT, EleutherAI / HuggingFace 2024).
- [x] This PR contains API-breaking changes.
  - `compute_perplexity` return type changes from `float` to `Tuple[float, float]`. In-tree call sites are updated.
- [ ] This PR depends on work in another PR (please provide links/details).
- [x] This PR introduces new dependencies (please detail).
  - First direct use of `scipy.stats.bootstrap` in this module (`scipy` is already a transitive dep).
- [x] There are coverage gaps not covered by tests.
  - No dedicated unit test for the bootstrap stderr; covered indirectly via existing eval/benchmark paths.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
