### PR TITLE
Feat (benchmark): Minor tweaks to `run_args_bucket_process`

### DIFF
--- a/src/brevitas_examples/common/benchmark/utils.py
+++ b/src/brevitas_examples/common/benchmark/utils.py
@@ -116,6 +116,7 @@ def run_args_bucket_process(
         args_queue: Queue):
     # Set visible devices
     os.environ["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
+    os.environ["HIP_VISIBLE_DEVICES"] = cuda_visible_devices
     # Imports are deferred to ensure that CUDA is not initialized
     # in the main process
     from brevitas import __version__ as brevitas_version
@@ -138,11 +139,16 @@ def run_args_bucket_process(
                 break
         except Exception:
             break
-        print(
-            f"Process: {id}, remaining combinations: {args_queue.qsize()}, remaining time: {'unknown' if num_runs == 0 else str(datetime.timedelta(seconds=int((args_queue.qsize() / num_processes + 1)*mean_running_time)))}"
-        )
         job_name = f"{hashlib.md5(_dict_to_bytes(args_dict)).hexdigest()}"
         job_folder = f"{results_folder}/{job_name}"
+        remaining_time = 'unknown'
+        if num_runs != 0:
+            remaining_time = str(
+                datetime.timedelta(
+                    seconds=int((args_queue.qsize() / num_processes + 1) * mean_running_time)))
+        print(
+            f"Job: {job_name}, process: {id}, gpu: {cuda_visible_devices}, remaining combinations: {args_queue.qsize()}, remaining time: {remaining_time}"
+        )
         # Check if a folder for the experiment already exists. In case the
         # experiment was successful before, do not try to run again
         if os.path.isdir(job_folder):

--- a/src/brevitas_examples/common/benchmark/utils.py
+++ b/src/brevitas_examples/common/benchmark/utils.py
@@ -147,7 +147,7 @@ def run_args_bucket_process(
                 datetime.timedelta(
                     seconds=int((args_queue.qsize() / num_processes + 1) * mean_running_time)))
         print(
-            f"Job: {job_name}, process: {id}, gpu: {cuda_visible_devices}, remaining combinations: {args_queue.qsize()}, remaining time: {remaining_time}"
+            f"Job: {job_name}, process: {id}, gpu(s): {cuda_visible_devices}, remaining combinations: {args_queue.qsize()}, remaining time: {remaining_time}"
         )
         # Check if a folder for the experiment already exists. In case the
         # experiment was successful before, do not try to run again


### PR DESCRIPTION
## Reason for this PR

- Correctly constraining GPU visibility on multi-GPU systems requires setting both `HIP_VISIBLE_DEVICES` and `CUDA_VISIBLE_DEVICES` when running one process per GPU, at least for ROCm v6.1 (ROCk v6.7.0). This change ensures consistent device assignment.
- Additionally, exposing which process is mapped to which GPU simplifies debugging and makes it easier to diagnose utilization issues.


<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

- Setting `HIP_VISIBLE_DEVICES` with `CUDA_VISIBLE_DEVICES`
- Expanded print statements

<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary

N/A - when ROCm is not installed, setting these variables is a no-op, so this remains safe across environments.


<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [ ] Code comments added to any hard-to-understand areas, if applicable.
- [ ] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
