### PR TITLE
Feat (llm): enabling narrow_range for inputs in LLM entry point

### DIFF
--- a/src/brevitas_examples/llm/llm_args.py
+++ b/src/brevitas_examples/llm/llm_args.py
@@ -173,6 +173,10 @@ def create_args_parser() -> ArgumentParser:
         choices=['sym', 'asym'],
         help='Input quantization type. Default: asym.')
     parser.add_argument(
+        '--input-narrow-range',
+        action="store_true",
+        help='Use narrow range for input quantization. Default: False.')
+    parser.add_argument(
         '--input-quant-granularity',
         type=str,
         default='per_tensor',

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -470,6 +470,9 @@ def quantize_llm(args, extra_args=None):
                     'zero_point_affine_rescaling_init': args.weight_quant_rescaling_init}}
         if args.weight_narrow_range:
             weight_kwargs = {**weight_kwargs, **{'narrow_range': args.weight_narrow_range}}
+        input_kwargs = {}
+        if args.input_narrow_range:
+            input_kwargs = {**input_kwargs, **{'narrow_range': args.input_narrow_range}}
         quantizers_dict = generate_quantizers(
             weight_bit_width=args.weight_bit_width,
             weight_param_method=args.weight_param_method,
@@ -502,7 +505,8 @@ def quantize_llm(args, extra_args=None):
             scale_rounding_func_type=args.scale_rounding_func_type,
             quant_attn_mode='sdpa',
             scaling_min_val=args.scaling_min_val,
-            weight_kwargs=weight_kwargs)
+            weight_kwargs=weight_kwargs,
+            input_kwargs=input_kwargs)
         if args.custom_quantizer is not None:
             quantizer_name = parse_custom_quantizer(args.custom_quantizer)
             custom_quantizer = QUANTIZERS_REGISTRY.get(quantizer_name)


### PR DESCRIPTION
## Reason for this PR

This pull request adds support for exposing the input narrow range option in the LLM entrypoint.

<!--
The "why" -

Provide a short summary to answer "Why are these changes needed?".

Include links to relevant Issues, and links to any background information or discussion.

Help reviewers, and people in the future, understand the context behind this work.
-->

## Changes Made in this PR

* Added a new CLI argument `--input-narrow-range` to `llm_args.py` to allow users to specify the use of narrow range for input quantization.
* Updated `quantize_llm` in `main.py` to read the `input_narrow_range` argument and construct `input_kwargs` accordingly, so the narrow range setting is passed to quantizer creation.
* Modified the call to `generate_quantizers` to include the new `input_kwargs` parameter, ensuring the input quantization configuration is applied.


<!--

The "what" -

Provide a short summary of specific changes made in this pull request.

The "how" -

Explain the approach you took to address the problem - your reasoning.
Mention any alternative approaches any why they didn't work.

Detail any notable implementation details.
-->

## Testing Summary


<!--
Briefly explain how you tested and verified your work.

e.g.

- Tests run locally.
- New tests created or tests updated.
- Any tools run over code (linters/debugger walk/profiler).
-->

## Risk Highlight

<!--
Please add any additional comments to help reviewers and maintainers.
-->

- [ ] This PR includes code from another work (please detail).
- [ ] This PR contains API-breaking changes.
- [ ] This PR depends on work in another PR (please provide links/details).
- [ ] This PR introduces new dependencies (please detail).
- [ ] There are coverage gaps not covered by tests.
- [ ] Documentation updates required in subsequent PR.

## Checklist

- [x] Code comments added to any hard-to-understand areas, if applicable.
- [x] Changes generate no new warnings.
- [ ] Updated any relevant tests, if applicable.
- [x] No conflicts with destination `dev` branch.
- [x] I reviewed my own code changes.
- [ ] Initial CI/CD passing.
- [ ] 1+ reviews given, and any review issues addressed and approved.
- [ ] Post-review full CI/CD passing.
