### PR TITLE
Fix (gguf): adding metadata to GGUF export; bumping GGUF version to 0.18.0

### DIFF
--- a/requirements/requirements-llm.txt
+++ b/requirements/requirements-llm.txt
@@ -1,6 +1,6 @@
 accelerate
 datasets
-gguf==0.17.0
+gguf==0.18.0
 numexpr<2.14.0
 onnx
 onnxruntime<1.21

--- a/src/brevitas_examples/llm/gguf_export/export.py
+++ b/src/brevitas_examples/llm/gguf_export/export.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import os
+import re
 import shutil
 import sys
 
@@ -45,6 +46,16 @@ FTYPE_MAP: dict[str, gguf.LlamaFileType] = {
     "auto": gguf.LlamaFileType.GUESSED,}
 
 
+def _resolve_model_name(name_or_path: str) -> str:
+    # For HF cache snapshot dirs, recover the model id from models--<org>--<model>
+    # so general.name is human-readable rather than the snapshot SHA.
+    m = re.search(r'models--([^/]+)/snapshots/[a-f0-9]{40}', name_or_path)
+    if m:
+        return m.group(1).split('--')[-1]
+    parts = [p for p in name_or_path.split('/') if p]
+    return parts[-1] if parts else name_or_path
+
+
 def save_quantized_as_gguf(output_dir, model, tokenizer, backend="gguf:q4_0"):
     """Export the model to gguf format."""
     st = time.time()
@@ -66,11 +77,7 @@ def save_quantized_as_gguf(output_dir, model, tokenizer, backend="gguf:q4_0"):
             logger.error(f"Model {model_architecture} is not supported")
             sys.exit(1)
         model_class = ModelBase.from_model_architecture(model_architecture)
-        model_name = model.name_or_path.split('/')
-        if len(model_name[-1]) == 0:
-            model_name = model_name[-2]
-        else:
-            model_name = model_name[-1]
+        model_name = _resolve_model_name(model.name_or_path)
 
         output_type = backend.split(":")[-1]
         assert output_type.lower() in FTYPE_MAP, f"{output_type} is not supported"

--- a/src/brevitas_examples/llm/gguf_export/export.py
+++ b/src/brevitas_examples/llm/gguf_export/export.py
@@ -54,6 +54,8 @@ def save_quantized_as_gguf(output_dir, model, tokenizer, backend="gguf:q4_0"):
     tmp_work_dir = Path(os.path.join(output_dir, 'tmp_dir'))
     tokenizer.save_pretrained(tmp_work_dir)
     config.save_pretrained(tmp_work_dir)
+    if getattr(model, 'generation_config', None) is not None:
+        model.generation_config.save_pretrained(tmp_work_dir)
 
     with torch.no_grad():
         hparams = ModelBase.load_hparams(tmp_work_dir)


### PR DESCRIPTION
 ## Reason for this PR

 The Brevitas GGUF export was dropping metadata that llama.cpp's canonical `convert_hf_to_gguf.py` writes. 
- Most notably, the `generation_config` was missing entirely; the export never saved `generation_config.json`, so the sampling defaults (`general.sampling.{temperature,top_p}`) never made it into the GGUF KV store. This PR saves the generation config alongside the tokenizer/model config so those KVs are emitted. 
- Separately, `general.name` was being set to the HF cache snapshot SHA: when a model is loaded from the hub cache, `model.name_or_path` is the snapshot directory (`.../models--meta-llama--Llama-3.2-1B/snapshots/<40-char-sha>`), and the previous trailing-slash split picked up the SHA rather than a readable model id.

The `gguf` bump to 0.18.0 is required to close the rest of the gap: 0.18.0 adds `SpecialVocab` post-processor parsing, which is what lets the exporter emit the `add_bos_token` / `add_sep_token` tokenizer flags.

> [!IMPORTANT]
> This came out of an investigation into Brevitas vs. llama.cpp GGUF export divergence; the metadata was one key difference, and another was the file size mismatch from exporting F32 or F16 rather than Q6_K, which we fix on another branch: https://github.com/i-colbert/brevitas/tree/gguf_q6_k_layers/src/brevitas_examples/llm/gguf_export, currently planned for another PR.

## Changes Made in this PR

1. **Bump `gguf` 0.17.0 → 0.18.0** (`requirements-llm.txt`). 0.18.0 adds `SpecialVocab` post-processor parsing, which lets the exporter emit `add_bos_token` / `add_sep_token` KVs from the tokenizer config.

2. **Save `generation_config.json` into the temp work dir** before `Metadata.load` runs, guarded with `getattr(model, 'generation_config', None)` so models without a generation config are unaffected.
     
3. **Add `_resolve_model_name` helper** so `general.name` resolves to a clean model id (e.g. `Llama-3.2-1B`). It recovers the model id from the `models--<org>--<model>/snapshots/<sha>` HF cache layout via regex, and otherwise falls back to the path basename. This replaces the previous brittle trailing-slash split, which produced the SHA for cache-snapshot paths.

## Testing Summary

Direct casting, no algorithms applied.

```yml
  model: meta-llama/Llama-3.2-1B
  weight_bit_width: 4
  weight_group_size: 32
  eval: true
  dataset: wikitext2
  dataset_eval_split: test
  export_target: gguf:q4_0
```

  | Source | PPL | File size |
  |--------|-------------|-----------|
  | Brevitas quant (in-process) | 10.158 | — |
  | `llama-perplexity`, Brevitas GGUF | 10.1003 ± 0.203 | 1,606,127,456 B |
  | `llama-perplexity`, reference llama.cpp Q4_0 | 9.8428 ± 0.196 | 770,924,480 B |

  **Reproducibility checks:**

  1. **Round-trip faithful** ✅ — Brevitas-quant in-process (10.158) ≈ exported-GGUF (10.100). Within noise.
  2. **In family with reference** ✅ — Brevitas GGUF (10.100) vs reference Q4_0 (9.843). Within noise.
  3. **File size** ⚠️  — 2.08× the reference (1.606 GB vs 771 MB). Without the Q6_K casting, `token_embd`/`output` are written as **F32**, causing a ~835 MB bloat.


For awareness, the Q6_K fixes on my [gguf_q6_k_layers](https://github.com/i-colbert/brevitas/tree/gguf_q6_k_layers/src/brevitas_examples/llm/gguf_export ) branch resolve this 835 MB bloat. Here is the results below:

  | Source | PPL  | File size |
  |--------|-------------|-----------|
  | Brevitas quant (in-process) | 10.158 | — |
  | `llama-perplexity`, Brevitas GGUF | 10.1122 ± 0.203 | 770,924,384 B |
  | `llama-perplexity`, reference llama.cpp Q4_0 | 9.8428 ± 0.196 | 770,924,480 B |

 **Reproducibility checks:**

  1. **Round-trip faithful** ✅ — Brevitas in-process (10.158) ≈ exported-GGUF (10.112). Within noise.
  2. **In family with reference** ✅ — Brevitas GGUF (10.112) vs reference Q4_0 (9.843). Within noise.
  3. **File size matches** ✅ — 96 B diff (metadata only). `token_embd`/`output` land at Q6_K.

# Risk Highlight
  
  - [x] This PR introduces new dependencies (please detail). — bumps `gguf` 0.17.0 → 0.18.0.
  - [ ] This PR includes code from another work (please detail).
  - [ ] This PR contains API-breaking changes.
  - [ ] This PR depends on work in another PR (please provide links/details).
  - [ ] There are coverage gaps not covered by tests.
  - [ ] Documentation updates required in subsequent PR.
  
Note: the related token-embedding/output Q6_K bump work (file-size fix + numpy port of `quantize_row_q6_K_ref`) is split onto a separate branch (`gguf_q6_k_layers`) and will be its own PR.

## Checklist
  
  - [x] Code comments added to any hard-to-understand areas, if applicable.
  - [x] Changes generate no new warnings.
  - [ ] Updated any relevant tests, if applicable.
  - [x] No conflicts with destination `dev` branch.
  - [x] I reviewed my own code changes.
  - [x] Initial CI/CD passing.
  - [ ] 1+ reviews given, and any review issues addressed and approved.
  - [ ] Post-review full CI/CD passing.