### PR TITLE
Fix (core/float): better handling of continuous mantissa bit-width

### DIFF
--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -14,7 +14,7 @@ class StaticMaxMantissa(torch.nn.Module):
     Module that returns a maximum mantissa value computed once at initialization.
 
     Args:
-        mantissa_bit_width: the number of mantissa bits used to compute the maximum mantissa value.
+        bit_width: the number of mantissa bits used to compute the maximum mantissa value.
         max_mantissa_round_impl (torch.nn.Module, optional): Module used to round the integer max
             mantissa value during the computation. Defaults to None, in which case
             compute_max_mantissa falls back to its previous closed-form implementation without
@@ -37,14 +37,13 @@ class StaticMaxMantissa(torch.nn.Module):
 
     def __init__(
             self,
-            mantissa_bit_width,
+            bit_width,
             max_mantissa_round_impl: Optional[torch.nn.Module] = None,
             device: Optional[torch.device] = None,
             dtype: Optional[torch.dtype] = None):
         super().__init__()
         max_mantissa = compute_max_mantissa(
-            torch.tensor(float(mantissa_bit_width), device=device, dtype=dtype),
-            max_mantissa_round_impl)
+            torch.tensor(float(bit_width), device=device, dtype=dtype), max_mantissa_round_impl)
         self.compute_max_mantissa = StatelessBuffer(max_mantissa)
 
     def forward(self, x):

--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -11,30 +11,41 @@ from brevitas.function import compute_max_mantissa
 
 class StaticMaxMantissa(torch.nn.Module):
     """
-    Module that returns a pre-computed maximum mantissa value.
+    Module that returns a maximum mantissa value computed once at initialization.
 
     Args:
-        compute_max_mantissa (torch.Tensor): Pre-computed maximum mantissa tensor.
+        mantissa_bit_width: the number of mantissa bits used to compute the maximum mantissa value.
+        max_mantissa_round_impl (torch.nn.Module, optional): Module used to round the integer max
+            mantissa value during the computation. Defaults to None, in which case
+            compute_max_mantissa falls back to its previous closed-form implementation without
+            applying any rounding function.
+        device: Device on which to create the tensor. Default: None.
+        dtype: Data type of the tensor. Default: None.
 
     Examples:
-        >>> max_mantissa = torch.tensor(7.0)
-        >>> static_max = StaticMaxMantissa(max_mantissa)
+        >>> static_max = StaticMaxMantissa(3)
         >>> static_max(torch.randn(2))
-        tensor(7.)
+        tensor(1.8750)
 
     Note:
-        The pre-computed mantissa value is stored using StatelessBuffer, meaning it won't be saved as part of
-        a checkpoint but will be properly handled during device transfers and dtype conversions.
+        The maximum mantissa value is computed once during initialization and stored using
+        StatelessBuffer, meaning it won't be saved as part of a checkpoint but will be properly
+        handled during device transfers and dtype conversions. The rounding function used by
+        compute_max_mantissa can be customized through dependency injection via
+        max_mantissa_round_impl.
     """
 
     def __init__(
             self,
-            compute_max_mantissa: torch.Tensor,
+            mantissa_bit_width,
+            max_mantissa_round_impl: Optional[torch.nn.Module] = None,
             device: Optional[torch.device] = None,
             dtype: Optional[torch.dtype] = None):
         super().__init__()
-        self.compute_max_mantissa = StatelessBuffer(
-            torch.tensor(compute_max_mantissa, device=device, dtype=dtype))
+        max_mantissa = compute_max_mantissa(
+            torch.tensor(float(mantissa_bit_width), device=device, dtype=dtype),
+            max_mantissa_round_impl)
+        self.compute_max_mantissa = StatelessBuffer(max_mantissa)
 
     def forward(self, x):
         return self.compute_max_mantissa()

--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -17,9 +17,9 @@ class StaticMaxMantissa(torch.nn.Module):
     Args:
         bit_width: the number of mantissa bits used to compute the maximum mantissa value.
         max_mantissa_round_impl (torch.nn.Module, optional): Module used to round the integer max
-            mantissa value during the computation. Defaults to None, in which case
-            compute_max_mantissa falls back to its previous closed-form implementation without
-            applying any rounding function.
+            mantissa value during the computation. Forwarded to :class:`ComputeMaxMantissa`.
+            Defaults to None, in which case the closed-form implementation is used and no rounding
+            is applied.
         device: Device on which to create the tensor. Default: None.
         dtype: Data type of the tensor. Default: None.
 
@@ -29,11 +29,10 @@ class StaticMaxMantissa(torch.nn.Module):
         tensor(1.8750)
 
     Note:
-        The maximum mantissa value is computed once during initialization and stored using
-        StatelessBuffer, meaning it won't be saved as part of a checkpoint but will be properly
-        handled during device transfers and dtype conversions. The rounding function used by
-        compute_max_mantissa can be customized through dependency injection via
-        max_mantissa_round_impl.
+        The maximum mantissa value is computed once during initialization via
+        :class:`ComputeMaxMantissa` and stored using StatelessBuffer, meaning it won't be saved as
+        part of a checkpoint but will be properly handled during device transfers and dtype
+        conversions.
     """
 
     def __init__(

--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -6,8 +6,8 @@ from typing import Union
 
 import torch
 
+import brevitas
 from brevitas.core.utils import StatelessBuffer
-from brevitas.function import compute_max_mantissa
 
 
 class StaticMaxMantissa(torch.nn.Module):
@@ -43,42 +43,50 @@ class StaticMaxMantissa(torch.nn.Module):
             device: Optional[torch.device] = None,
             dtype: Optional[torch.dtype] = None):
         super().__init__()
-        max_mantissa = compute_max_mantissa(
-            torch.tensor(float(bit_width), device=device, dtype=dtype), max_mantissa_round_impl)
+        # Reuse ComputeMaxMantissa so that the formula (and the optional rounding) lives in a
+        # single place. The value is computed once here, eagerly, and cached in a StatelessBuffer.
+        max_mantissa = ComputeMaxMantissa(max_mantissa_round_impl)(
+            torch.tensor(float(bit_width), device=device, dtype=dtype))
         self.compute_max_mantissa = StatelessBuffer(max_mantissa)
 
     def forward(self, x: torch.Tensor):
         return self.compute_max_mantissa()
 
 
-class ComputeMaxMantissa(torch.nn.Module):
+class ComputeMaxMantissa(brevitas.jit.ScriptModule):
     """
-    Module that computes the maximum mantissa value dynamically from input tensor.
+    Module that computes the maximum mantissa value dynamically from the input mantissa bit width.
 
     Args:
         max_mantissa_round_impl (torch.nn.Module, optional): Module used to round the integer max
-            mantissa value during the computation. Defaults to None, in which case
-            compute_max_mantissa falls back to its previous closed-form implementation without
-            applying any rounding function.
+            mantissa value ``2 ** (mantissa_bit_width + 1) - 1`` before scaling, enabling support
+            for continuous (fractional) mantissa bit-widths (e.g. via a straight-through estimator).
+            Defaults to None, in which case the closed-form implementation
+            ``2 * (1 - 2 ** (-mantissa_bit_width - 1))`` is used and no rounding is applied.
 
     Examples:
         >>> compute_max = ComputeMaxMantissa()
-        >>> input_tensor = torch.randn(2, 3)
-        >>> max_mantissa = compute_max(input_tensor)
+        >>> compute_max(torch.tensor(3.))
+        tensor(1.8750)
 
     Note:
-        This module computes the maximum mantissa on-the-fly using the compute_max_mantissa
-        function from brevitas.function. The rounding function used by compute_max_mantissa can
-        be customized through dependency injection via max_mantissa_round_impl.
+        The rounding implementation is held as a submodule (rather than passed to a free function),
+        so that this module remains compatible with the TorchScript JIT: TorchScript supports
+        calling submodules but does not support ``torch.nn.Module`` values as function arguments.
+        When ``max_mantissa_round_impl`` is None the previous closed-form behaviour is preserved
+        and no rounding implementation is required.
     """
 
     def __init__(self, max_mantissa_round_impl: Optional[torch.nn.Module] = None):
         super().__init__()
         self.max_mantissa_round_impl = max_mantissa_round_impl
 
+    @brevitas.jit.script_method
     def forward(self, x: torch.Tensor):
-        x = compute_max_mantissa(x, self.max_mantissa_round_impl)
-        return x
+        if self.max_mantissa_round_impl is not None:
+            return self.max_mantissa_round_impl(torch.exp2(x + 1) - 1) * torch.exp2(-x)
+        # No rounding implementation: fall back to the previous closed-form computation.
+        return 2 * (1 - 2 ** (-x - 1))
 
 
 class StaticExponentBias(torch.nn.Module):

--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -8,18 +8,18 @@ import torch
 
 import brevitas
 from brevitas.core.utils import StatelessBuffer
+from brevitas.function.ops import compute_max_mantissa
 
 
 class StaticMaxMantissa(torch.nn.Module):
     """
     Module that returns a maximum mantissa value computed once at initialization.
 
+    Used when the mantissa bit-width is constant (CONST or STATEFUL_CONST), in which case it is
+    always a discrete integer value and no rounding is needed.
+
     Args:
-        bit_width: the number of mantissa bits used to compute the maximum mantissa value.
-        max_mantissa_round_impl (torch.nn.Module, optional): Module used to round the integer max
-            mantissa value during the computation. Forwarded to :class:`ComputeMaxMantissa`.
-            Defaults to None, in which case the closed-form implementation is used and no rounding
-            is applied.
+        bit_width: the integer number of mantissa bits used to compute the maximum mantissa value.
         device: Device on which to create the tensor. Default: None.
         dtype: Data type of the tensor. Default: None.
 
@@ -29,24 +29,19 @@ class StaticMaxMantissa(torch.nn.Module):
         tensor(1.8750)
 
     Note:
-        The maximum mantissa value is computed once during initialization via
-        :class:`ComputeMaxMantissa` and stored using StatelessBuffer, meaning it won't be saved as
-        part of a checkpoint but will be properly handled during device transfers and dtype
-        conversions.
+        The maximum mantissa value is computed once during initialization and stored using
+        StatelessBuffer, meaning it won't be saved as part of a checkpoint but will be properly
+        handled during device transfers and dtype conversions.
     """
 
     def __init__(
             self,
             bit_width: Union[int, float],
-            max_mantissa_round_impl: Optional[torch.nn.Module] = None,
             device: Optional[torch.device] = None,
             dtype: Optional[torch.dtype] = None):
         super().__init__()
-        # Reuse ComputeMaxMantissa so that the formula (and the optional rounding) lives in a
-        # single place. The value is computed once here, eagerly, and cached in a StatelessBuffer.
-        max_mantissa = ComputeMaxMantissa(max_mantissa_round_impl)(
-            torch.tensor(float(bit_width), device=device, dtype=dtype))
-        self.compute_max_mantissa = StatelessBuffer(max_mantissa)
+        self.compute_max_mantissa = StatelessBuffer(
+            compute_max_mantissa(torch.tensor(float(bit_width), device=device, dtype=dtype)))
 
     def forward(self, x: torch.Tensor):
         return self.compute_max_mantissa()
@@ -84,8 +79,7 @@ class ComputeMaxMantissa(brevitas.jit.ScriptModule):
     def forward(self, x: torch.Tensor):
         if self.max_mantissa_round_impl is not None:
             return self.max_mantissa_round_impl(torch.exp2(x + 1) - 1) * torch.exp2(-x)
-        # No rounding implementation: fall back to the previous closed-form computation.
-        return 2 * (1 - 2 ** (-x - 1))
+        return compute_max_mantissa(x)
 
 
 class StaticExponentBias(torch.nn.Module):

--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -44,6 +44,12 @@ class ComputeMaxMantissa(torch.nn.Module):
     """
     Module that computes the maximum mantissa value dynamically from input tensor.
 
+    Args:
+        max_mantissa_round_impl (torch.nn.Module, optional): Module used to round the integer max
+            mantissa value during the computation. Defaults to None, in which case
+            compute_max_mantissa falls back to its previous closed-form implementation without
+            applying any rounding function.
+
     Examples:
         >>> compute_max = ComputeMaxMantissa()
         >>> input_tensor = torch.randn(2, 3)
@@ -51,14 +57,16 @@ class ComputeMaxMantissa(torch.nn.Module):
 
     Note:
         This module computes the maximum mantissa on-the-fly using the compute_max_mantissa
-        function from brevitas.function.
+        function from brevitas.function. The rounding function used by compute_max_mantissa can
+        be customized through dependency injection via max_mantissa_round_impl.
     """
 
-    def __init__(self):
+    def __init__(self, max_mantissa_round_impl: Optional[torch.nn.Module] = None):
         super().__init__()
+        self.max_mantissa_round_impl = max_mantissa_round_impl
 
     def forward(self, x):
-        x = compute_max_mantissa(x)
+        x = compute_max_mantissa(x, self.max_mantissa_round_impl)
         return x
 
 

--- a/src/brevitas/core/bit_width/float.py
+++ b/src/brevitas/core/bit_width/float.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Optional
+from typing import Union
 
 import torch
 
@@ -37,7 +38,7 @@ class StaticMaxMantissa(torch.nn.Module):
 
     def __init__(
             self,
-            bit_width,
+            bit_width: Union[int, float],
             max_mantissa_round_impl: Optional[torch.nn.Module] = None,
             device: Optional[torch.device] = None,
             dtype: Optional[torch.dtype] = None):
@@ -46,7 +47,7 @@ class StaticMaxMantissa(torch.nn.Module):
             torch.tensor(float(bit_width), device=device, dtype=dtype), max_mantissa_round_impl)
         self.compute_max_mantissa = StatelessBuffer(max_mantissa)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor):
         return self.compute_max_mantissa()
 
 
@@ -75,7 +76,7 @@ class ComputeMaxMantissa(torch.nn.Module):
         super().__init__()
         self.max_mantissa_round_impl = max_mantissa_round_impl
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor):
         x = compute_max_mantissa(x, self.max_mantissa_round_impl)
         return x
 

--- a/src/brevitas/core/quant/float.py
+++ b/src/brevitas/core/quant/float.py
@@ -11,7 +11,6 @@ import brevitas
 from brevitas.core.function_wrapper import RoundSte
 from brevitas.core.scaling import ConstScaling
 from brevitas.core.utils import StatelessBuffer
-from brevitas.function import compute_max_mantissa
 from brevitas.utils.torch_utils import float_internal_scale
 
 

--- a/src/brevitas/export/inference/handler.py
+++ b/src/brevitas/export/inference/handler.py
@@ -13,11 +13,11 @@ from torch import Tensor
 import torch.nn as nn
 
 import brevitas.config as config
+from brevitas.core.bit_width.float import ComputeMaxMantissa as ComputeMaxMantissaModule
 from brevitas.core.function_wrapper.shape import dynamic_over_sub_channel_block_view
 from brevitas.core.function_wrapper.shape import DynamicOverSubChannelBlockView
 from brevitas.core.restrict_val import FloatToIntImplType
 from brevitas.core.restrict_val import RestrictValueType
-from brevitas.function import compute_max_mantissa
 from brevitas.function.ops import max_float
 from brevitas.function.ops import max_int
 from brevitas.function.ops import min_int
@@ -121,15 +121,13 @@ class DynamicScaleZeroPointMixin(torch.nn.Module, ABC):
             else:
                 exponent_bit_width = submodule.exponent_bit_width_impl()
                 mantissa_bit_width = submodule.mantissa_bit_width_impl()
-                # The export path relies on the closed-form compute_max_mantissa, which is only
-                # valid for integer mantissa/exponent bit-widths.
                 assert torch.equal(mantissa_bit_width, mantissa_bit_width.round()), \
                     "Export requires an integer mantissa bit-width."
                 assert torch.equal(exponent_bit_width, exponent_bit_width.round()), \
                     "Export requires an integer exponent bit-width."
                 self.threshold = submodule.float_scaling_impl(
                     exponent_bit_width,
-                    compute_max_mantissa(mantissa_bit_width),
+                    ComputeMaxMantissaModule()(mantissa_bit_width),
                     submodule.exponent_bias_impl())
             self.scaling_restriction = type(
                 submodule.scaling_impl.restrict_clamp_scaling.restrict_value_impl)
@@ -429,13 +427,11 @@ class FloatInferenceHandlerBase(InferenceHandler, FloatToIntMixin):
                 self.float_clamp_impl = module.fused_activation_quant_proxy.tensor_quant.float_clamp_impl
                 self.max_available_float = module.fused_activation_quant_proxy.tensor_quant.float_clamp_impl.max_available_float
 
-            # The export path relies on the closed-form compute_max_mantissa, which is only
-            # valid for integer mantissa/exponent bit-widths.
             assert torch.equal(self.mantissa_bit_width, self.mantissa_bit_width.round()), \
                 "Export requires an integer mantissa bit-width."
             assert torch.equal(self.exponent_bit_width, self.exponent_bit_width.round()), \
                 "Export requires an integer exponent bit-width."
-            self.pre_compute_max_mantissa = compute_max_mantissa(self.mantissa_bit_width)
+            self.pre_compute_max_mantissa = ComputeMaxMantissaModule()(self.mantissa_bit_width)
             self.max_clamp = max_float(
                 self.exponent_bit_width, self.pre_compute_max_mantissa, self.exponent_bias)
             self.max_clamp = self.max_clamp if self.max_available_float is None else torch.min(

--- a/src/brevitas/export/inference/handler.py
+++ b/src/brevitas/export/inference/handler.py
@@ -119,9 +119,17 @@ class DynamicScaleZeroPointMixin(torch.nn.Module, ABC):
                 bit_width = submodule.msb_clamp_bit_width_impl()
                 self.threshold = submodule.int_scaling_impl(bit_width)
             else:
+                exponent_bit_width = submodule.exponent_bit_width_impl()
+                mantissa_bit_width = submodule.mantissa_bit_width_impl()
+                # The export path relies on the closed-form compute_max_mantissa, which is only
+                # valid for integer mantissa/exponent bit-widths.
+                assert torch.equal(mantissa_bit_width, mantissa_bit_width.round()), \
+                    "Export requires an integer mantissa bit-width."
+                assert torch.equal(exponent_bit_width, exponent_bit_width.round()), \
+                    "Export requires an integer exponent bit-width."
                 self.threshold = submodule.float_scaling_impl(
-                    submodule.exponent_bit_width_impl(),
-                    compute_max_mantissa(submodule.mantissa_bit_width_impl()),
+                    exponent_bit_width,
+                    compute_max_mantissa(mantissa_bit_width),
                     submodule.exponent_bias_impl())
             self.scaling_restriction = type(
                 submodule.scaling_impl.restrict_clamp_scaling.restrict_value_impl)
@@ -421,6 +429,12 @@ class FloatInferenceHandlerBase(InferenceHandler, FloatToIntMixin):
                 self.float_clamp_impl = module.fused_activation_quant_proxy.tensor_quant.float_clamp_impl
                 self.max_available_float = module.fused_activation_quant_proxy.tensor_quant.float_clamp_impl.max_available_float
 
+            # The export path relies on the closed-form compute_max_mantissa, which is only
+            # valid for integer mantissa/exponent bit-widths.
+            assert torch.equal(self.mantissa_bit_width, self.mantissa_bit_width.round()), \
+                "Export requires an integer mantissa bit-width."
+            assert torch.equal(self.exponent_bit_width, self.exponent_bit_width.round()), \
+                "Export requires an integer exponent bit-width."
             self.pre_compute_max_mantissa = compute_max_mantissa(self.mantissa_bit_width)
             self.max_clamp = max_float(
                 self.exponent_bit_width, self.pre_compute_max_mantissa, self.exponent_bias)

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -208,10 +208,9 @@ def compute_max_mantissa(mantissa_bit_width: Tensor, round_func=None):
     Args:
         mantissa_bit_width (Tensor): the number of mantissa bits.
         round_func (Callable, optional): function used to round the integer max mantissa value
-            ``2 ** (mantissa_bit_width + 1) - 1`` before scaling, enabling dependency injection of
-            a custom rounding (e.g. a straight-through estimator). Defaults to ``None``, in which
-            case the closed-form previous implementation ``2 * (1 - 2 ** (-mantissa_bit_width - 1))``
-            is used and no rounding function is applied.
+            ``2 ** (mantissa_bit_width + 1) - 1`` before scaling, enabling the use of a custom rounding.
+            Defaults to ``None``, in which case the closed-form implementation
+            ``2 * (1 - 2 ** (-mantissa_bit_width - 1))`` is used and no rounding function is applied.
 
     Returns:
         Tensor: the maximum representable mantissa value.

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -201,26 +201,6 @@ def min_int(
     return value
 
 
-def compute_max_mantissa(mantissa_bit_width: Tensor):
-    """
-    Computes the maximum representable mantissa value for a given (integer) mantissa bit width.
-
-    Args:
-        mantissa_bit_width (Tensor): the number of mantissa bits.
-
-    Returns:
-        Tensor: the maximum representable mantissa value.
-
-    Note:
-        This is the closed-form implementation ``2 * (1 - 2 ** (-mantissa_bit_width - 1))`` and is
-        kept free of any rounding function so that it remains compatible with the TorchScript JIT.
-        Rounding of continuous (fractional) mantissa bit-widths is handled by
-        :class:`brevitas.core.bit_width.float.ComputeMaxMantissa`, which accepts a rounding
-        implementation as a submodule at init time.
-    """
-    return 2 * (1 - 2 ** (-mantissa_bit_width - 1))
-
-
 @brevitas.jit.ignore
 def max_float(exponent_bit_width: Tensor, max_mantissa: Tensor, exponent_bias: Tensor):
     max_exponent = (2. ** exponent_bit_width) - 1. - exponent_bias

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -6,6 +6,7 @@ Implementation of various core operations often performed as part of quantizatio
 The implemented functions adheres to the restriction imposed by Pytorch 1.1.0's TorchScript compiler.
 """
 
+from typing import Optional
 from typing import Union
 
 import torch
@@ -201,7 +202,7 @@ def min_int(
     return value
 
 
-def compute_max_mantissa(mantissa_bit_width: Tensor, round_func=None):
+def compute_max_mantissa(mantissa_bit_width: Tensor, round_func: Optional[torch.nn.Module] = None):
     """
     Computes the maximum representable mantissa value for a given mantissa bit width.
 

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -201,6 +201,11 @@ def min_int(
     return value
 
 
+@brevitas.jit.script
+def compute_max_mantissa(mantissa_bit_width: Tensor) -> Tensor:
+    return 2 * (1 - 2 ** (-mantissa_bit_width - 1))
+
+
 @brevitas.jit.ignore
 def max_float(exponent_bit_width: Tensor, max_mantissa: Tensor, exponent_bias: Tensor):
     max_exponent = (2. ** exponent_bit_width) - 1. - exponent_bias

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -201,8 +201,24 @@ def min_int(
     return value
 
 
-def compute_max_mantissa(mantissa_bit_width: Tensor):
-    return 2 * (1 - 2 ** (-mantissa_bit_width - 1))
+def compute_max_mantissa(mantissa_bit_width: Tensor, round_func=None):
+    """
+    Computes the maximum representable mantissa value for a given mantissa bit width.
+
+    Args:
+        mantissa_bit_width (Tensor): the number of mantissa bits.
+        round_func (Callable, optional): function used to round the integer max mantissa value
+            ``2 ** (mantissa_bit_width + 1) - 1`` before scaling, enabling dependency injection of
+            a custom rounding (e.g. a straight-through estimator). Defaults to ``None``, in which
+            case the closed-form previous implementation ``2 * (1 - 2 ** (-mantissa_bit_width - 1))``
+            is used and no rounding function is applied.
+
+    Returns:
+        Tensor: the maximum representable mantissa value.
+    """
+    if round_func is None:
+        return 2 * (1 - 2 ** (-mantissa_bit_width - 1))
+    return round_func(torch.exp2(mantissa_bit_width + 1) - 1) * torch.exp2(-mantissa_bit_width)
 
 
 @brevitas.jit.ignore

--- a/src/brevitas/function/ops.py
+++ b/src/brevitas/function/ops.py
@@ -6,7 +6,6 @@ Implementation of various core operations often performed as part of quantizatio
 The implemented functions adheres to the restriction imposed by Pytorch 1.1.0's TorchScript compiler.
 """
 
-from typing import Optional
 from typing import Union
 
 import torch
@@ -202,23 +201,24 @@ def min_int(
     return value
 
 
-def compute_max_mantissa(mantissa_bit_width: Tensor, round_func: Optional[torch.nn.Module] = None):
+def compute_max_mantissa(mantissa_bit_width: Tensor):
     """
-    Computes the maximum representable mantissa value for a given mantissa bit width.
+    Computes the maximum representable mantissa value for a given (integer) mantissa bit width.
 
     Args:
         mantissa_bit_width (Tensor): the number of mantissa bits.
-        round_func (Callable, optional): function used to round the integer max mantissa value
-            ``2 ** (mantissa_bit_width + 1) - 1`` before scaling, enabling the use of a custom rounding.
-            Defaults to ``None``, in which case the closed-form implementation
-            ``2 * (1 - 2 ** (-mantissa_bit_width - 1))`` is used and no rounding function is applied.
 
     Returns:
         Tensor: the maximum representable mantissa value.
+
+    Note:
+        This is the closed-form implementation ``2 * (1 - 2 ** (-mantissa_bit_width - 1))`` and is
+        kept free of any rounding function so that it remains compatible with the TorchScript JIT.
+        Rounding of continuous (fractional) mantissa bit-widths is handled by
+        :class:`brevitas.core.bit_width.float.ComputeMaxMantissa`, which accepts a rounding
+        implementation as a submodule at init time.
     """
-    if round_func is None:
-        return 2 * (1 - 2 ** (-mantissa_bit_width - 1))
-    return round_func(torch.exp2(mantissa_bit_width + 1) - 1) * torch.exp2(-mantissa_bit_width)
+    return 2 * (1 - 2 ** (-mantissa_bit_width - 1))
 
 
 @brevitas.jit.ignore

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -136,11 +136,13 @@ class MantissaBitWidthClass(ExtendedInjector):
         return solve_bit_width_impl_from_enum(mantissa_bit_width_impl_type)
 
     @value
-    def compute_max_mantissa(mantissa_bit_width_impl_type, bit_width):
+    def compute_max_mantissa(mantissa_bit_width_impl_type, bit_width, max_mantissa_round_impl=None):
+        round_impl = max_mantissa_round_impl() if max_mantissa_round_impl is not None else None
         if mantissa_bit_width_impl_type == BitWidthImplType.CONST or mantissa_bit_width_impl_type == BitWidthImplType.STATEFUL_CONST:
-            return StaticMaxMantissa(compute_max_mantissa(torch.tensor(float(bit_width))))
+            return StaticMaxMantissa(
+                compute_max_mantissa(torch.tensor(float(bit_width)), round_impl))
         else:
-            return ComputeMaxMantissa
+            return ComputeMaxMantissa(max_mantissa_round_impl=round_impl)
 
 
 class SolveFloatBitWidthImplFromEnum(ExtendedInjector):

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -135,13 +135,15 @@ class MantissaBitWidthClass(ExtendedInjector):
         return solve_bit_width_impl_from_enum(mantissa_bit_width_impl_type)
 
     @value
-    def compute_max_mantissa(mantissa_bit_width_impl_type, bit_width, max_mantissa_round_impl=None):
-        # max_mantissa_round_impl is already resolved by dependency injection: it is either None
-        # (default, falling back to the previous implementation) or an instantiated rounding module.
+    def compute_max_mantissa(mantissa_bit_width_impl_type):
+        # The selected class is instantiated by dependency injection within this scope, which
+        # resolves its __init__ arguments (e.g. bit_width, max_mantissa_round_impl) by name.
+        # max_mantissa_round_impl is not provided here, so it falls back to the constructor default
+        # None (i.e. the previous implementation without any rounding function).
         if mantissa_bit_width_impl_type == BitWidthImplType.CONST or mantissa_bit_width_impl_type == BitWidthImplType.STATEFUL_CONST:
-            return StaticMaxMantissa(bit_width, max_mantissa_round_impl=max_mantissa_round_impl)
+            return StaticMaxMantissa
         else:
-            return ComputeMaxMantissa(max_mantissa_round_impl=max_mantissa_round_impl)
+            return ComputeMaxMantissa
 
 
 class SolveFloatBitWidthImplFromEnum(ExtendedInjector):

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -137,9 +137,7 @@ class MantissaBitWidthClass(ExtendedInjector):
     @value
     def compute_max_mantissa(mantissa_bit_width_impl_type: BitWidthImplType):
         # The selected class is instantiated by dependency injection within this scope, which
-        # resolves its __init__ arguments (e.g. bit_width, max_mantissa_round_impl) by name.
-        # max_mantissa_round_impl is not provided here, so it falls back to the constructor default
-        # None (i.e. the previous implementation without any rounding function).
+        # resolves its __init__ arguments (e.g. bit_width) by name.
         if mantissa_bit_width_impl_type == BitWidthImplType.CONST or mantissa_bit_width_impl_type == BitWidthImplType.STATEFUL_CONST:
             return StaticMaxMantissa
         else:

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -135,7 +135,7 @@ class MantissaBitWidthClass(ExtendedInjector):
         return solve_bit_width_impl_from_enum(mantissa_bit_width_impl_type)
 
     @value
-    def compute_max_mantissa(mantissa_bit_width_impl_type):
+    def compute_max_mantissa(mantissa_bit_width_impl_type: BitWidthImplType):
         # The selected class is instantiated by dependency injection within this scope, which
         # resolves its __init__ arguments (e.g. bit_width, max_mantissa_round_impl) by name.
         # max_mantissa_round_impl is not provided here, so it falls back to the constructor default

--- a/src/brevitas/quant/solver/common.py
+++ b/src/brevitas/quant/solver/common.py
@@ -22,7 +22,6 @@ from brevitas.core.scaling import ScalingImplType
 from brevitas.core.scaling import ScalingPerOutputType
 from brevitas.core.stats import *
 from brevitas.core.stats.stats_op import SIGNEDNESS_STATS
-from brevitas.function.ops import compute_max_mantissa
 from brevitas.inject import ExtendedInjector
 from brevitas.inject import value
 from brevitas.inject.enum import LearnedRoundImplType
@@ -137,12 +136,12 @@ class MantissaBitWidthClass(ExtendedInjector):
 
     @value
     def compute_max_mantissa(mantissa_bit_width_impl_type, bit_width, max_mantissa_round_impl=None):
-        round_impl = max_mantissa_round_impl() if max_mantissa_round_impl is not None else None
+        # max_mantissa_round_impl is already resolved by dependency injection: it is either None
+        # (default, falling back to the previous implementation) or an instantiated rounding module.
         if mantissa_bit_width_impl_type == BitWidthImplType.CONST or mantissa_bit_width_impl_type == BitWidthImplType.STATEFUL_CONST:
-            return StaticMaxMantissa(
-                compute_max_mantissa(torch.tensor(float(bit_width)), round_impl))
+            return StaticMaxMantissa(bit_width, max_mantissa_round_impl=max_mantissa_round_impl)
         else:
-            return ComputeMaxMantissa(max_mantissa_round_impl=round_impl)
+            return ComputeMaxMantissa(max_mantissa_round_impl=max_mantissa_round_impl)
 
 
 class SolveFloatBitWidthImplFromEnum(ExtendedInjector):

--- a/tests/brevitas/core/test_clamp.py
+++ b/tests/brevitas/core/test_clamp.py
@@ -5,7 +5,7 @@ from hypothesis import given
 import pytest
 import torch
 
-from brevitas.core.bit_width.float import ComputeMaxMantissa
+from brevitas.function.ops import compute_max_mantissa
 from brevitas.function.ops import max_float
 from brevitas.quant.float import *
 from brevitas.quant.float_quant_fnuz import *
@@ -50,7 +50,7 @@ def test_max_value(minifloat, expected_max_val):
     minifloat = minifloat.let(tracked_parameter_list=[torch.nn.Parameter(torch.randn(1, 5))])
     # Instantiate quantizer to check that init is correct
     obj = minifloat.tensor_quant
-    max_mantissa = ComputeMaxMantissa()(
+    max_mantissa = compute_max_mantissa(
         torch.tensor(minifloat.mantissa_bit_width, dtype=torch.float32))
     max_val = max_float(
         torch.tensor(minifloat.exponent_bit_width, dtype=torch.float32),
@@ -86,7 +86,7 @@ def test_min_value(minifloat, expected_min_val):
 
 @given(inp=float_tensor_random_shape_st())
 def test_float_clamp(inp, fp8_clamp):
-    max_mantissa = ComputeMaxMantissa()(
+    max_mantissa = compute_max_mantissa(
         torch.tensor(fp8_clamp.mantissa_bit_width, dtype=torch.float32))
     max_val = max_float(
         torch.tensor(fp8_clamp.exponent_bit_width, dtype=torch.float32),

--- a/tests/brevitas/core/test_clamp.py
+++ b/tests/brevitas/core/test_clamp.py
@@ -5,7 +5,7 @@ from hypothesis import given
 import pytest
 import torch
 
-from brevitas.function.ops import compute_max_mantissa
+from brevitas.core.bit_width.float import ComputeMaxMantissa
 from brevitas.function.ops import max_float
 from brevitas.quant.float import *
 from brevitas.quant.float_quant_fnuz import *
@@ -50,7 +50,7 @@ def test_max_value(minifloat, expected_max_val):
     minifloat = minifloat.let(tracked_parameter_list=[torch.nn.Parameter(torch.randn(1, 5))])
     # Instantiate quantizer to check that init is correct
     obj = minifloat.tensor_quant
-    max_mantissa = compute_max_mantissa(
+    max_mantissa = ComputeMaxMantissa()(
         torch.tensor(minifloat.mantissa_bit_width, dtype=torch.float32))
     max_val = max_float(
         torch.tensor(minifloat.exponent_bit_width, dtype=torch.float32),
@@ -86,7 +86,7 @@ def test_min_value(minifloat, expected_min_val):
 
 @given(inp=float_tensor_random_shape_st())
 def test_float_clamp(inp, fp8_clamp):
-    max_mantissa = compute_max_mantissa(
+    max_mantissa = ComputeMaxMantissa()(
         torch.tensor(fp8_clamp.mantissa_bit_width, dtype=torch.float32))
     max_val = max_float(
         torch.tensor(fp8_clamp.exponent_bit_width, dtype=torch.float32),

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -7,6 +7,7 @@ import mock
 import pytest
 import torch
 
+import brevitas
 from brevitas.core.bit_width.float import ComputeMaxMantissa
 from brevitas.core.function_wrapper import FloatClamp
 from brevitas.core.function_wrapper import RoundSte
@@ -27,7 +28,7 @@ from tests.brevitas.hyp_helper import random_minifloat_format_and_value
 from tests.marker import jit_disabled_for_mock
 
 
-class BitwidthWrapper(torch.nn.Module):
+class BitwidthWrapper(brevitas.jit.ScriptModule):
 
     def __init__(self, value):
         super().__init__()
@@ -35,26 +36,29 @@ class BitwidthWrapper(torch.nn.Module):
         # This is also done throughout the codebase
         self.value = torch.tensor(float(value))
 
+    @brevitas.jit.script_method
     def forward(self):
         return self.value
 
 
-class ThreeInputScalingWrapper(torch.nn.Module):
+class ThreeInputScalingWrapper(brevitas.jit.ScriptModule):
 
     def __init__(self):
         super().__init__()
 
-    def forward(self, x, y, z):
+    @brevitas.jit.script_method
+    def forward(self, x: torch.Tensor, y: torch.Tensor, z: torch.Tensor):
         return torch.tensor(1.)
 
 
-class TwoInputScalingWrapper(torch.nn.Module):
+class TwoInputScalingWrapper(brevitas.jit.ScriptModule):
 
     def __init__(self, value):
         super().__init__()
         self.value = value
 
-    def forward(self, x, y):
+    @brevitas.jit.script_method
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
         return self.value
 
 

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -16,7 +16,6 @@ from brevitas.core.quant.float import FloatQuant
 from brevitas.core.quant.float import min_internal_scale
 from brevitas.core.scaling import ConstScaling
 from brevitas.core.scaling import FloatScaling
-from brevitas.function.ops import compute_max_mantissa
 from brevitas.function.ops import max_float
 from brevitas.utils.torch_utils import float_internal_scale
 from brevitas.utils.torch_utils import torch_dtype
@@ -140,7 +139,7 @@ def test_float_to_quant_float(inp, minifloat_format):
             input_view_impl=Identity(),
             signed=signed,
             float_clamp_impl=float_clamp)
-        max_mantissa = compute_max_mantissa(torch.tensor(mantissa_bit_width, dtype=torch.float))
+        max_mantissa = ComputeMaxMantissa()(torch.tensor(mantissa_bit_width, dtype=torch.float))
         expected_out, *_ = float_quant(inp)
         scale = float_quant.scaling_impl(inp)
         out_quant, scale = float_quant.quantize(inp, scale)
@@ -254,7 +253,7 @@ def test_inner_scale(inp, minifloat_format, scale):
 
         # scale inp manually
         scaled_inp = inp / scale
-        max_mantissa = compute_max_mantissa(torch.tensor(float(mantissa_bit_width)))
+        max_mantissa = ComputeMaxMantissa()(torch.tensor(float(mantissa_bit_width)))
         max_val = max_float(
             torch.tensor(exponent_bit_width), max_mantissa, torch.tensor(exponent_bias))
         max_available_float = float_clamp.max_available_float

--- a/tests/brevitas/core/test_float_quant.py
+++ b/tests/brevitas/core/test_float_quant.py
@@ -16,6 +16,7 @@ from brevitas.core.quant.float import FloatQuant
 from brevitas.core.quant.float import min_internal_scale
 from brevitas.core.scaling import ConstScaling
 from brevitas.core.scaling import FloatScaling
+from brevitas.function.ops import compute_max_mantissa
 from brevitas.function.ops import max_float
 from brevitas.utils.torch_utils import float_internal_scale
 from brevitas.utils.torch_utils import torch_dtype
@@ -139,7 +140,7 @@ def test_float_to_quant_float(inp, minifloat_format):
             input_view_impl=Identity(),
             signed=signed,
             float_clamp_impl=float_clamp)
-        max_mantissa = ComputeMaxMantissa()(torch.tensor(mantissa_bit_width, dtype=torch.float))
+        max_mantissa = compute_max_mantissa(torch.tensor(mantissa_bit_width, dtype=torch.float))
         expected_out, *_ = float_quant(inp)
         scale = float_quant.scaling_impl(inp)
         out_quant, scale = float_quant.quantize(inp, scale)
@@ -253,7 +254,7 @@ def test_inner_scale(inp, minifloat_format, scale):
 
         # scale inp manually
         scaled_inp = inp / scale
-        max_mantissa = ComputeMaxMantissa()(torch.tensor(float(mantissa_bit_width)))
+        max_mantissa = compute_max_mantissa(torch.tensor(float(mantissa_bit_width)))
         max_val = max_float(
             torch.tensor(exponent_bit_width), max_mantissa, torch.tensor(exponent_bias))
         max_available_float = float_clamp.max_available_float


### PR DESCRIPTION
## Reason for this PR

When `mantissa_bit_width` is a **fractional** number (e.g., 2.8), the maximum
representable value (`maxval`) does **not** lie on the quantization grid. This
means that after fake quantization (quantize → clamp → dequantize) with absmax
scaling, the element with the largest absolute value cannot be faithfully
represented.

```
m = 2.8, exponent bits = 4, bias = 7
max_exponent = 15 − 7 = 8

max_mantissa = 2 × (1 − 2^(−3.8)) ≈ 1.8564
maxval = 1.8564 × 256 ≈ 475.24

grid_step = 2^(8 − 2.8) = 2^5.2 ≈ 36.76

Grid points near maxval:
    k = 12 → 12 × 36.76 = 441.10   ← nearest valid grid point below
    k = 13 → 13 × 36.76 = 477.86   ← nearest valid grid point above

maxval = 475.24 # is between these two points—not on the grid.

Quantizing maxval: round(475.24 / 36.76) = round(12.93) = 13
Result: 13 × 36.76 = 477.86 > maxval → clamped to 475.24
But 475.24 is not a valid grid point!

```
## Changes Made in this PR

Replace `compute_max_mantissa` so that the number of mantissa steps is always
rounded down to an integer.
The rounding function can be selected through dependency injection (e.g., `RoundSte`).

```
m = 2.8, exponent bits = 4, bias = 7
max_exponent = 15 − 7 = 8

max_mantissa = round(2^(2.8+1) − 1) × 2^(−2.8)
             = round(2^3.8 − 1) × 2^(−2.8)
             = round(13.9288 − 1) × 0.143587
             = round(12.9288) × 0.143587
             = 13 × 0.143587
             ≈ 1.8666

maxval = 1.8666 × 256 ≈ 477.86

grid_step = 2^(8 − 2.8) = 2^5.2 ≈ 36.76

Grid points near maxval:
    k = 12 → 12 × 36.76 = 441.10   ← nearest grid point below
    k = 13 → 13 × 36.76 = 477.86   ← maxval lands exactly here

maxval ≈ 477.86 is exactly on the grid (k = 13).

Quantizing maxval: round(477.86 / 36.76) = round(13.00) = 13
Result: 13 × 36.76 = 477.86 = maxval → no clamping, and it IS a valid grid point.
```

For discrete mantissa values, rounding is a no-op, always for any rounding operation.