### PR TITLE
Fix (brevitas_examples/llm): patch dynamo FX  with torch 2.10+

### DIFF
--- a/src/brevitas_examples/common/dynamo_utils.py
+++ b/src/brevitas_examples/common/dynamo_utils.py
@@ -1,0 +1,44 @@
+from contextlib import nullcontext
+import functools
+
+from packaging import version
+
+from brevitas import torch_version
+
+
+def patch_dynamo_export():
+    # torch._dynamo.export in torch 2.10 and 2.11 can crash with
+    # "'NoneType' object has no attribute 'is_tensor'" when a raw None is left on
+    # Dynamo's symbolic stack: OutputGraph.compile_subgraph calls x.is_tensor()
+    # over those stack values. Upstream fixed this in 2.12 by replacing raw None
+    # on the stack with ConstantVariable(None) (pytorch/pytorch#169325). We
+    # backport that behaviour out-of-source for 2.10/2.11 only by coercing raw
+    # None to a ConstantVariable when the stack values are gathered.
+    if not (version.parse('2.10') <= torch_version < version.parse('2.12')):
+        return
+    from torch._dynamo.output_graph import OutputGraph
+    from torch._dynamo.variables import ConstantVariable
+    if getattr(OutputGraph._get_stack_values_to_restore, '_brevitas_none_patch', False):
+        return
+    original_fn = OutputGraph._get_stack_values_to_restore
+
+    @functools.wraps(original_fn)
+    def _get_stack_values_to_restore(self, tx, stack_pops):
+        stack_values, meta = original_fn(self, tx, stack_pops)
+        stack_values = [ConstantVariable.create(None) if v is None else v for v in stack_values]
+        return stack_values, meta
+
+    _get_stack_values_to_restore._brevitas_none_patch = True
+    OutputGraph._get_stack_values_to_restore = _get_stack_values_to_restore
+
+
+def dynamo_export_ctx():
+    # From torch 2.10 onwards, torch._dynamo.export inlines built-in nn modules
+    # (install_free_tensors_for_export=True) instead of emitting call_module
+    # nodes. Setting install_free_tensors_for_export=False routes them back
+    # through the specialized NNModuleVariable path, restoring the pre-2.10 graph
+    # structure. The flag does not exist before torch 2.10.
+    if torch_version >= version.parse('2.10'):
+        import torch._dynamo.config as dynamo_config
+        return dynamo_config.patch(install_free_tensors_for_export=False)
+    return nullcontext()

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -85,7 +85,7 @@ except:
     logging.debug("Shark-AI not installed, cannot export to Shark")
 
 
-def _maybe_patch_dynamo_export_for_torch_2_10_2_11():
+def _maybe_patch_dynamo_export():
     # torch._dynamo.export in torch 2.10 and 2.11 can crash with
     # "'NoneType' object has no attribute 'is_tensor'" when a raw None is left on
     # Dynamo's symbolic stack: OutputGraph.compile_subgraph calls x.is_tensor()

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -12,11 +12,13 @@ import sys
 import warnings
 
 import numpy as np
+from packaging import version
 import torch
 from torch.utils.data import DataLoader
 from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
+from brevitas import torch_version
 from brevitas.export.inference.manager import quant_inference_mode
 from brevitas.export.onnx.standard.qcdq.manager import StdQCDQONNXManager
 from brevitas.graph import load_quant_model_mode
@@ -83,6 +85,47 @@ except:
     logging.debug("Shark-AI not installed, cannot export to Shark")
 
 
+def _maybe_patch_dynamo_export_for_torch_2_10_2_11():
+    # torch._dynamo.export in torch 2.10 and 2.11 can crash with
+    # "'NoneType' object has no attribute 'is_tensor'" when a raw None is left on
+    # Dynamo's symbolic stack: OutputGraph.compile_subgraph calls x.is_tensor()
+    # over those stack values. Upstream fixed this in 2.12 by replacing raw None
+    # on the stack with ConstantVariable(None) (pytorch/pytorch#169325). We
+    # backport that behaviour out-of-source for 2.10/2.11 only by coercing raw
+    # None to a ConstantVariable when the stack values are gathered.
+    if not (version.parse('2.10') <= torch_version < version.parse('2.12')):
+        return
+    from torch._dynamo.output_graph import OutputGraph
+    from torch._dynamo.variables import ConstantVariable
+    if getattr(OutputGraph._get_stack_values_to_restore, '_brevitas_none_patch', False):
+        return
+    original_fn = OutputGraph._get_stack_values_to_restore
+
+    @functools.wraps(original_fn)
+    def _get_stack_values_to_restore(self, tx, stack_pops):
+        stack_values, meta = original_fn(self, tx, stack_pops)
+        stack_values = [ConstantVariable.create(None) if v is None else v for v in stack_values]
+        return stack_values, meta
+
+    _get_stack_values_to_restore._brevitas_none_patch = True
+    OutputGraph._get_stack_values_to_restore = _get_stack_values_to_restore
+
+
+_maybe_patch_dynamo_export_for_torch_2_10_2_11()
+
+
+def dynamo_export_ctx():
+    # From torch 2.10 onwards, torch._dynamo.export inlines built-in nn modules
+    # (install_free_tensors_for_export=True) instead of emitting call_module
+    # nodes. Setting install_free_tensors_for_export=False routes them back
+    # through the specialized NNModuleVariable path, restoring the pre-2.10 graph
+    # structure. The flag does not exist before torch 2.10.
+    if torch_version >= version.parse('2.10'):
+        import torch._dynamo.config as dynamo_config
+        return dynamo_config.patch(install_free_tensors_for_export=False)
+    return nullcontext()
+
+
 def filter_results(results, tasks):
     # filter out what we actually want to track
     eval_results = dict()
@@ -99,7 +142,7 @@ def filter_results(results, tasks):
 def fused_rotation_no_fx(model, calibration_loader, args):
     with torch.no_grad(), rmsnorm_patch(model, model.config) as patcher:
         rmsnorm_classes = patcher.rmsnorm_classes
-        with make_dynamo_compatible(model) as dynamo_comp:
+        with make_dynamo_compatible(model) as dynamo_comp, dynamo_export_ctx():
             fx_model, guards = torch._dynamo.export(dynamo_comp.model)(**next(iter(calibration_loader)))
     if hasattr(model, str(torch.nn.functional.scaled_dot_product_attention)):
         m_to_add = getattr(model, str(torch.nn.functional.scaled_dot_product_attention))
@@ -351,7 +394,7 @@ def quantize_llm(args, extra_args=None):
     if require_fx:
         with torch.no_grad(), rmsnorm_patch(model, model.config, enabled=args.replace_rmsnorm) as patcher:
             rmsnorm_classes = patcher.rmsnorm_classes
-            with make_dynamo_compatible(model) as dynamo_comp:
+            with make_dynamo_compatible(model) as dynamo_comp, dynamo_export_ctx():
                 model, guards = torch._dynamo.export(model)(**next(iter(calibration_loader)))
         # Blockwise optimization does not work with FX at the moment
         args.gpxq_block_name = None

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -11,8 +11,6 @@ import pprint
 import sys
 import warnings
 
-from brevitas_example.common.dynamo_utils import dynamo_export_ctx
-from brevitas_example.common.dynamo_utils import patch_dynamo_export
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
@@ -37,6 +35,8 @@ from brevitas.utils.python_utils import hooked_on_a_function
 from brevitas_examples.common.accelerate_utils.accelerate import offload_model
 from brevitas_examples.common.accelerate_utils.accelerate import remove_hooks
 from brevitas_examples.common.accelerate_utils.accelerate import update_internal_dict
+from brevitas_examples.common.dynamo_utils import dynamo_export_ctx
+from brevitas_examples.common.dynamo_utils import patch_dynamo_export
 from brevitas_examples.common.generative.quantize import generate_quant_maps
 from brevitas_examples.common.generative.quantize import generate_quantizers
 from brevitas_examples.common.generative.quantizers import QUANTIZERS_REGISTRY

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -111,7 +111,7 @@ def _maybe_patch_dynamo_export():
     OutputGraph._get_stack_values_to_restore = _get_stack_values_to_restore
 
 
-_maybe_patch_dynamo_export_for_torch_2_10_2_11()
+_maybe_patch_dynamo_export()
 
 
 def dynamo_export_ctx():

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -11,14 +11,14 @@ import pprint
 import sys
 import warnings
 
+from brevitas_example.common.dynamo_utils import dynamo_export_ctx
+from brevitas_example.common.dynamo_utils import patch_dynamo_export
 import numpy as np
-from packaging import version
 import torch
 from torch.utils.data import DataLoader
 from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
-from brevitas import torch_version
 from brevitas.export.inference.manager import quant_inference_mode
 from brevitas.export.onnx.standard.qcdq.manager import StdQCDQONNXManager
 from brevitas.graph import load_quant_model_mode
@@ -84,46 +84,8 @@ except:
     SharkManager = None
     logging.debug("Shark-AI not installed, cannot export to Shark")
 
-
-def _maybe_patch_dynamo_export():
-    # torch._dynamo.export in torch 2.10 and 2.11 can crash with
-    # "'NoneType' object has no attribute 'is_tensor'" when a raw None is left on
-    # Dynamo's symbolic stack: OutputGraph.compile_subgraph calls x.is_tensor()
-    # over those stack values. Upstream fixed this in 2.12 by replacing raw None
-    # on the stack with ConstantVariable(None) (pytorch/pytorch#169325). We
-    # backport that behaviour out-of-source for 2.10/2.11 only by coercing raw
-    # None to a ConstantVariable when the stack values are gathered.
-    if not (version.parse('2.10') <= torch_version < version.parse('2.12')):
-        return
-    from torch._dynamo.output_graph import OutputGraph
-    from torch._dynamo.variables import ConstantVariable
-    if getattr(OutputGraph._get_stack_values_to_restore, '_brevitas_none_patch', False):
-        return
-    original_fn = OutputGraph._get_stack_values_to_restore
-
-    @functools.wraps(original_fn)
-    def _get_stack_values_to_restore(self, tx, stack_pops):
-        stack_values, meta = original_fn(self, tx, stack_pops)
-        stack_values = [ConstantVariable.create(None) if v is None else v for v in stack_values]
-        return stack_values, meta
-
-    _get_stack_values_to_restore._brevitas_none_patch = True
-    OutputGraph._get_stack_values_to_restore = _get_stack_values_to_restore
-
-
-_maybe_patch_dynamo_export()
-
-
-def dynamo_export_ctx():
-    # From torch 2.10 onwards, torch._dynamo.export inlines built-in nn modules
-    # (install_free_tensors_for_export=True) instead of emitting call_module
-    # nodes. Setting install_free_tensors_for_export=False routes them back
-    # through the specialized NNModuleVariable path, restoring the pre-2.10 graph
-    # structure. The flag does not exist before torch 2.10.
-    if torch_version >= version.parse('2.10'):
-        import torch._dynamo.config as dynamo_config
-        return dynamo_config.patch(install_free_tensors_for_export=False)
-    return nullcontext()
+# We need to patch this before anything else is executed
+patch_dynamo_export()
 
 
 def filter_results(results, tasks):


### PR DESCRIPTION
## Reason for this PR

In torch 2.10 and above, `torch._dynamo.export` stops creating `call_module` and flattens everything to `call_function`.

## Changes Made in this PR

This PR does two things:
- uses `install_free_tensors_for_export` to restore `call_module` in the FX graph
- Patches a torch function that is broken in torch 2.10 and torch 2.11 (fixed in torch 2.12)


Tested locally with:
```python
import torch
import torch.nn as nn
import torch._dynamo.config as dynamo_config
import inspect, textwrap                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
import torch._dynamo.output_graph as og                                                                                                                                                                                                                                                                                                                                 
from torch._dynamo.variables import CONSTANT_VARIABLE_NONE                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                        
_orig = og.OutputGraph._get_stack_values_to_restore                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                        
def _patched(self, tx, stack_pops):                                                                                                                                                                                                                                                                                                                                     
    stack_values, meta = _orig(self, tx, stack_pops)                                                                                                                                                                                                                                                                                                                    
    stack_values = [CONSTANT_VARIABLE_NONE if v is None else v for v in stack_values]                                                                                                                                                                                                                                                                                   
    return stack_values, meta                                                                                                                                                                                                                                                                                                                                           
                                                                                                         
# This is needed only for torch 2.10 and torch 2.11                                                                                                                                                                                                                                         
og.OutputGraph._get_stack_values_to_restore = _patched         

class Model(nn.Module):
    def __init__(self):
        super().__init__()
        self.module1 = nn.Linear(3, 16)
    
    def forward(self, x):
        return self.module1(x)

model = Model()
with dynamo_config.patch(install_free_tensors_for_export=False):                                                                                                                                                                                                                                                                                                        
         fx_export, _ = torch._dynamo.export(model, torch.randn(1, 3))
print(fx_export.graph.print_tabular())


```


Related to https://github.com/pytorch/pytorch/issues/174481