### PR TITLE
Fix (tests/permute): use symbolic_trace instead of dynamo

### DIFF
--- a/tests/brevitas/graph/test_rotations.py
+++ b/tests/brevitas/graph/test_rotations.py
@@ -197,7 +197,7 @@ def test_compute_rotations(
         region_dict in zip(mask, RESIDUAL_MODEL_REGION_DICTS) if mask_element]
     # Use FX model if requested
     if use_fx:
-        graph_model, _ = torch._dynamo.export(model)(sample_inputs)
+        graph_model = symbolic_trace(model)
         # The module names in the original model need to be mapped to the ones
         # in graph_model
         map_model_graph = {}


### PR DESCRIPTION
## Reason for this PR

For some reasons, we use `_dynamo.export` for some tests, however this is not (very) compatible with latest torch versions, unless with flags and patching.

For testing purposes, we have always used `symbolic_trace`, so we stick to that for consistency whilst we figure out how to proceed with FX graphs moving forward.

`_dynamo.export` is to be preferred to `symbolic_trace` only when dealing with big models and complex set of operators.