### PR TITLE
Fix (fx): push support for value_tracer

### DIFF
--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -80,7 +80,11 @@ ALL_SUPPORTED_PYTORCH_VERSIONS = (
     '2.6.0',
     '2.7.1',
     '2.8.0',
-    '2.9.0')
+    '2.9.0',
+    '2.10.0',
+    '2.11.0',
+    '2.12.1')
+
 ALL_SUPPORTED_EXCLUSION_LIST = generate_exclusion_list([
     [['python_version', [
         '3.9',]], ['pytorch_version', [

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -19,7 +19,7 @@ TORCHVISION_VERSION_DICT = {
     '2.6.0': '0.21.0',
     '2.7.1': '0.22.1',
     '2.8.0': '0.23.0',
-    '2.9.0': '0.24.0'}
+    '2.9.1': '0.24.1'}
 
 BASE_YML_TEMPLATE = 'base.yml.template'
 BASE_YML_REDUCED_TEMPLATE = 'base_reduced.yml.template'
@@ -80,7 +80,7 @@ ALL_SUPPORTED_PYTORCH_VERSIONS = (
     '2.6.0',
     '2.7.1',
     '2.8.0',
-    '2.9.0',
+    '2.9.1',
     '2.10.0',
     '2.11.0',
     '2.12.1')

--- a/src/brevitas/fx/__init__.py
+++ b/src/brevitas/fx/__init__.py
@@ -15,7 +15,7 @@ import torch
 from brevitas import torch_version
 
 # This needs to be bumped until https://github.com/pytorch/pytorch/pull/94461 gets merged
-if torch_version < version.parse('2.11'):
+if torch_version < version.parse('2.13'):
     import brevitas.backport.fx as fx
     from brevitas.backport.fx._compatibility import compatibility
     from brevitas.backport.fx._symbolic_trace import _assert_is_none


### PR DESCRIPTION
## Reason for this PR

Push support for value tracer to include latest 2.12 torch version.
