### PR TITLE
Docs: add v0.13.0 to the version selector

### DIFF
--- a/docs/dev/_static/versions.json
+++ b/docs/dev/_static/versions.json
@@ -40,8 +40,13 @@
         "url": "https://xilinx.github.io/brevitas/v0.12.0/"
     },
     {
-        "name": "v0.12.1 (stable)",
+        "name": "v0.12.1",
         "version": "v0.12.1",
         "url": "https://xilinx.github.io/brevitas/v0.12.1/"
+    },
+    {
+        "name": "v0.13.0 (stable)",
+        "version": "v0.13.0",
+        "url": "https://xilinx.github.io/brevitas/v0.13.0/"
     }
 ]

--- a/docsrc/source/_static/versions.json
+++ b/docsrc/source/_static/versions.json
@@ -40,8 +40,13 @@
         "url": "https://xilinx.github.io/brevitas/v0.12.0/"
     },
     {
-        "name": "v0.12.1 (stable)",
+        "name": "v0.12.1",
         "version": "v0.12.1",
         "url": "https://xilinx.github.io/brevitas/v0.12.1/"
+    },
+    {
+        "name": "v0.13.0 (stable)",
+        "version": "v0.13.0",
+        "url": "https://xilinx.github.io/brevitas/v0.13.0/"
     }
 ]


### PR DESCRIPTION
When releasing a new version, we need to update the `versions.json`.

The `versions.json` in `docs/dev` is the groud truth from which the version selector is generated, with the idea that other versions might be dropped/added in the future, while `dev` should _always_ be there.

`versions.json` in other subfolders (e.g., 'versions.json' in `/docs/v0.11.0`) are ignored, so we do not have to update them (I hope).
