### PR TITLE
Setup: adjust torch & python versions

### DIFF
--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -73,7 +73,6 @@ PYTEST_MATRIX_EXTRA_REDUCED = od([('jit_status', [
 ALL_SUPPORTED_PYTHON_VERSIONS = ('3.10', '3.11', '3.12', '3.13', '3.14')
 
 ALL_SUPPORTED_PYTORCH_VERSIONS = (
-    '1.12.1',
     '1.13.1',
     '2.0.1',
     '2.1.1',
@@ -92,18 +91,15 @@ ALL_SUPPORTED_PYTORCH_VERSIONS = (
 
 ALL_SUPPORTED_EXCLUSION_LIST = generate_exclusion_list([
     [['python_version', [
-        '3.11',]], ['pytorch_version', ['1.12.1', '1.13.1']]],
+        '3.11',]], ['pytorch_version', ['1.13.1']]],
     [['python_version', [
-        '3.12',]], ['pytorch_version', ['1.12.1', '1.13.1', '2.0.1', '2.1.1']]],
+        '3.12',]], ['pytorch_version', ['1.13.1', '2.0.1', '2.1.1']]],
     [['python_version', [
-        '3.13',]],
-     ['pytorch_version', ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1']]],
+        '3.13',]], ['pytorch_version', ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1']]],
     [['python_version', [
         '3.14',]],
      [
-         'pytorch_version',
-         [
-             '1.12.1',
+         'pytorch_version', [
              '1.13.1',
              '2.0.1',
              '2.1.1',

--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -19,7 +19,11 @@ TORCHVISION_VERSION_DICT = {
     '2.6.0': '0.21.0',
     '2.7.1': '0.22.1',
     '2.8.0': '0.23.0',
-    '2.9.1': '0.24.1'}
+    '2.9.1': '0.24.1',
+    '2.10.0': '0.25.0',
+    '2.11.0': '0.26.0',
+    '2.12.1': '0.27.1',
+    '2.13.0': '0.28.0'}
 
 BASE_YML_TEMPLATE = 'base.yml.template'
 BASE_YML_REDUCED_TEMPLATE = 'base_reduced.yml.template'
@@ -66,7 +70,7 @@ PYTEST_MATRIX_EXTRA_REDUCED = od([('jit_status', [
     'jit_disabled',])])
 
 # Data shared betwen Nox sessions and Github Actions, formatted as tuples
-ALL_SUPPORTED_PYTHON_VERSIONS = ('3.9', '3.10', '3.11', '3.12')
+ALL_SUPPORTED_PYTHON_VERSIONS = ('3.10', '3.11', '3.12', '3.13', '3.14')
 
 ALL_SUPPORTED_PYTORCH_VERSIONS = (
     '1.12.1',
@@ -83,16 +87,33 @@ ALL_SUPPORTED_PYTORCH_VERSIONS = (
     '2.9.1',
     '2.10.0',
     '2.11.0',
-    '2.12.1')
+    '2.12.1',
+    '2.13.0')
 
 ALL_SUPPORTED_EXCLUSION_LIST = generate_exclusion_list([
     [['python_version', [
-        '3.9',]], ['pytorch_version', [
-            '2.9.0',]]],
-    [['python_version', [
         '3.11',]], ['pytorch_version', ['1.12.1', '1.13.1']]],
     [['python_version', [
-        '3.12',]], ['pytorch_version', ['1.12.1', '1.13.1', '2.0.1', '2.1.1']]],])
+        '3.12',]], ['pytorch_version', ['1.12.1', '1.13.1', '2.0.1', '2.1.1']]],
+    [['python_version', [
+        '3.13',]],
+     ['pytorch_version', ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1']]],
+    [['python_version', [
+        '3.14',]],
+     [
+         'pytorch_version',
+         [
+             '1.12.1',
+             '1.13.1',
+             '2.0.1',
+             '2.1.1',
+             '2.2.2',
+             '2.3.1',
+             '2.4.1',
+             '2.5.1',
+             '2.6.0',
+             '2.7.1',
+             '2.8.0']]],])
 
 PYTHON_VERSIONS = ('3.10', '3.11')
 

--- a/.github/workflows/periodic_develop_install.yml
+++ b/.github/workflows/periodic_develop_install.yml
@@ -12,15 +12,12 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10', '3.11', '3.12']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.0']
+        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
-          - python_version: '3.9'
-            pytorch_version: '2.9.0'
-
           - python_version: '3.11'
             pytorch_version: '1.12.1'
 
@@ -38,6 +35,60 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.13'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.14'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.5.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.6.0'
+
+          - python_version: '3.14'
+            pytorch_version: '2.7.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.8.0'
 
 
 

--- a/.github/workflows/periodic_develop_install.yml
+++ b/.github/workflows/periodic_develop_install.yml
@@ -13,19 +13,13 @@ jobs:
 
       matrix:
         python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
+        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
           - python_version: '3.11'
-            pytorch_version: '1.12.1'
-
-          - python_version: '3.11'
             pytorch_version: '1.13.1'
-
-          - python_version: '3.12'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.12'
             pytorch_version: '1.13.1'
@@ -35,9 +29,6 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
-
-          - python_version: '3.13'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.13'
             pytorch_version: '1.13.1'
@@ -56,9 +47,6 @@ jobs:
 
           - python_version: '3.13'
             pytorch_version: '2.4.1'
-
-          - python_version: '3.14'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.14'
             pytorch_version: '1.13.1'

--- a/.github/workflows/periodic_end_to_end.yml
+++ b/.github/workflows/periodic_end_to_end.yml
@@ -12,15 +12,12 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10', '3.11', '3.12']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.0']
+        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
-          - python_version: '3.9'
-            pytorch_version: '2.9.0'
-
           - python_version: '3.11'
             pytorch_version: '1.12.1'
 
@@ -38,6 +35,60 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.13'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.14'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.5.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.6.0'
+
+          - python_version: '3.14'
+            pytorch_version: '2.7.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.8.0'
 
           - platform: 'windows-latest'
 

--- a/.github/workflows/periodic_end_to_end.yml
+++ b/.github/workflows/periodic_end_to_end.yml
@@ -13,19 +13,13 @@ jobs:
 
       matrix:
         python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
+        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
           - python_version: '3.11'
-            pytorch_version: '1.12.1'
-
-          - python_version: '3.11'
             pytorch_version: '1.13.1'
-
-          - python_version: '3.12'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.12'
             pytorch_version: '1.13.1'
@@ -35,9 +29,6 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
-
-          - python_version: '3.13'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.13'
             pytorch_version: '1.13.1'
@@ -56,9 +47,6 @@ jobs:
 
           - python_version: '3.13'
             pytorch_version: '2.4.1'
-
-          - python_version: '3.14'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.14'
             pytorch_version: '1.13.1'

--- a/.github/workflows/periodic_notebook.yml
+++ b/.github/workflows/periodic_notebook.yml
@@ -12,15 +12,12 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10', '3.11', '3.12']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.0']
+        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
-          - python_version: '3.9'
-            pytorch_version: '2.9.0'
-
           - python_version: '3.11'
             pytorch_version: '1.12.1'
 
@@ -38,6 +35,60 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.13'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.14'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.5.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.6.0'
+
+          - python_version: '3.14'
+            pytorch_version: '2.7.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.8.0'
 
           - platform: 'macos-latest'
 

--- a/.github/workflows/periodic_notebook.yml
+++ b/.github/workflows/periodic_notebook.yml
@@ -13,19 +13,13 @@ jobs:
 
       matrix:
         python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
+        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
           - python_version: '3.11'
-            pytorch_version: '1.12.1'
-
-          - python_version: '3.11'
             pytorch_version: '1.13.1'
-
-          - python_version: '3.12'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.12'
             pytorch_version: '1.13.1'
@@ -35,9 +29,6 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
-
-          - python_version: '3.13'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.13'
             pytorch_version: '1.13.1'
@@ -56,9 +47,6 @@ jobs:
 
           - python_version: '3.13'
             pytorch_version: '2.4.1'
-
-          - python_version: '3.14'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.14'
             pytorch_version: '1.13.1'

--- a/.github/workflows/periodic_ort_integration.yml
+++ b/.github/workflows/periodic_ort_integration.yml
@@ -12,15 +12,12 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10', '3.11', '3.12']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.0']
+        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
-          - python_version: '3.9'
-            pytorch_version: '2.9.0'
-
           - python_version: '3.11'
             pytorch_version: '1.12.1'
 
@@ -38,6 +35,60 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.13'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.14'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.5.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.6.0'
+
+          - python_version: '3.14'
+            pytorch_version: '2.7.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.8.0'
 
 
 

--- a/.github/workflows/periodic_ort_integration.yml
+++ b/.github/workflows/periodic_ort_integration.yml
@@ -13,19 +13,13 @@ jobs:
 
       matrix:
         python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
+        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
 
 
         exclude:
           - python_version: '3.11'
-            pytorch_version: '1.12.1'
-
-          - python_version: '3.11'
             pytorch_version: '1.13.1'
-
-          - python_version: '3.12'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.12'
             pytorch_version: '1.13.1'
@@ -35,9 +29,6 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
-
-          - python_version: '3.13'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.13'
             pytorch_version: '1.13.1'
@@ -56,9 +47,6 @@ jobs:
 
           - python_version: '3.13'
             pytorch_version: '2.4.1'
-
-          - python_version: '3.14'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.14'
             pytorch_version: '1.13.1'

--- a/.github/workflows/periodic_pytest.yml
+++ b/.github/workflows/periodic_pytest.yml
@@ -12,16 +12,13 @@ jobs:
 
 
       matrix:
-        python_version: ['3.9', '3.10', '3.11', '3.12']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.0']
+        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled']
 
 
         exclude:
-          - python_version: '3.9'
-            pytorch_version: '2.9.0'
-
           - python_version: '3.11'
             pytorch_version: '1.12.1'
 
@@ -39,6 +36,60 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.13'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.13'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.13'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.12.1'
+
+          - python_version: '3.14'
+            pytorch_version: '1.13.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.0.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.1.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.2.2'
+
+          - python_version: '3.14'
+            pytorch_version: '2.3.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.4.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.5.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.6.0'
+
+          - python_version: '3.14'
+            pytorch_version: '2.7.1'
+
+          - python_version: '3.14'
+            pytorch_version: '2.8.0'
 
 
 

--- a/.github/workflows/periodic_pytest.yml
+++ b/.github/workflows/periodic_pytest.yml
@@ -13,20 +13,14 @@ jobs:
 
       matrix:
         python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        pytorch_version: ['1.12.1', '1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
+        pytorch_version: ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1', '2.6.0', '2.7.1', '2.8.0', '2.9.1', '2.10.0', '2.11.0', '2.12.1', '2.13.0']
         platform: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         jit_status: ['jit_disabled']
 
 
         exclude:
           - python_version: '3.11'
-            pytorch_version: '1.12.1'
-
-          - python_version: '3.11'
             pytorch_version: '1.13.1'
-
-          - python_version: '3.12'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.12'
             pytorch_version: '1.13.1'
@@ -36,9 +30,6 @@ jobs:
 
           - python_version: '3.12'
             pytorch_version: '2.1.1'
-
-          - python_version: '3.13'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.13'
             pytorch_version: '1.13.1'
@@ -57,9 +48,6 @@ jobs:
 
           - python_version: '3.13'
             pytorch_version: '2.4.1'
-
-          - python_version: '3.14'
-            pytorch_version: '1.12.1'
 
           - python_version: '3.14'
             pytorch_version: '1.13.1'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you like this project please consider ⭐ this repo, as it is the simplest an
 ## Requirements
 
 * Python >= 3.10
-* [Pytorch](https://pytorch.org) >= 1.12, <= 2.12.1 (more recent versions would be untested).
+* [Pytorch](https://pytorch.org) >= 1.13, <= 2.12.1 (more recent versions would be untested).
 * Windows, Linux or macOS.
 * GPU training-time acceleration (*Optional* but recommended).
 

--- a/docsrc/source/setup.rst
+++ b/docsrc/source/setup.rst
@@ -9,7 +9,7 @@ Installation Requirements
 '''''''''''''''''''''''''
 
 -  Python >= 3.10
--  `Pytorch`_ >= 1.9.1, <= 2.12.1 (more recent versions would be untested).
+-  `Pytorch`_ >= 1.13, <= 2.12.1 (more recent versions would be untested).
 -  Windows, Linux or macOS.
 -  GPU training-time acceleration (*optional* but recommended).
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ dependencies==2.0.1
 packaging
 setuptools<70.0
 sympy
-torch>=1.12
+torch>=1.13
 typing-extensions>=3.7.4
 unfoldNd

--- a/src/brevitas/export/onnx/manager.py
+++ b/src/brevitas/export/onnx/manager.py
@@ -100,15 +100,12 @@ class ONNXBaseManager(BaseManager, ABC):
     def solve_keep_initializers_as_inputs(cls, export_kwargs):
         # See https://github.com/pytorch/pytorch/commit/7583519b870e33ee3182f330c1bb8663559697b6
         ka = 'keep_initializers_as_inputs'
-        if torch_version >= version.parse('1.3.0') and ka not in export_kwargs:
+        if ka not in export_kwargs:
             export_kwargs[ka] = True
 
     @classmethod
     def solve_enable_onnx_checker(cls, export_kwargs):
-        ka = 'enable_onnx_checker'
-        if (torch_version >= version.parse('1.5.0') and torch_version <= version.parse('1.10.0') and
-                ka not in export_kwargs):
-            export_kwargs[ka] = False
+        pass
 
     @classmethod
     def register_custom_fns(cls):

--- a/src/brevitas/export/onnx/standard/manager.py
+++ b/src/brevitas/export/onnx/standard/manager.py
@@ -7,11 +7,9 @@ from typing import Tuple
 from typing import Union
 import warnings
 
-from packaging import version
 from torch import Tensor
 from torch.nn import Module
 
-from brevitas import torch_version
 from brevitas.export.onnx.manager import ONNXBaseManager
 from brevitas.quant_tensor import QuantTensor
 
@@ -26,13 +24,6 @@ class StdONNXBaseManager(ONNXBaseManager, ABC):
         if ka not in export_kwargs:
             export_kwargs[ka] = DEFAULT_OPSET
             warnings.warn(f"ONNX opset version set to {DEFAULT_OPSET}, override with {ka}=")
-
-    @classmethod
-    def solve_enable_onnx_checker(cls, export_kwargs):
-        ka = 'enable_onnx_checker'
-        if (torch_version >= version.parse('1.5.0') and torch_version <= version.parse('1.10.0') and
-                ka not in export_kwargs):
-            export_kwargs[ka] = True
 
     @classmethod
     def export_onnx(

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -7,7 +7,6 @@ from typing import List
 from typing import Optional
 import warnings
 
-from packaging import version
 import torch
 
 try:
@@ -15,7 +14,6 @@ try:
 except:
     LinAlgError = RuntimeError
 
-from brevitas import torch_version
 from brevitas.graph.gpxq import GPxQ
 from brevitas.graph.gpxq import gpxq_mode
 from brevitas.graph.gpxq import SUPPORTED_CONV_OP
@@ -69,8 +67,6 @@ class GPTQ(GPxQ):
                                  device=self.device,
                                  dtype=self.dtype)
         self.nsamples = 0
-
-        assert torch_version >= version.parse('1.10'), "GPTQ requires torch 1.10 or higher"
 
     def compute_iterative_covariance(self, module, input, current_layer):
         # Update reference to current layer

--- a/src/brevitas/graph/quantize.py
+++ b/src/brevitas/graph/quantize.py
@@ -7,12 +7,11 @@ from typing import Optional
 from typing import Tuple
 from typing import Type
 
-from packaging import version
 import torch
 from torch import nn
+from torch.overrides import TorchFunctionMode
 
 from brevitas import config
-from brevitas import torch_version
 from brevitas.core.scaling.standalone import ConstScaling
 from brevitas.core.scaling.standalone import ParameterScaling
 from brevitas.fx.brevitas_tracer import symbolic_trace
@@ -42,33 +41,30 @@ from brevitas.quant import Uint8ActPerTensorFloat
 from brevitas.quant import Uint8ActPerTensorFloatMaxInit
 from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 
-if torch_version >= version.parse('1.12'):
-    from torch.overrides import TorchFunctionMode
 
-    class functional_quantization_mode(TorchFunctionMode):
+class functional_quantization_mode(TorchFunctionMode):
 
-        def __init__(self, model: torch.nn.Module, quant_map: Dict, enabled: bool = True):
-            super().__init__()
-            self.quant_map = quant_map
-            self.model = model
-            self.enabled = enabled
-            for stateless_function, stateless_module in quant_map.items():
-                if not hasattr(model, str(stateless_function)):
-                    model.add_module(str(stateless_function), stateless_module())
+    def __init__(self, model: torch.nn.Module, quant_map: Dict, enabled: bool = True):
+        super().__init__()
+        self.quant_map = quant_map
+        self.model = model
+        self.enabled = enabled
+        for stateless_function, stateless_module in quant_map.items():
+            if not hasattr(model, str(stateless_function)):
+                model.add_module(str(stateless_function), stateless_module())
 
-        def __torch_function__(self, func, types, args=(), kwargs=None):
-            if kwargs is None:
-                kwargs = dict()
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = dict()
 
-            if hasattr(self.model, str(func)) and self.enabled:
-                module = getattr(self.model, str(func))
-                out = module(*args, **kwargs)
-            else:
-                out = func(*args, **kwargs)
+        if hasattr(self.model, str(func)) and self.enabled:
+            module = getattr(self.model, str(func))
+            out = module(*args, **kwargs)
+        else:
+            out = func(*args, **kwargs)
 
-            return out
-else:
-    functional_quantization_mode = object()
+        return out
+
 
 COMPUTE_LAYER_MAP = {
     nn.AvgPool2d:

--- a/src/brevitas/nn/quant_convtranspose.py
+++ b/src/brevitas/nn/quant_convtranspose.py
@@ -7,7 +7,6 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 
-from packaging import version
 import torch
 from torch import Tensor
 from torch.nn import ConvTranspose1d
@@ -17,7 +16,6 @@ from torch.nn.functional import conv_transpose1d
 from torch.nn.functional import conv_transpose2d
 from torch.nn.functional import conv_transpose3d
 
-from brevitas import torch_version
 from brevitas.function.ops import max_int
 from brevitas.function.ops_ste import ceil_ste
 from brevitas.inject.defaults import Int8WeightPerTensorFloat
@@ -96,12 +94,8 @@ class QuantConvTranspose1d(QuantWBIOL, ConvTranspose1d):
         return self.forward_impl(input)
 
     def compute_output_padding(self, inp, output_size):
-        if torch_version >= version.parse('1.12'):
-            return self._output_padding(
-                inp, output_size, self.stride, self.padding, self.kernel_size, num_spatial_dims=1)
-        else:
-            return self._output_padding(
-                inp, output_size, self.stride, self.padding, self.kernel_size)
+        return self._output_padding(
+            inp, output_size, self.stride, self.padding, self.kernel_size, num_spatial_dims=1)
 
     def conv_transpose1d_zeros_pad(
             self, x: Tensor, weight: Tensor, bias: Optional[Tensor], output_padding):
@@ -191,12 +185,8 @@ class QuantConvTranspose2d(QuantWBIOL, ConvTranspose2d):
         return self.forward_impl(input)
 
     def compute_output_padding(self, inp, output_size):
-        if torch_version >= version.parse('1.12'):
-            return self._output_padding(
-                inp, output_size, self.stride, self.padding, self.kernel_size, num_spatial_dims=2)
-        else:
-            return self._output_padding(
-                inp, output_size, self.stride, self.padding, self.kernel_size)
+        return self._output_padding(
+            inp, output_size, self.stride, self.padding, self.kernel_size, num_spatial_dims=2)
 
     def conv_transpose2d_zeros_pad(
             self, x: Tensor, weight: Tensor, bias: Optional[Tensor], output_padding):
@@ -286,12 +276,8 @@ class QuantConvTranspose3d(QuantWBIOL, ConvTranspose3d):
         return self.forward_impl(input)
 
     def compute_output_padding(self, inp, output_size):
-        if torch_version >= version.parse('1.12'):
-            return self._output_padding(
-                inp, output_size, self.stride, self.padding, self.kernel_size, num_spatial_dims=3)
-        else:
-            return self._output_padding(
-                inp, output_size, self.stride, self.padding, self.kernel_size)
+        return self._output_padding(
+            inp, output_size, self.stride, self.padding, self.kernel_size, num_spatial_dims=3)
 
     def conv_transpose3d_zeros_pad(
             self, x: Tensor, weight: Tensor, bias: Optional[Tensor], output_padding):

--- a/src/brevitas/nn/quant_mha.py
+++ b/src/brevitas/nn/quant_mha.py
@@ -46,7 +46,6 @@ from typing import Tuple
 from typing import Union
 import warnings
 
-from packaging import version
 import torch
 from torch import Tensor
 from torch.nn import Module
@@ -56,7 +55,6 @@ from torch.nn.init import constant_
 from torch.nn.init import xavier_normal_
 from torch.nn.init import xavier_uniform_
 
-from brevitas import torch_version
 from brevitas.nn import QuantIdentity
 from brevitas.nn import QuantLinear
 from brevitas.nn.utils import check_tensors_same_ptr
@@ -172,9 +170,7 @@ class QuantMultiheadAttention(Module):
                 **filter_kwargs('in_proj_'))
             self.in_proj = None
 
-        # Keep compatibility with this regression between 1.6.0 and 1.8.2, where bias is always enabled
-        # https://github.com/pytorch/pytorch/issues/52257
-        out_proj_bias = bias or (version.parse('1.8.2') >= torch_version >= version.parse('1.6.0'))
+        out_proj_bias = bias
 
         self.out_proj = QuantLinear(
             embed_dim,

--- a/src/brevitas/utils/jit_utils.py
+++ b/src/brevitas/utils/jit_utils.py
@@ -1,10 +1,7 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from packaging import version
 import torch
-
-from brevitas import torch_version
 
 
 def clear_class_registry():
@@ -13,5 +10,4 @@ def clear_class_registry():
     # https://github.com/pytorch/pytorch/issues/35600
     torch._C._jit_clear_class_registry()
     torch.jit._recursive.concrete_type_store = torch.jit._recursive.ConcreteTypeStore()
-    if torch_version >= version.parse('1.7.0'):
-        torch.jit._state._script_classes.clear()
+    torch.jit._state._script_classes.clear()

--- a/tests/brevitas/export/test_torch_qcdq.py
+++ b/tests/brevitas/export/test_torch_qcdq.py
@@ -6,12 +6,10 @@ import torch
 
 from brevitas.export import export_torch_qcdq
 from tests.marker import jit_disabled_for_export
-from tests.marker import requires_pt_ge
 
 from .quant_module_fixture import *
 
 
-@requires_pt_ge('1.9.1')
 @jit_disabled_for_export()
 @torch.no_grad()
 def test_torch_qcdq_wbiol_export(
@@ -55,7 +53,6 @@ def test_torch_qcdq_wbiol_export(
     assert torch.allclose(out, torchscript_out_value, atol=tolerance)
 
 
-@requires_pt_ge('1.9.1')
 @jit_disabled_for_export()
 @parametrize('input_signed', [True, False])
 @torch.no_grad()

--- a/tests/brevitas/graph/equalization_fixtures.py
+++ b/tests/brevitas/graph/equalization_fixtures.py
@@ -63,14 +63,6 @@ def equalize_test(model, regions, merge_bias, bias_shrinkage, scale_computation_
 def model_coverage(model_dict: dict):
     model_name, coverage = model_dict
 
-    if model_name == 'googlenet' and torch_version == version.parse('1.8.1'):
-        pytest.skip(
-            'Skip because of PyTorch error = AttributeError: \'function\' object has no attribute \'GoogLeNetOutputs\' '
-        )
-    if 'vit' in model_name and torch_version < version.parse('1.13'):
-        pytest.skip(
-            f'ViT supported from torch version 1.13, current torch version is {torch_version}')
-
     kwargs = dict()
     if model_name in ('inception_v3', 'googlenet'):
         kwargs['transform_input'] = False
@@ -110,9 +102,6 @@ def bnconv_model():
 @pytest_cases.parametrize('add_bias_kv', [True, False])
 @pytest_cases.parametrize('batch_first', [True, False])
 def linearmha_model(bias, add_bias_kv, batch_first):
-    if torch_version < version.parse('1.9.1'):
-        pytest.skip(f"batch_first not supported in MHA with torch version {torch_version}")
-
     # Skip due to following issue https://github.com/pytorch/pytorch/issues/97128
     if torch_version == version.parse('2.0.1') and not bias and batch_first and not add_bias_kv:
         pytest.skip(f"Skip due to a regression in pytorch 2.0.1")
@@ -140,9 +129,6 @@ def linearmha_model(bias, add_bias_kv, batch_first):
 @pytest_cases.parametrize('add_bias_kv', [True, False])
 @pytest_cases.parametrize('batch_first', [True, False])
 def layernormmha_model(bias, add_bias_kv, batch_first):
-    if torch_version < version.parse('1.9.1'):
-        pytest.skip(f"batch_first not supported in MHA with torch version {torch_version}")
-
     # Skip due to following issue https://github.com/pytorch/pytorch/issues/97128
     if torch_version == version.parse('2.0.1') and not bias and batch_first and not add_bias_kv:
         pytest.skip(f"Skip due to a regression in pytorch 2.0.1")
@@ -173,9 +159,6 @@ def layernormmha_model(bias, add_bias_kv, batch_first):
 @pytest_cases.parametrize('add_bias_kv', [True, False])
 @pytest_cases.parametrize('batch_first', [True, False])
 def mhalinear_model(bias, add_bias_kv, batch_first):
-    if torch_version < version.parse('1.9.1'):
-        pytest.skip(f"batch_first not supported in MHA with torch version {torch_version}")
-
     # Skip due to following issue https://github.com/pytorch/pytorch/issues/97128
     if torch_version == version.parse('2.0.1') and not bias and batch_first and not add_bias_kv:
         pytest.skip(f"Skip due to a regression in pytorch 2.0.1")

--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -164,8 +164,6 @@ def test_models(toy_model, merge_bias, request):
     "device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"],
     ids=lambda dtype: str(dtype).split(".")[-1])
 def test_act_equalization_models(toy_model, layerwise, fuse_scaling, dtype, device, request):
-    if not fuse_scaling and parse('1.9.0') > torch_version:
-        pytest.skip("Parametrizations were not available in PyTorch versions below 1.9.0")
     if dtype in [torch.float16, torch.bfloat16] and parse('2.3.0') > torch_version:
         pytest.skip(
             "Some operations are not implemented for float16/bfloat16 in PyTorch versions below 2.3.0"
@@ -213,17 +211,7 @@ def test_act_equalization_models(toy_model, layerwise, fuse_scaling, dtype, devi
 @pytest_cases.parametrize("layerwise", [True, False])
 @pytest_cases.parametrize("fuse_scaling", [True, False])
 def test_act_equalization_torchvision_models(model_dict: dict, layerwise: bool, fuse_scaling: bool):
-    if not fuse_scaling and parse('1.9.0') > torch_version:
-        pytest.skip("Parametrizations were not available in PyTorch versions below 1.9.0")
     model, coverage = model_dict
-
-    if model == 'googlenet' and torch_version == version.parse('1.8.1'):
-        pytest.skip(
-            'Skip because of PyTorch error = AttributeError: \'function\' object has no attribute \'GoogLeNetOutputs\' '
-        )
-    if 'vit' in model and torch_version < version.parse('1.13'):
-        pytest.skip(
-            f'ViT supported from torch version 1.13, current torch version is {torch_version}')
 
     try:
         model = getattr(models, model)(pretrained=True, transform_input=False)

--- a/tests/brevitas/nn/nn_quantizers_fixture.py
+++ b/tests/brevitas/nn/nn_quantizers_fixture.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from packaging import version
 import pytest
 import pytest_cases
 from pytest_cases import get_case_id
@@ -9,7 +8,6 @@ from pytest_cases import set_case_id
 import torch
 import torch.nn as nn
 
-from brevitas import torch_version
 import brevitas.config as config
 from brevitas.inject.enum import ScalingPerOutputType
 from brevitas.nn import QuantConv1d
@@ -650,9 +648,7 @@ def case_mha(
         input_quantized,
         request,
         io_quantizer):
-    extra_kwargs = {}
-    if torch_version >= version.parse('1.9.1'):
-        extra_kwargs['batch_first'] = batch_first
+    extra_kwargs = {'batch_first': batch_first}
 
     # Change the case_id based on current value of Parameters
     set_case_id(request.node.callspec.id, case_mha)

--- a/tests/brevitas/nn/test_attention.py
+++ b/tests/brevitas/nn/test_attention.py
@@ -1,12 +1,10 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from packaging import version
 import pytest
 import torch
 from torch.nn import MultiheadAttention
 
-from brevitas import torch_version
 from brevitas.nn import QuantMultiheadAttention
 
 ATOL = 1e-6
@@ -20,9 +18,7 @@ class TestQuantMultiheadAttention:
     @pytest.mark.parametrize("bias", [True, False])
     @pytest.mark.parametrize("packed_in_proj", [True, False])
     def test_mha_quant_disabled_fwd(self, batch_first, bias, packed_in_proj):
-        extra_kwargs = {}
-        if torch_version >= version.parse('1.9.1'):
-            extra_kwargs['batch_first'] = batch_first
+        extra_kwargs = {'batch_first': batch_first}
 
         m = MultiheadAttention(EMBED_DIM, NUM_HEADS, bias=bias, **extra_kwargs)
         qm = QuantMultiheadAttention(

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -4,12 +4,10 @@
 from enum import Enum
 
 import numpy as np
-from packaging import version
 import pytest
 import pytest_cases
 import torch
 
-from brevitas import torch_version
 from brevitas.nn import QuantIdentity
 from brevitas.quant.float import Fp8e4m3ActPerTensorFloat
 from brevitas.quant.float_quant_ocp import Fp8e5m2OCPActPerTensorFloat
@@ -95,9 +93,6 @@ def test_quant_tensor_init():
     'op', [Operator.ADD, Operator.SUBTRACT, Operator.DIVIDE, Operator.MULTIPLY, Operator.MATMUL])
 @pytest.mark.parametrize('quant_fn', [to_quant_tensor, to_float_quant_tensor])
 def test_quant_tensor_operators(op, quant_fn):
-
-    if quant_fn == to_float_quant_tensor and torch_version < version.parse('1.13'):
-        pytest.skip("Torch 1.13 is required for JIT to be compatible with FloatQuantTensor")
 
     # Avoid 0 values
     x = 1 + torch.rand(4, 4)

--- a/tests/brevitas_end_to_end/test_torchvision_models.py
+++ b/tests/brevitas_end_to_end/test_torchvision_models.py
@@ -76,19 +76,6 @@ def quantize_float(model):
 def shared_quant_fn(model_name, quantize_fn):
     inp = torch.randn(BATCH, IN_CH, HEIGHT, WIDTH)
 
-    if torch_version <= version.parse('1.9.1') and model_name == 'regnet_x_400mf':
-        return None
-
-    if torch_version < version.parse('1.9.1') and model_name == 'googlenet':
-        return None
-
-    # EfficientNet is present since 1.10.1. Mobilenet is not correctly exported before 1.10.1
-    if torch_version < version.parse('1.10.1') and model_name in ('efficientnet_b0',
-                                                                  'mobilenet_v3_small'):
-        return None
-    if torch_version < version.parse('1.11.0') and model_name == 'vit_b_32':
-        return None
-
     # Due to a regression in torchvision, we cannot load pretrained weights for effnet_b0
     # https://github.com/pytorch/vision/issues/7744
     if torch_version == version.parse('2.1.0') and model_name == 'efficientnet_b0':

--- a/tests/brevitas_examples/test_pretrained_accuracy.py
+++ b/tests/brevitas_examples/test_pretrained_accuracy.py
@@ -8,10 +8,8 @@ import pytest
 
 from brevitas_examples.bnn_pynq.bnn_pynq_train import launch
 from brevitas_examples.bnn_pynq.models import get_model_cfg
-from tests.marker import requires_pt_lt
 
 
-@requires_pt_lt('1.6.0')
 @pytest.mark.parametrize("model", ["TFC", "SFC", "LFC", "CNV"])
 @pytest.mark.parametrize("weight_bit_width", [1, 2])
 @pytest.mark.parametrize("act_bit_width", [1, 2])

--- a/tests/brevitas_examples/test_pretrained_accuracy.py
+++ b/tests/brevitas_examples/test_pretrained_accuracy.py
@@ -8,8 +8,10 @@ import pytest
 
 from brevitas_examples.bnn_pynq.bnn_pynq_train import launch
 from brevitas_examples.bnn_pynq.models import get_model_cfg
+from tests.marker import requires_pt_lt
 
 
+@requires_pt_lt('1.6.0')
 @pytest.mark.parametrize("model", ["TFC", "SFC", "LFC", "CNV"])
 @pytest.mark.parametrize("weight_bit_width", [1, 2])
 @pytest.mark.parametrize("act_bit_width", [1, 2])

--- a/tests/brevitas_finn/brevitas_examples/test_mobilenet_finn_export.py
+++ b/tests/brevitas_finn/brevitas_examples/test_mobilenet_finn_export.py
@@ -4,7 +4,6 @@
 from platform import system
 
 import numpy as np
-from packaging.version import parse
 import pytest
 from qonnx.core.modelwrapper import ModelWrapper
 import qonnx.core.onnx_exec as oxe
@@ -15,7 +14,6 @@ from qonnx.transformation.general import RemoveStaticGraphInputs
 from qonnx.transformation.infer_shapes import InferShapes
 import torch
 
-from brevitas import torch_version
 from brevitas_examples.imagenet_classification import quant_mobilenet_v1_4b
 from tests.conftest import MIN_QONNX_VERSION
 from tests.marker import requires_package_ge
@@ -24,8 +22,7 @@ from ...export_fixture import qonnx_export_fn
 from ...export_fixture import rm_onnx
 
 ort_mac_fail = pytest.mark.skipif(
-    torch_version >= parse('1.5.0') and system() == 'Darwin',
-    reason='Issue with ORT and MobileNet export on MacOS on PyTorch >= 1.5.0')
+    system() == 'Darwin', reason='Issue with ORT and MobileNet export on MacOS')
 
 INPUT_SIZE = (1, 3, 224, 224)
 #ATOL = 1  # Alternative: how many bitflips to tolerate in the 32-bit output

--- a/tests/brevitas_ort/test_quant_module.py
+++ b/tests/brevitas_ort/test_quant_module.py
@@ -12,7 +12,6 @@ from pytest_cases import parametrize_with_cases
 import torch
 
 from brevitas import torch_version
-from tests.marker import requires_pt_ge
 
 from ..export_fixture import rm_onnx
 from .common import *
@@ -23,7 +22,6 @@ from .quant_module_cases import QuantWBIOLCases
 
 @parametrize_with_cases('model', cases=QuantWBIOLCases)
 @pytest.mark.parametrize('export_type', ['qcdq', 'qcdq_dynamo', 'qonnx', 'qonnx_dynamo'])
-@requires_pt_ge('1.10')
 def test_ort_wbiol(model, export_type, current_cases):
     cases_generator_func = current_cases['model'][1]
     case_id = get_case_id(cases_generator_func)
@@ -105,7 +103,6 @@ def test_ort_wbiol(model, export_type, current_cases):
 
 @parametrize_with_cases('model', cases=QuantAvgPoolCases)
 @pytest.mark.parametrize('export_type', ['qcdq', 'qcdq_dynamo'])
-@requires_pt_ge('1.10')
 def test_ort_avgpool(model, export_type, current_cases):
     if export_type == 'qcdq_dynamo' and torch_version < parse('2.8'):
         pytest.skip('QCDQ dynamo export requires PyTorch >= 2.8')
@@ -121,7 +118,6 @@ def test_ort_avgpool(model, export_type, current_cases):
 
 @parametrize_with_cases('model', cases=QuantRecurrentCases)
 @pytest.mark.parametrize('export_type', ['qcdq', 'qonnx_opset14'])
-@requires_pt_ge('1.10')
 def test_ort_lstm(model, export_type, current_cases):
     cases_generator_func = current_cases['model'][1]
     case_id = get_case_id(cases_generator_func)


### PR DESCRIPTION
## Reason for this PR
- Minimum torch version is now 1.13
    - Remove unused guards for torch < 1.13
- Update periodic tests to support most recent torch versions (until 2.13) and python version (up to 3.14) 

NB: tests/brevitas_examples/test_pretrained_accuracy.py, tests were skipped if torch version was greater than torch 1.6, so we haven't tested those in a while.. Re-enabling them here and see what happens.