### PR TITLE
Fix (tests/ort): Fix dynamo export for PT 2.8

### DIFF
--- a/src/brevitas/export/onnx/standard/manager.py
+++ b/src/brevitas/export/onnx/standard/manager.py
@@ -15,7 +15,14 @@ from brevitas import torch_version
 from brevitas.export.onnx.manager import ONNXBaseManager
 from brevitas.quant_tensor import QuantTensor
 
-DEFAULT_OPSET = 13
+# Opset 18 is required for the dynamo (torch.export) path: torch's ONNX exporter only
+# registers the `onnx_symbolic._symbolic` decomposition (used to emit QuantizeLinear/
+# DequantizeLinear) for opset >= TORCHLIB_OPSET (18). Requesting a lower opset makes
+# torch < 2.9 drop that decomposition and fail with a DispatchError. Torch 2.9+ clamps
+# the registry opset up to 18 automatically, but we set it explicitly for older torch.
+# Opset 18 needs torch >= 2.0 (torch <= 1.13 caps the TorchScript exporter below 18),
+# so we fall back to the historical default of 13 on those older versions.
+DEFAULT_OPSET = 18 if torch_version >= version.parse('2.0') else 13
 
 
 class StdONNXBaseManager(ONNXBaseManager, ABC):

--- a/src/brevitas/export/onnx/standard/manager.py
+++ b/src/brevitas/export/onnx/standard/manager.py
@@ -15,14 +15,7 @@ from brevitas import torch_version
 from brevitas.export.onnx.manager import ONNXBaseManager
 from brevitas.quant_tensor import QuantTensor
 
-# Opset 18 is required for the dynamo (torch.export) path: torch's ONNX exporter only
-# registers the `onnx_symbolic._symbolic` decomposition (used to emit QuantizeLinear/
-# DequantizeLinear) for opset >= TORCHLIB_OPSET (18). Requesting a lower opset makes
-# torch < 2.9 drop that decomposition and fail with a DispatchError. Torch 2.9+ clamps
-# the registry opset up to 18 automatically, but we set it explicitly for older torch.
-# Opset 18 needs torch >= 2.0 (torch <= 1.13 caps the TorchScript exporter below 18),
-# so we fall back to the historical default of 13 on those older versions.
-DEFAULT_OPSET = 18 if torch_version >= version.parse('2.0') else 13
+DEFAULT_OPSET = 13
 
 
 class StdONNXBaseManager(ONNXBaseManager, ABC):

--- a/tests/brevitas_ort/common.py
+++ b/tests/brevitas_ort/common.py
@@ -137,7 +137,7 @@ def is_brevitas_ort_close(
         export_type,
         tolerance=None,
         first_output_only=False,
-        onnx_opset=14,
+        onnx_opset=18,
         export_q_weight=False):
     input_t = torch.from_numpy(np_input)
     inference_inp = torch.randn_like(input_t)

--- a/tests/brevitas_ort/test_quant_module.py
+++ b/tests/brevitas_ort/test_quant_module.py
@@ -36,7 +36,7 @@ def test_ort_wbiol(model, export_type, current_cases):
     quantizer = case_id.split('-')[-7]
     o_bit_width = case_id.split('-')[-6]
     i_bit_width = case_id.split('-')[-4]
-    onnx_opset = 14
+    onnx_opset = 18
     export_q_weight = False
 
     # Round weights can be exported as a Q-node (QuantizeLinear); floor weights and A2Q require


### PR DESCRIPTION
## Reason for this PR

Dynamo (`torch.export`) QCDQ ONNX export fails on **PyTorch 2.8.x** but works on **2.9.1**:

```
DispatchError: No ONNX function found for
<OpOverload(op='onnx_symbolic._symbolic', overload='default')>.
Failure message: No decompositions registered for the real-valued input
```

**Root cause.** Brevitas' dynamo handlers emit `QuantizeLinear`/`DequantizeLinear` via torch's generic symbolic op `torch.ops.onnx_symbolic._symbolic` (the ONNX op name is just a string arg):

```python
# src/brevitas/export/onnx/standard/function.py  (QuantizeLinearDynamoFn)
return torch.onnx.ops.symbolic('QuantizeLinear', (x, output_scale, output_zero_point),
                               attrs, dtype=output_dtype, shape=x.shape, version=None)
```

torch registers that op's translation without an explicit opset, so it inherits the `onnx_impl` default `opset_introduced=18`, and the registry drops any decomposition with `opset_introduced > requested_opset`:

```python
# torch/.../_torchlib/ops/symbolic.py
@onnx_impl(torch.ops.onnx_symbolic._symbolic.default, no_compile=True)  # opset_introduced defaults to 18
# torch/.../_registration.py  (_cleanup_registry_based_on_opset_version)
decomps = [d for d in decomps if d.opset_introduced <= self.opset_version]
```

The ORT tests exported QCDQ at opset **14**, so `18 > 14` → handler filtered out → dispatch fails. The 2.8 vs 2.9 difference is only in how `export_compat` picks the registry opset:

```python
# torch 2.8.0 _compat.py — requested opset used as-is → handler dropped
registry = ONNXRegistry().from_torchlib(opset_version=opset_version)

# torch 2.9.1 _compat.py — clamps up to TORCHLIB_OPSET (18) → handler kept
registry_opset_version = max(opset_version, _constants.TORCHLIB_OPSET)  # (+ warning)
```

Only the dynamo path is affected (TorchScript uses `g.op(...)`). `QuantizeLinear`/`DequantizeLinear` are valid at opset 13+; this is a registry-gating artifact, not an ONNX op requirement.

## Changes Made in this PR

Export the ORT tests at opset ≥ 18 so the `_symbolic` decomposition survives on torch 2.8, matching torch 2.9+ behaviour.

- **`tests/brevitas_ort/common.py`** — `is_brevitas_ort_close(..., onnx_opset=18)` (was 14); fixes `test_ort_avgpool`, which relies on this default.
- **`tests/brevitas_ort/test_quant_module.py`** — `test_ort_wbiol` `onnx_opset = 18` (was 14). fp8 `opset=19` and `qonnx_opset14` cases unchanged.

## Testing Summary

- Reproduced on torch 2.8.0, absent on 2.9.1, via `nox` (`tests_brevitas_ort_integration`).
- Failing cases now pass on both:
  ```
  nox -R -s "tests_brevitas_ort_integration-3.11(pytorch_2.8.0)" -- tests/brevitas_ort/test_quant_module.py -k "avgpool or wbiol" -v
  nox -R -s "tests_brevitas_ort_integration-3.11(pytorch_2.9.1)" -- tests/brevitas_ort/test_quant_module.py -k "avgpool or wbiol" -v
  ```
- Full ORT suite run on both to check for opset-18 QCDQ↔ORT numerical regressions.

## Risk Highlight

Test-only change (opset 14 → 18 in the ORT tests). Default export behaviour (`DEFAULT_OPSET`) is unchanged.

- [ ] This PR contains API-breaking changes.

## Checklist

- [x] Changes generate no new warnings.
- [x] Updated any relevant tests, if applicable.
- [ ] No conflicts with destination `dev` branch.
- [ ] I reviewed my own code changes.
- [ ] Initial CI/CD passing.