### PR TITLE
Fix (papers/axe): match new benchmark structure

### DIFF
--- a/src/brevitas_examples/papers/axe/benchmark.py
+++ b/src/brevitas_examples/papers/axe/benchmark.py
@@ -1,20 +1,27 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from argparse import Namespace
 import sys
+from typing import List
+from typing import Optional
 
-from brevitas_examples.common.benchmark.utils import benchmark
-from brevitas_examples.llm.benchmark.llm_benchmark import LLMBenchmarkUtils
+from brevitas_examples.llm.benchmark.llm_benchmark import LLMEntryPointUtils
+from brevitas_examples.llm.benchmark.llm_benchmark import LLMGridBenchmark
 
 
-class AXEBenchmark(LLMBenchmarkUtils):
+class AXEEntryPointUtils(LLMEntryPointUtils):
 
     @staticmethod
-    def validate(args, extra_args=None):
-        super(LLMBenchmarkUtils, AXEBenchmark).validate(args, extra_args)
+    def validate(args: Namespace, extra_args: Optional[List[str]] = None) -> None:
+        LLMEntryPointUtils.validate(args=args, extra_args=extra_args)
         assert (int(args.gptq) + int(args.gpfq) + int(args.qronos)) == 1
         assert args.weight_scale_precision == args.input_scale_precision
 
 
+class AXEBenchmark(LLMGridBenchmark):
+    entry_point_utils = AXEEntryPointUtils
+
+
 if __name__ == "__main__":
-    benchmark(AXEBenchmark, sys.argv[1:])
+    AXEBenchmark.run(sys.argv[1:])


### PR DESCRIPTION
## Reason for this PR

The benchmark.py interface has changed in the last release, and we need to update the papers to match that.