### PR TITLE
Fix (tests): skipping incompatible torch.compile tests

### DIFF
--- a/src/brevitas/__init__.py
+++ b/src/brevitas/__init__.py
@@ -28,14 +28,6 @@ else:
 python_version = version.parse(
     f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
 
-
-def is_compile_unsupported_pt_py(pt_version: str = '2.3.1', py_version: str = '3.12') -> bool:
-    # torch.compile is unsupported on old PyTorch releases with recent Python versions
-    # (e.g. PyTorch <= 2.3.1 on Python >= 3.12) due to an upstream incompatibility.
-    return torch_version <= version.parse(pt_version) and python_version >= version.parse(
-        py_version)
-
-
 try:
     # Attempt _dynamo import
     is_dynamo_compiling = torch._dynamo.is_compiling

--- a/src/brevitas/__init__.py
+++ b/src/brevitas/__init__.py
@@ -3,6 +3,7 @@
 
 import glob
 import os
+import sys
 from typing import List
 from typing import Optional
 import warnings
@@ -23,6 +24,17 @@ if torch.__version__.endswith('+cpu'):
     torch_version = version.parse(torch.__version__.rstrip('+cpu'))
 else:
     torch_version = version.parse(torch.__version__)
+
+python_version = version.parse(
+    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
+
+
+def is_compile_unsupported_pt_py(pt_version: str = '2.3.1', py_version: str = '3.12') -> bool:
+    # torch.compile is unsupported on old PyTorch releases with recent Python versions
+    # (e.g. PyTorch <= 2.3.1 on Python >= 3.12) due to an upstream incompatibility.
+    return torch_version <= version.parse(pt_version) and python_version >= version.parse(
+        py_version)
+
 
 try:
     # Attempt _dynamo import

--- a/tests/brevitas/graph/test_rotations.py
+++ b/tests/brevitas/graph/test_rotations.py
@@ -382,10 +382,7 @@ def test_fuse_parametrized_modules_after_compile_and_train(device):
     """
     if device == 'cpu':
         pytest.skip('Compile tests are disabled on CPU')
-    if is_compile_unsupported_pt_py():
-        pytest.skip(
-            'Upstream torch incompatibility: torch.compile is unsupported for '
-            'PyTorch <= 2.3.1 on Python >= 3.12')
+    is_compile_unsupported_pt_py()
     torch.set_default_device(device)
 
     model = nn.Sequential(nn.Linear(2, 3))

--- a/tests/brevitas/graph/test_rotations.py
+++ b/tests/brevitas/graph/test_rotations.py
@@ -5,17 +5,15 @@ import copy
 from functools import partial
 from functools import reduce
 import itertools
-import sys
 from unittest.mock import patch
 
-from packaging import version
 import pytest
 import pytest_cases
 import torch
 import torch.nn as nn
 import torch.nn.utils.parametrize as parametrize
 
-from brevitas import torch_version
+from brevitas import is_compile_unsupported_pt_py
 from brevitas.fx import symbolic_trace
 from brevitas.graph.equalize import _apply_had_device
 from brevitas.graph.equalize import _apply_ort_device
@@ -384,7 +382,7 @@ def test_fuse_parametrized_modules_after_compile_and_train(device):
     """
     if device == 'cpu':
         pytest.skip('Compile tests are disabled on CPU')
-    if torch_version <= version.parse('2.3.1') and sys.version_info >= (3, 12):
+    if is_compile_unsupported_pt_py():
         pytest.skip(
             'Upstream torch incompatibility: torch.compile is unsupported for '
             'PyTorch <= 2.3.1 on Python >= 3.12')

--- a/tests/brevitas/graph/test_rotations.py
+++ b/tests/brevitas/graph/test_rotations.py
@@ -13,7 +13,6 @@ import torch
 import torch.nn as nn
 import torch.nn.utils.parametrize as parametrize
 
-from brevitas import is_compile_unsupported_pt_py
 from brevitas.fx import symbolic_trace
 from brevitas.graph.equalize import _apply_had_device
 from brevitas.graph.equalize import _apply_ort_device
@@ -33,6 +32,7 @@ from brevitas.graph.quantize import layerwise_quantize
 from brevitas.nn.equalized_layer import RotatedModule
 from brevitas.utils.parametrization_utils import RotationWeightParametrization
 from brevitas.utils.python_utils import recurse_getattr
+from tests.marker import is_compile_unsupported_pt_py
 from tests.marker import requires_pt_ge
 
 from .equalization_fixtures import ATOL

--- a/tests/brevitas/graph/test_rotations.py
+++ b/tests/brevitas/graph/test_rotations.py
@@ -5,14 +5,17 @@ import copy
 from functools import partial
 from functools import reduce
 import itertools
+import sys
 from unittest.mock import patch
 
+from packaging import version
 import pytest
 import pytest_cases
 import torch
 import torch.nn as nn
 import torch.nn.utils.parametrize as parametrize
 
+from brevitas import torch_version
 from brevitas.fx import symbolic_trace
 from brevitas.graph.equalize import _apply_had_device
 from brevitas.graph.equalize import _apply_ort_device
@@ -381,6 +384,10 @@ def test_fuse_parametrized_modules_after_compile_and_train(device):
     """
     if device == 'cpu':
         pytest.skip('Compile tests are disabled on CPU')
+    if torch_version <= version.parse('2.3.1') and sys.version_info >= (3, 12):
+        pytest.skip(
+            'Upstream torch incompatibility: torch.compile is unsupported for '
+            'PyTorch <= 2.3.1 on Python >= 3.12')
     torch.set_default_device(device)
 
     model = nn.Sequential(nn.Linear(2, 3))

--- a/tests/brevitas/graph/test_rotations.py
+++ b/tests/brevitas/graph/test_rotations.py
@@ -32,8 +32,8 @@ from brevitas.graph.quantize import layerwise_quantize
 from brevitas.nn.equalized_layer import RotatedModule
 from brevitas.utils.parametrization_utils import RotationWeightParametrization
 from brevitas.utils.python_utils import recurse_getattr
-from tests.marker import is_compile_unsupported_pt_py
 from tests.marker import requires_pt_ge
+from tests.marker import requires_torch_compile
 
 from .equalization_fixtures import ATOL
 from .equalization_fixtures import SEED
@@ -372,6 +372,7 @@ def test_fuse_parametrized_modules(kwargs):
 
 
 @requires_pt_ge('2.3.1')
+@requires_torch_compile()
 @pytest_cases.parametrize('device', ['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu'])
 def test_fuse_parametrized_modules_after_compile_and_train(device):
     """Test that fuse_parametrizations works correctly after compile_quant + a training step.
@@ -382,7 +383,6 @@ def test_fuse_parametrized_modules_after_compile_and_train(device):
     """
     if device == 'cpu':
         pytest.skip('Compile tests are disabled on CPU')
-    is_compile_unsupported_pt_py()
     torch.set_default_device(device)
 
     model = nn.Sequential(nn.Linear(2, 3))

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -62,7 +62,7 @@ ACT_QUANTIZERS = {
 def test_compile_weight(weight, weight_quantizer):
     name, quant = weight_quantizer
     if version.parse('2.8') <= torch_version < version.parse('2.9'):
-        pytest.skip('Skipping due to random failures')
+        pytest.skip('Skipping due to random failures on torch 2.8.x')
     if name == 'mxfloat8' and torch_version == version.parse('2.3.1'):
         pytest.skip("Skip test for unknown failure. It works with more recent version of torch.")
     if platform.system() == "Windows":
@@ -92,7 +92,7 @@ def test_compile_weight(weight, weight_quantizer):
 def test_compile_act(inp, act_quantizer):
     name, quant = act_quantizer
     if version.parse('2.8') <= torch_version < version.parse('2.9'):
-        pytest.skip('Skipping due to random failures')
+        pytest.skip('Skipping due to random failures on torch 2.8.x')
     if platform.system() == "Windows":
         pytest.skip("Skip compile + windows because of unknown failure")
     if torch_version >= version.parse('2.5.0') and torch_version < version.parse('2.8.0'):

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -60,10 +60,7 @@ ACT_QUANTIZERS = {
 @jit_disabled_for_compile()
 def test_compile_weight(weight, weight_quantizer):
     name, quant = weight_quantizer
-    if is_compile_unsupported_pt_py():
-        pytest.skip(
-            'Upstream torch incompatibility: torch.compile is unsupported for '
-            'PyTorch <= 2.3.1 on Python >= 3.12')
+    is_compile_unsupported_pt_py()
     if version.parse('2.8') <= torch_version < version.parse('2.9'):
         pytest.skip('Skipping due to random failures')
     if name == 'mxfloat8' and torch_version == version.parse('2.3.1'):
@@ -93,10 +90,7 @@ def test_compile_weight(weight, weight_quantizer):
 @jit_disabled_for_compile()
 def test_compile_act(inp, act_quantizer):
     name, quant = act_quantizer
-    if is_compile_unsupported_pt_py():
-        pytest.skip(
-            'Upstream torch incompatibility: torch.compile is unsupported for '
-            'PyTorch <= 2.3.1 on Python >= 3.12')
+    is_compile_unsupported_pt_py()
     if version.parse('2.8') <= torch_version < version.parse('2.9'):
         pytest.skip('Skipping due to random failures')
     if platform.system() == "Windows":

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import platform
-import sys
 
 from hypothesis import given
 from hypothesis import reproduce_failure
@@ -11,6 +10,7 @@ import pytest
 import pytest_cases
 import torch
 
+from brevitas import is_compile_unsupported_pt_py
 from brevitas import torch_version
 from brevitas.export.inference import quant_inference_mode
 import brevitas.nn as qnn
@@ -60,7 +60,7 @@ ACT_QUANTIZERS = {
 @jit_disabled_for_compile()
 def test_compile_weight(weight, weight_quantizer):
     name, quant = weight_quantizer
-    if torch_version <= version.parse('2.3.1') and sys.version_info >= (3, 12):
+    if is_compile_unsupported_pt_py():
         pytest.skip(
             'Upstream torch incompatibility: torch.compile is unsupported for '
             'PyTorch <= 2.3.1 on Python >= 3.12')
@@ -93,7 +93,7 @@ def test_compile_weight(weight, weight_quantizer):
 @jit_disabled_for_compile()
 def test_compile_act(inp, act_quantizer):
     name, quant = act_quantizer
-    if torch_version <= version.parse('2.3.1') and sys.version_info >= (3, 12):
+    if is_compile_unsupported_pt_py():
         pytest.skip(
             'Upstream torch incompatibility: torch.compile is unsupported for '
             'PyTorch <= 2.3.1 on Python >= 3.12')

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import platform
+import sys
 
 from hypothesis import given
 from hypothesis import reproduce_failure
@@ -59,6 +60,12 @@ ACT_QUANTIZERS = {
 @jit_disabled_for_compile()
 def test_compile_weight(weight, weight_quantizer):
     name, quant = weight_quantizer
+    if torch_version <= version.parse('2.3.1') and sys.version_info >= (3, 12):
+        pytest.skip(
+            'Upstream torch incompatibility: torch.compile is unsupported for '
+            'PyTorch <= 2.3.1 on Python >= 3.12')
+    if version.parse('2.8') <= torch_version < version.parse('2.9'):
+        pytest.skip('Skipping due to random failures')
     if name == 'mxfloat8' and torch_version == version.parse('2.3.1'):
         pytest.skip("Skip test for unknown failure. It works with more recent version of torch.")
     if platform.system() == "Windows":
@@ -86,6 +93,12 @@ def test_compile_weight(weight, weight_quantizer):
 @jit_disabled_for_compile()
 def test_compile_act(inp, act_quantizer):
     name, quant = act_quantizer
+    if torch_version <= version.parse('2.3.1') and sys.version_info >= (3, 12):
+        pytest.skip(
+            'Upstream torch incompatibility: torch.compile is unsupported for '
+            'PyTorch <= 2.3.1 on Python >= 3.12')
+    if version.parse('2.8') <= torch_version < version.parse('2.9'):
+        pytest.skip('Skipping due to random failures')
     if platform.system() == "Windows":
         pytest.skip("Skip compile + windows because of unknown failure")
     if torch_version >= version.parse('2.5.0') and torch_version < version.parse('2.8.0'):

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -10,7 +10,6 @@ import pytest
 import pytest_cases
 import torch
 
-from brevitas import is_compile_unsupported_pt_py
 from brevitas import torch_version
 from brevitas.export.inference import quant_inference_mode
 import brevitas.nn as qnn
@@ -27,6 +26,7 @@ from brevitas.quant.mx_quant_ocp import MXInt8Weight
 from brevitas_examples.common.generative.quantize import Int8DynamicActPerTensorFloat
 from brevitas_examples.common.generative.quantizers import FP8e4m3OCPDynamicActPerRowFloat
 from tests.brevitas.hyp_helper import float_tensor_st
+from tests.marker import is_compile_unsupported_pt_py
 from tests.marker import jit_disabled_for_compile
 from tests.marker import requires_pt_ge
 

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -26,9 +26,9 @@ from brevitas.quant.mx_quant_ocp import MXInt8Weight
 from brevitas_examples.common.generative.quantize import Int8DynamicActPerTensorFloat
 from brevitas_examples.common.generative.quantizers import FP8e4m3OCPDynamicActPerRowFloat
 from tests.brevitas.hyp_helper import float_tensor_st
-from tests.marker import is_compile_unsupported_pt_py
 from tests.marker import jit_disabled_for_compile
 from tests.marker import requires_pt_ge
+from tests.marker import requires_torch_compile
 
 
 class Fp8PerRow(FP8e4m3OCPDynamicActPerRowFloat):
@@ -57,10 +57,10 @@ ACT_QUANTIZERS = {
 @pytest_cases.parametrize('weight_quantizer', WEIGHT_QUANTIZERS.items())
 @given(weight=float_tensor_st(shape=(8, 16), max_val=1e10, min_val=-1e10))
 @requires_pt_ge('2.3.1')
+@requires_torch_compile()
 @jit_disabled_for_compile()
 def test_compile_weight(weight, weight_quantizer):
     name, quant = weight_quantizer
-    is_compile_unsupported_pt_py()
     if version.parse('2.8') <= torch_version < version.parse('2.9'):
         pytest.skip('Skipping due to random failures')
     if name == 'mxfloat8' and torch_version == version.parse('2.3.1'):
@@ -87,10 +87,10 @@ def test_compile_weight(weight, weight_quantizer):
 @pytest_cases.parametrize('act_quantizer', ACT_QUANTIZERS.items())
 @given(inp=float_tensor_st(shape=(8, 16), max_val=1e10, min_val=-1e10))
 @requires_pt_ge('2.3.1')
+@requires_torch_compile()
 @jit_disabled_for_compile()
 def test_compile_act(inp, act_quantizer):
     name, quant = act_quantizer
-    is_compile_unsupported_pt_py()
     if version.parse('2.8') <= torch_version < version.parse('2.9'):
         pytest.skip('Skipping due to random failures')
     if platform.system() == "Windows":

--- a/tests/brevitas_end_to_end/test_torchvision_models.py
+++ b/tests/brevitas_end_to_end/test_torchvision_models.py
@@ -118,10 +118,7 @@ def torchvision_model_compile(model_name, quantize_fn):
 @requires_pt_ge('2.2')
 def test_torchvision_compile(torchvision_model_compile):
     torch._dynamo.config.capture_scalar_outputs = True
-    if is_compile_unsupported_pt_py():
-        pytest.skip(
-            'Upstream torch incompatibility: torch.compile is unsupported for '
-            'PyTorch <= 2.3.1 on Python >= 3.12')
+    is_compile_unsupported_pt_py()
     if torchvision_model_compile is None:
         pytest.skip('Model not instantiated')
     if version.parse('2.2.0') <= torch_version <= version.parse('2.4.1'):

--- a/tests/brevitas_end_to_end/test_torchvision_models.py
+++ b/tests/brevitas_end_to_end/test_torchvision_models.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import sys
 
 from packaging import version
 import pytest
@@ -117,6 +118,10 @@ def torchvision_model_compile(model_name, quantize_fn):
 @requires_pt_ge('2.2')
 def test_torchvision_compile(torchvision_model_compile):
     torch._dynamo.config.capture_scalar_outputs = True
+    if torch_version <= version.parse('2.3.1') and sys.version_info >= (3, 12):
+        pytest.skip(
+            'Upstream torch incompatibility: torch.compile is unsupported for '
+            'PyTorch <= 2.3.1 on Python >= 3.12')
     if torchvision_model_compile is None:
         pytest.skip('Model not instantiated')
     if version.parse('2.2.0') <= torch_version <= version.parse('2.4.1'):

--- a/tests/brevitas_end_to_end/test_torchvision_models.py
+++ b/tests/brevitas_end_to_end/test_torchvision_models.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import sys
 
 from packaging import version
 import pytest
@@ -11,6 +10,7 @@ from pytest_cases import parametrize
 import torch
 import torchvision.models as modelzoo
 
+from brevitas import is_compile_unsupported_pt_py
 from brevitas import torch_version
 from brevitas.export import export_onnx_qcdq
 from brevitas.export import export_torch_qcdq
@@ -118,7 +118,7 @@ def torchvision_model_compile(model_name, quantize_fn):
 @requires_pt_ge('2.2')
 def test_torchvision_compile(torchvision_model_compile):
     torch._dynamo.config.capture_scalar_outputs = True
-    if torch_version <= version.parse('2.3.1') and sys.version_info >= (3, 12):
+    if is_compile_unsupported_pt_py():
         pytest.skip(
             'Upstream torch incompatibility: torch.compile is unsupported for '
             'PyTorch <= 2.3.1 on Python >= 3.12')

--- a/tests/brevitas_end_to_end/test_torchvision_models.py
+++ b/tests/brevitas_end_to_end/test_torchvision_models.py
@@ -10,7 +10,6 @@ from pytest_cases import parametrize
 import torch
 import torchvision.models as modelzoo
 
-from brevitas import is_compile_unsupported_pt_py
 from brevitas import torch_version
 from brevitas.export import export_onnx_qcdq
 from brevitas.export import export_torch_qcdq
@@ -21,6 +20,7 @@ from brevitas.graph.quantize import quantize
 from brevitas.graph.target.flexml import preprocess_for_flexml_quantize
 from brevitas.graph.target.flexml import quantize_flexml
 from brevitas_examples.imagenet_classification.ptq.ptq_common import quantize_model
+from tests.marker import is_compile_unsupported_pt_py
 from tests.marker import requires_pt_ge
 
 TORCH_COMPILE_ATOL = 0.35

--- a/tests/brevitas_end_to_end/test_torchvision_models.py
+++ b/tests/brevitas_end_to_end/test_torchvision_models.py
@@ -20,8 +20,8 @@ from brevitas.graph.quantize import quantize
 from brevitas.graph.target.flexml import preprocess_for_flexml_quantize
 from brevitas.graph.target.flexml import quantize_flexml
 from brevitas_examples.imagenet_classification.ptq.ptq_common import quantize_model
-from tests.marker import is_compile_unsupported_pt_py
 from tests.marker import requires_pt_ge
+from tests.marker import requires_torch_compile
 
 TORCH_COMPILE_ATOL = 0.35
 BATCH = 1
@@ -116,9 +116,9 @@ def torchvision_model_compile(model_name, quantize_fn):
 
 
 @requires_pt_ge('2.2')
+@requires_torch_compile()
 def test_torchvision_compile(torchvision_model_compile):
     torch._dynamo.config.capture_scalar_outputs = True
-    is_compile_unsupported_pt_py()
     if torchvision_model_compile is None:
         pytest.skip('Model not instantiated')
     if version.parse('2.2.0') <= torch_version <= version.parse('2.4.1'):

--- a/tests/marker.py
+++ b/tests/marker.py
@@ -15,7 +15,12 @@ from brevitas import torch_version
 def is_compile_unsupported_pt_py(pt_version: str = '2.3.1', py_version: str = '3.12') -> bool:
     # torch.compile is unsupported on old PyTorch releases with recent Python versions
     # (e.g. PyTorch <= 2.3.1 on Python >= 3.12) due to an upstream incompatibility.
-    return torch_version <= parse(pt_version) and python_version >= parse(py_version)
+    unsupported = torch_version <= parse(pt_version) and python_version >= parse(py_version)
+    if unsupported:
+        pytest.skip(
+            'Upstream torch incompatibility: torch.compile is unsupported for '
+            f'PyTorch <= {pt_version} on Python >= {py_version}')
+    return unsupported
 
 
 def requires_package_ge(package_name: str, required_package_version: str):

--- a/tests/marker.py
+++ b/tests/marker.py
@@ -8,7 +8,14 @@ from packaging.version import parse
 import pytest
 
 from brevitas import config
+from brevitas import python_version
 from brevitas import torch_version
+
+
+def is_compile_unsupported_pt_py(pt_version: str = '2.3.1', py_version: str = '3.12') -> bool:
+    # torch.compile is unsupported on old PyTorch releases with recent Python versions
+    # (e.g. PyTorch <= 2.3.1 on Python >= 3.12) due to an upstream incompatibility.
+    return torch_version <= parse(pt_version) and python_version >= parse(py_version)
 
 
 def requires_package_ge(package_name: str, required_package_version: str):

--- a/tests/marker.py
+++ b/tests/marker.py
@@ -13,13 +13,15 @@ from brevitas import torch_version
 
 
 def is_compile_unsupported_pt_py(pt_version: str = '2.3.1', py_version: str = '3.12') -> bool:
-    # torch.compile is unsupported on old PyTorch releases with recent Python versions
-    # (e.g. PyTorch <= 2.3.1 on Python >= 3.12) due to an upstream incompatibility.
-    unsupported = torch_version <= parse(pt_version) and python_version >= parse(py_version)
+    # torch.compile is unsupported on Python >= 3.14 and on old PyTorch releases with
+    # recent Python versions (e.g. PyTorch <= 2.3.1 on Python >= 3.12).
+    unsupported = (
+        python_version >= parse('3.14') or
+        (torch_version <= parse(pt_version) and python_version >= parse(py_version)))
     if unsupported:
         pytest.skip(
-            'Upstream torch incompatibility: torch.compile is unsupported for '
-            f'PyTorch <= {pt_version} on Python >= {py_version}')
+            'Upstream torch incompatibility: torch.compile is unsupported on '
+            f'Python >= 3.14 and for PyTorch <= {pt_version} on Python >= {py_version}')
     return unsupported
 
 

--- a/tests/marker.py
+++ b/tests/marker.py
@@ -15,14 +15,14 @@ from brevitas import torch_version
 def requires_torch_compile():
     # Newest Python versions have only limited supports for torch.compile on
     # older torch versions
-    skip = ((torch_version <= parse('2.9') and python_version >= parse('3.14')) or
+    skip = ((torch_version <= parse('2.9.1') and python_version >= parse('3.14')) or
             (torch_version <= parse('2.3.1') and python_version >= parse('3.12')))
 
     return pytest.mark.skipif(
         skip,
         reason=(
             'Upstream torch incompatibility: torch.compile is unsupported for '
-            'PyTorch <= 2.9 on Python >= 3.14 and '
+            'PyTorch <= 2.9.1 on Python >= 3.14 and '
             'PyTorch <= 2.3.1 on Python >= 3.12'))
 
 

--- a/tests/marker.py
+++ b/tests/marker.py
@@ -13,9 +13,8 @@ from brevitas import torch_version
 
 
 def requires_torch_compile():
-    # torch.compile is unsupported on Python >= 3.14 with PyTorch <= 2.9 and on
-    # old PyTorch releases with recent Python versions (e.g. PyTorch <= 2.3.1
-    # on Python >= 3.12).
+    # Newest Python versions have only limited supports for torch.compile on
+    # older torch versions
     skip = ((torch_version <= parse('2.9') and python_version >= parse('3.14')) or
             (torch_version <= parse('2.3.1') and python_version >= parse('3.12')))
 

--- a/tests/marker.py
+++ b/tests/marker.py
@@ -12,17 +12,19 @@ from brevitas import python_version
 from brevitas import torch_version
 
 
-def is_compile_unsupported_pt_py(pt_version: str = '2.3.1', py_version: str = '3.12') -> bool:
-    # torch.compile is unsupported on Python >= 3.14 and on old PyTorch releases with
-    # recent Python versions (e.g. PyTorch <= 2.3.1 on Python >= 3.12).
-    unsupported = (
-        python_version >= parse('3.14') or
-        (torch_version <= parse(pt_version) and python_version >= parse(py_version)))
-    if unsupported:
-        pytest.skip(
-            'Upstream torch incompatibility: torch.compile is unsupported on '
-            f'Python >= 3.14 and for PyTorch <= {pt_version} on Python >= {py_version}')
-    return unsupported
+def requires_torch_compile():
+    # torch.compile is unsupported on Python >= 3.14 with PyTorch <= 2.9 and on
+    # old PyTorch releases with recent Python versions (e.g. PyTorch <= 2.3.1
+    # on Python >= 3.12).
+    skip = ((torch_version <= parse('2.9') and python_version >= parse('3.14')) or
+            (torch_version <= parse('2.3.1') and python_version >= parse('3.12')))
+
+    return pytest.mark.skipif(
+        skip,
+        reason=(
+            'Upstream torch incompatibility: torch.compile is unsupported for '
+            'PyTorch <= 2.9 on Python >= 3.14 and '
+            'PyTorch <= 2.3.1 on Python >= 3.12'))
 
 
 def requires_package_ge(package_name: str, required_package_version: str):


### PR DESCRIPTION
## Reason for this PR

`torch.compile` is not compatible with torch <= 2.3.1 and python 3.12+, and python 3.14 and torch <= 2.9.1

Furthermore, there are flaky tests when using torch.compile with torch 2.8 and  python versions 3.10, 3.11, and 3.12, due to segfaults.