### PR TITLE
fix (test): set lower default opset version for PT<2

### DIFF
--- a/tests/brevitas_ort/common.py
+++ b/tests/brevitas_ort/common.py
@@ -5,12 +5,14 @@ import re
 
 import numpy as np
 import onnxruntime as ort
+from packaging.version import parse
 import pytest
 from qonnx.core.modelwrapper import ModelWrapper
 import qonnx.core.onnx_exec as oxe
 from qonnx.transformation.infer_shapes import InferShapes
 import torch
 
+from brevitas import torch_version
 from brevitas.export import export_onnx_qcdq
 from brevitas.export import export_qonnx
 from brevitas.nn import QuantConv1d
@@ -34,6 +36,8 @@ from brevitas.quant.shifted_scaled_int import ShiftedUint8WeightPerChannelFloat
 from brevitas.quant.shifted_scaled_int import ShiftedUint8WeightPerTensorFloat
 from brevitas.quant_tensor import QuantTensor
 from brevitas_examples.common.generative.quantizers import ShiftedUint8DynamicActPerTensorFloat
+
+DEFAULT_ONNX_OPSET = 18 if torch_version >= parse('2.0') else 17
 
 SEED = 123456
 OUT_CH = 16
@@ -137,7 +141,7 @@ def is_brevitas_ort_close(
         export_type,
         tolerance=None,
         first_output_only=False,
-        onnx_opset=18,
+        onnx_opset=DEFAULT_ONNX_OPSET,
         export_q_weight=False):
     input_t = torch.from_numpy(np_input)
     inference_inp = torch.randn_like(input_t)

--- a/tests/brevitas_ort/test_quant_module.py
+++ b/tests/brevitas_ort/test_quant_module.py
@@ -34,7 +34,7 @@ def test_ort_wbiol(model, export_type, current_cases):
     quantizer = case_id.split('-')[-7]
     o_bit_width = case_id.split('-')[-6]
     i_bit_width = case_id.split('-')[-4]
-    onnx_opset = 18
+    onnx_opset = DEFAULT_ONNX_OPSET
     export_q_weight = False
 
     # Round weights can be exported as a Q-node (QuantizeLinear); floor weights and A2Q require


### PR DESCRIPTION
# Clamp ORT test ONNX opset to 17 on PyTorch < 2.0

Example [failure](https://github.com/Xilinx/brevitas/actions/runs/30343843243/job/90225326737?pr=1564). Previous PR (#1559 ) broke these tests for `PyTorch<2`.

## Summary

The ORT integration tests requested ONNX opset 18 unconditionally, which
`torch.onnx.export` rejects on PyTorch < 2.0 (max supported opset is 17). This
caused the entire `qcdq` export path in `tests/brevitas_ort/test_quant_module.py`
to fail with `ValueError: Unsupported ONNX opset version: 18` under the
PyTorch 1.13.1 environment. The fix derives the default opset from the running
PyTorch version so exports stay valid on older PyTorch while keeping opset 18
on PyTorch >= 2.0.

## Changes

- Added a version-derived default in `tests/brevitas_ort/common.py`:
  `DEFAULT_ONNX_OPSET = 18 if torch_version >= parse('2.0') else 17`, backed by
  new imports of `packaging.version.parse` and `brevitas.torch_version`.
- Switched the `is_brevitas_ort_close` default parameter from `onnx_opset=18`
  to `onnx_opset=DEFAULT_ONNX_OPSET`, covering the `qcdq` paths of
  `test_ort_avgpool` and `test_ort_lstm` that rely on the default.
- Updated `test_ort_wbiol` to initialize `onnx_opset = DEFAULT_ONNX_OPSET`
  (imported via the existing `from .common import *`) instead of the literal
  `18`. The fp8 branch (opset 19, already gated to PyTorch >= 2.1) is unchanged.

Opset 17 is a safe target on PyTorch < 2.0: the QCDQ QuantizeLinear/
DequantizeLinear ops are supported from opset 13 (Brevitas' own export default),
so clamping to 17 preserves behavior while staying within the supported range.

## Verification

Ran the tests locally with PyTorch 1.13 as follows:

```bash
tests/brevitas_ort/test_quant_module.py -k qcdq -q
#14682 passed, 72298 skipped, 86952 deselected, 2548 warnings in 3879.55s (1:04:39)
```