### PR TITLE
fix (ex/benchmark): fix a few race conditions in folder creation

### DIFF
--- a/src/brevitas_examples/common/benchmark/utils.py
+++ b/src/brevitas_examples/common/benchmark/utils.py
@@ -757,8 +757,8 @@ class BenchmarkUtils:
         # Retrieve the argument parser for the entrypoint
         entrypoint_parser = entry_point_utils.argument_parser
         # Instantiate directory for storing the results
-        if not script_args.dry_run and not os.path.exists(script_args.results_folder):
-            os.makedirs(script_args.results_folder)
+        if not script_args.dry_run:
+            os.makedirs(script_args.results_folder, exist_ok=True)
         # If a benchmark YAML is passed, use that to retrieve argument combinations,
         # otherwise generate all possible combinations of arguments from the
         # entrypoint_parser

--- a/src/brevitas_examples/speech_to_text/get_librispeech_data.py
+++ b/src/brevitas_examples/speech_to_text/get_librispeech_data.py
@@ -85,8 +85,7 @@ def __process_data(data_folder: str, dst_folder: str, manifest_file: str):
 
     """
 
-    if not os.path.exists(dst_folder):
-        os.makedirs(dst_folder)
+    os.makedirs(dst_folder, exist_ok=True)
 
     files = []
     entries = []


### PR DESCRIPTION
# Fix race conditions in benchmark folder creation

## Summary

Makes directory creation idempotent in the benchmark utilities and the
LibriSpeech data preparation script to avoid `FileExistsError` crashes when
runs are launched in parallel on large-scale systems. The previous
check-then-create pattern had a time-of-check/time-of-use race where another
process could create the directory between the `os.path.exists` check and the
`os.makedirs` call.

## Changes

- `src/brevitas_examples/common/benchmark/utils.py`: in `BenchmarkUtils.run`,
  drop the `not os.path.exists(...)` guard on the results folder and create it
  with `os.makedirs(..., exist_ok=True)`, still gated by the `dry_run` check.
- `src/brevitas_examples/speech_to_text/get_librispeech_data.py`: in
  `__process_data`, replace the `if not os.path.exists(dst_folder)` guard with
  `os.makedirs(dst_folder, exist_ok=True)`.

Both changes preserve the prior behavior of ensuring the directory exists while
tolerating concurrent creation. The per-job `os.mkdir(job_folder)` path in
`utils.py` is intentionally left unchanged so that a collision there still
surfaces as an error, since it would indicate multiple workers handling the
same job.