### PR TITLE
Fix (ci): add python 3.13 & PyTorch 2.5.1 to the exclusion list

### DIFF
--- a/.github/workflows/gen_github_actions.py
+++ b/.github/workflows/gen_github_actions.py
@@ -95,7 +95,8 @@ ALL_SUPPORTED_EXCLUSION_LIST = generate_exclusion_list([
     [['python_version', [
         '3.12',]], ['pytorch_version', ['1.13.1', '2.0.1', '2.1.1']]],
     [['python_version', [
-        '3.13',]], ['pytorch_version', ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1']]],
+        '3.13',]],
+     ['pytorch_version', ['1.13.1', '2.0.1', '2.1.1', '2.2.2', '2.3.1', '2.4.1', '2.5.1']]],
     [['python_version', [
         '3.14',]],
      [

--- a/.github/workflows/periodic_develop_install.yml
+++ b/.github/workflows/periodic_develop_install.yml
@@ -48,6 +48,9 @@ jobs:
           - python_version: '3.13'
             pytorch_version: '2.4.1'
 
+          - python_version: '3.13'
+            pytorch_version: '2.5.1'
+
           - python_version: '3.14'
             pytorch_version: '1.13.1'
 

--- a/.github/workflows/periodic_end_to_end.yml
+++ b/.github/workflows/periodic_end_to_end.yml
@@ -48,6 +48,9 @@ jobs:
           - python_version: '3.13'
             pytorch_version: '2.4.1'
 
+          - python_version: '3.13'
+            pytorch_version: '2.5.1'
+
           - python_version: '3.14'
             pytorch_version: '1.13.1'
 

--- a/.github/workflows/periodic_notebook.yml
+++ b/.github/workflows/periodic_notebook.yml
@@ -48,6 +48,9 @@ jobs:
           - python_version: '3.13'
             pytorch_version: '2.4.1'
 
+          - python_version: '3.13'
+            pytorch_version: '2.5.1'
+
           - python_version: '3.14'
             pytorch_version: '1.13.1'
 

--- a/.github/workflows/periodic_ort_integration.yml
+++ b/.github/workflows/periodic_ort_integration.yml
@@ -48,6 +48,9 @@ jobs:
           - python_version: '3.13'
             pytorch_version: '2.4.1'
 
+          - python_version: '3.13'
+            pytorch_version: '2.5.1'
+
           - python_version: '3.14'
             pytorch_version: '1.13.1'
 

--- a/.github/workflows/periodic_pytest.yml
+++ b/.github/workflows/periodic_pytest.yml
@@ -49,6 +49,9 @@ jobs:
           - python_version: '3.13'
             pytorch_version: '2.4.1'
 
+          - python_version: '3.13'
+            pytorch_version: '2.5.1'
+
           - python_version: '3.14'
             pytorch_version: '1.13.1'
 


### PR DESCRIPTION
# CI matrix fixes for PyTorch 2.5.1, python 3.13

[Example failure](https://github.com/Xilinx/brevitas/actions/runs/30362997547/job/90287080776).

Error:

```text
nox > python -m pip install -e '.[test, numpy]' torch==2.5.1+cpu --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple torchvision==0.20.1+cpu ...
ERROR: Could not find a version that satisfies the requirement torchvision==0.20.1+cpu (from versions: ..., 0.21.0, 0.21.0+cpu, ..., 0.28.0, 0.28.0+cpu)
ERROR: No matching distribution found for torchvision==0.20.1+cpu
```

## Summary

Removes an impossible CI matrix cell for Python 3.13 with an unavailable
PyTorch build.

## Changes

- CI matrix hygiene: `torch 2.5.1` is added to the Python-3.13 row of
  `ALL_SUPPORTED_EXCLUSION_LIST` in
  `.github/workflows/gen_github_actions.py`. PyTorch first published cp313
  wheels at 2.6.0 / torchvision 0.21.0, so the pinned `2.5.1` install can never
  resolve for Python 3.13. Regenerating the workflows drops the newly excluded
  `(3.13, 2.5.1)` cells; the five `periodic_*.yml` files each gain the
  corresponding exclude entry. Excluding the torch cell also removes the paired
  torchvision request, so no torchvision mapping change is needed.