### PR TITLE
Fix (deps/test): Add `filelock` to `test` extras

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,3 +1,4 @@
+filelock
 hypothesis
 mock
 psutil


### PR DESCRIPTION
Fix from #1557, `filelock` was added as a requirement in the test, but not as a dependency. This adds `filelock` as an explicit dependency to the `test` extras.

[Example failure](https://github.com/Xilinx/brevitas/actions/runs/30362997547/job/90287075445).

Error message:

```text
ImportError while loading conftest 'tests/brevitas_examples/conftest.py'.
tests/brevitas_examples/conftest.py:6: in <module>
    from filelock import FileLock
E   ModuleNotFoundError: No module named 'filelock'
```

Verified by running the failing test locally:

```bash
nox -s 'tests_brevitas_install_dev-3.10(pytorch_1.13.1)'
# ...
# 1 passed, 1 warning in 10.66s
```