### PR TITLE
Fix (fx): bump FX version guard to 2.14

### DIFF
--- a/src/brevitas/fx/__init__.py
+++ b/src/brevitas/fx/__init__.py
@@ -15,7 +15,7 @@ import torch
 from brevitas import torch_version
 
 # This needs to be bumped until https://github.com/pytorch/pytorch/pull/94461 gets merged
-if torch_version < version.parse('2.13'):
+if torch_version < version.parse('2.14'):
     import brevitas.backport.fx as fx
     from brevitas.backport.fx._compatibility import compatibility
     from brevitas.backport.fx._symbolic_trace import _assert_is_none


### PR DESCRIPTION
Use custom tracer for PyTorch 2.13. [Example failure](https://github.com/Xilinx/brevitas/actions/runs/30534304283/job/90843765202).

```text
FAILED tests/brevitas/fx/test_tracer.py::test_value_tracer[resnet18-True-True] - ValueError: not enough values to unpack (expected 3, got 2)
```