### PR TITLE
Fix (ci): skip fp16/bf16 cpu tests on windows+cpu

### DIFF
--- a/tests/brevitas/graph/test_equalization.py
+++ b/tests/brevitas/graph/test_equalization.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy
+import platform
 
 from packaging.version import parse
 import pytest
@@ -168,6 +169,9 @@ def test_act_equalization_models(toy_model, layerwise, fuse_scaling, dtype, devi
         pytest.skip(
             "Some operations are not implemented for float16/bfloat16 in PyTorch versions below 2.3.0"
         )
+    if dtype in [torch.float16, torch.bfloat16
+                ] and device == 'cpu' and platform.system() == 'Windows':
+        pytest.skip("Windows CPU oneDNN backend cannot build bf16/fp16 matmul primitives")
     test_id = request.node.callspec.id
 
     if 'mha' in test_id:


### PR DESCRIPTION
# Skip fp16/bf16 activation-equalization tests on Windows CPU

[Example failing run](https://github.com/Xilinx/brevitas/actions/runs/30661657513/job/91259069447), addresses #1573.

## Summary

CI's periodic Pytest runs were failing on Windows CPU jobs (e.g. torch 2.12.1, Python 3.10) with `RuntimeError: could not create a primitive` inside `test_act_equalization_models[linearmha_model-...]`. The failure is an upstream PyTorch/oneDNN limitation: the Windows CPU backend cannot build an mkldnn matmul primitive for `float16`/`bfloat16` inputs to `torch.nn.Linear`, which the `linearmha_model` toy model exercises. This PR skips the affected test combinations instead of letting them fail.

## Changes

- `tests/brevitas/graph/test_equalization.py`: in `test_act_equalization_models`, added a skip guard for `dtype in [torch.float16, torch.bfloat16]` when `device == 'cpu'` and `platform.system() == 'Windows'`, alongside the existing `torch < 2.3.0` skip for the same dtypes. The condition is platform/dtype-based rather than tied to a specific torch version, so it also covers other Windows CPU bf16/fp16 failures independent of the exact PyTorch release.

## Verification

Not run against the CI's Windows matrix (not reproducible locally). Locally verified: `ast.parse` syntax check, `yapf`/`isort` formatting checks against the repo's configured style produced no diff, and `pytest --collect-only -k test_act_equalization_models` collected all 186 parametrized cases without error on Linux (where the new skip does not trigger).