### PR TITLE
Fix (test/ort): re-enable asymmetric ORT tests

### DIFF
--- a/tests/brevitas_ort/test_quant_module.py
+++ b/tests/brevitas_ort/test_quant_module.py
@@ -59,8 +59,6 @@ def test_ort_wbiol(model, export_type, current_cases):
     if export_type == 'qonnx_dynamo' and torch_version < parse('2.8'):
         pytest.skip('QONNX dynamo export requires PyTorch >= 2.8')
 
-    if 'per_channel' in quantizer and 'asymmetric' in quantizer:
-        pytest.skip('Per-channel zero-point is not well supported in ORT.')
     if 'QuantLinear' in impl and 'asymmetric' in quantizer:
         pytest.skip('ORT execution is unreliable and fails randomly on a subset of cases.')
     if 'dynamic' in quantizer and ((o_bit_width != "o8" or i_bit_width != "i8") or


### PR DESCRIPTION
While working on #1568, I noticed some ORT tests were disabled because they used to fail with older ONNXRuntime versions. In this PR, we re-enable those tests.

When comparing to previous workflow runs, re-enabling these tests increased the test runtime by ~3mins (~32mins -> ~35mins), so I think it's worthwhile including. If we want to reduce the overall runtime, I'd consider merging #1568.

Workflow run _before_ re-enabling the tests:

```text
=== Run 31173610855 -- Test Brevitas-ORT integration (.github/workflows/ort_integration.yml) [xilinx/brevitas] ===
Total jobs:       36   (success=36)
Failing jobs:     0 (0%)
Job duration:     min=1172s (build (3.11, 2.5.1, ubuntu-latest))
                  avg=1932s
                  max=2601s (build (3.11, 2.5.1, windows-latest))
Wall clock: 2603s | Sum of job time: 69548s | Concurrency: ~26.7x
```

Workflow run after re-enabling the tests:

```text
=== Run 31189959886 -- Test Brevitas-ORT integration (.github/workflows/ort_integration.yml) [xilinx/brevitas] ===
Total jobs:       36   (success=36)
Failing jobs:     0 (0%)
Job duration:     min=1159s (build (3.11, 2.5.1, macos-latest))
                  avg=2154s
                  max=3037s (build (3.11, 2.5.1, windows-latest))
Wall clock: 3056s | Sum of job time: 77528s | Concurrency: ~25.4x
```