### PR TITLE
Fix (brevitas_examples/llm): more robust BF16 rotation training

### DIFF
--- a/src/brevitas/optim/cailey_sgd.py
+++ b/src/brevitas/optim/cailey_sgd.py
@@ -13,6 +13,8 @@ import random
 import torch
 from torch.optim.optimizer import Optimizer
 
+from brevitas.utils.torch_utils import resolve_torch_dtype
+
 
 def unit(v, dim: int = 1, eps: float = 1e-8):
     vnorm = norm(v, dim)
@@ -52,26 +54,6 @@ def qr_retraction(tan_vec):
 
 
 epsilon = 1e-8
-
-
-def _resolve_dtype(dtype):
-    """Normalize a dtype specification into an ``Optional[torch.dtype]``.
-
-    Accepts ``None``, a ``torch.dtype``, or the name of a floating-point dtype
-    (e.g. ``"float32"``). Non-floating or unknown dtypes are rejected so that
-    misconfigurations fail early rather than silently degrading precision.
-    """
-    if dtype is None or isinstance(dtype, torch.dtype):
-        resolved = dtype
-    elif isinstance(dtype, str):
-        resolved = getattr(torch, dtype, None)
-        if not isinstance(resolved, torch.dtype):
-            raise ValueError(f"Unknown torch dtype {dtype!r} for CaileySGD.")
-    else:
-        raise ValueError(f"CaileySGD dtype must be None, a str, or a torch.dtype, got {dtype!r}.")
-    if resolved is not None and not resolved.is_floating_point:
-        raise ValueError(f"CaileySGD dtype must be a floating-point dtype, got {resolved}.")
-    return resolved
 
 
 class CaileySGD(Optimizer):
@@ -126,7 +108,7 @@ class CaileySGD(Optimizer):
             omega=0,
             iters=iters,
             grad_clip=grad_clip,
-            dtype=_resolve_dtype(dtype),
+            dtype=resolve_torch_dtype(dtype, option="CaileySGD dtype", require_floating_point=True),
         )
         if nesterov and (momentum <= 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
@@ -135,13 +117,15 @@ class CaileySGD(Optimizer):
         # when the optimizer is built from ``optimizer_scheduler_args``, where the
         # dtype is provided as a per-group kwarg rather than a constructor argument.
         for group in self.param_groups:
-            group["dtype"] = _resolve_dtype(group.get("dtype"))
+            group["dtype"] = resolve_torch_dtype(
+                group.get("dtype"), option="CaileySGD dtype", require_floating_point=True)
 
     def __setstate__(self, state) -> None:
         super(CaileySGD, self).__setstate__(state)
         for group in self.param_groups:
             group.setdefault("nesterov", False)
-            group["dtype"] = _resolve_dtype(group.get("dtype"))
+            group["dtype"] = resolve_torch_dtype(
+                group.get("dtype"), option="CaileySGD dtype", require_floating_point=True)
 
     def step(self, closure=None):
         """Performs a single optimization step.

--- a/src/brevitas/optim/cailey_sgd.py
+++ b/src/brevitas/optim/cailey_sgd.py
@@ -54,6 +54,26 @@ def qr_retraction(tan_vec):
 epsilon = 1e-8
 
 
+def _resolve_dtype(dtype):
+    """Normalize a dtype specification into an ``Optional[torch.dtype]``.
+
+    Accepts ``None``, a ``torch.dtype``, or the name of a floating-point dtype
+    (e.g. ``"float32"``). Non-floating or unknown dtypes are rejected so that
+    misconfigurations fail early rather than silently degrading precision.
+    """
+    if dtype is None or isinstance(dtype, torch.dtype):
+        resolved = dtype
+    elif isinstance(dtype, str):
+        resolved = getattr(torch, dtype, None)
+        if not isinstance(resolved, torch.dtype):
+            raise ValueError(f"Unknown torch dtype {dtype!r} for CaileySGD.")
+    else:
+        raise ValueError(f"CaileySGD dtype must be None, a str, or a torch.dtype, got {dtype!r}.")
+    if resolved is not None and not resolved.is_floating_point:
+        raise ValueError(f"CaileySGD dtype must be a floating-point dtype, got {resolved}.")
+    return resolved
+
+
 class CaileySGD(Optimizer):
     r"""This optimizer updates variables with two different routines
         based on the boolean variable 'stiefel'.
@@ -106,16 +126,22 @@ class CaileySGD(Optimizer):
             omega=0,
             iters=iters,
             grad_clip=grad_clip,
+            dtype=_resolve_dtype(dtype),
         )
         if nesterov and (momentum <= 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
         super(CaileySGD, self).__init__(params, defaults)
-        self.dtype = getattr(torch, dtype) if dtype is not None else dtype
+        # Normalize any per-parameter-group dtype override. This is the path used
+        # when the optimizer is built from ``optimizer_scheduler_args``, where the
+        # dtype is provided as a per-group kwarg rather than a constructor argument.
+        for group in self.param_groups:
+            group["dtype"] = _resolve_dtype(group.get("dtype"))
 
     def __setstate__(self, state) -> None:
         super(CaileySGD, self).__setstate__(state)
         for group in self.param_groups:
             group.setdefault("nesterov", False)
+            group["dtype"] = _resolve_dtype(group.get("dtype"))
 
     def step(self, closure=None):
         """Performs a single optimization step.
@@ -132,6 +158,11 @@ class CaileySGD(Optimizer):
             momentum = group["momentum"]
             stiefel = group["stiefel"]
             iters = group["iters"]
+            # Optional per-group compute dtype. When it differs from the stored
+            # parameter dtype, the Stiefel update is carried out on a persistent
+            # higher-precision master copy ("weight_buffer") and only the final
+            # result is cast back into the (possibly lower-precision) parameter.
+            dtype = group.get("dtype")
 
             for p in group["params"]:
                 if p.grad is None:
@@ -140,9 +171,9 @@ class CaileySGD(Optimizer):
                 param = p.data
                 param_state = self.state[p]
                 # Store a copy of weights in desired dtype if it is different from param dtype
-                if self.dtype is not None and self.dtype != param.dtype:
+                if dtype is not None and dtype != param.dtype:
                     if "weight_buffer" not in param_state:
-                        param_state["weight_buffer"] = param.clone().to(self.dtype)
+                        param_state["weight_buffer"] = param.clone().to(dtype)
                     param = param_state["weight_buffer"]
 
                 unity = param.view(p.size()[0], -1)
@@ -154,8 +185,8 @@ class CaileySGD(Optimizer):
                         unity = qr_retraction(unity)
 
                     g = p.grad.data.view(p.size()[0], -1)
-                    if self.dtype is not None:
-                        g = g.to(self.dtype)
+                    if dtype is not None:
+                        g = g.to(dtype)
 
                     lr = group["lr"]
 
@@ -183,6 +214,12 @@ class CaileySGD(Optimizer):
                         V.copy_(torch.mm(W, unity.t()))  # n-by-p
 
                 else:
+
+                    if dtype is not None and dtype != p.data.dtype:
+                        raise ValueError(
+                            "CaileySGD per-group `dtype` (higher-precision master weights) is "
+                            "only supported for Stiefel updates. Set stiefel=True or remove the "
+                            "dtype override for this parameter group.")
 
                     weight_decay = group["weight_decay"]
                     dampening = group["dampening"]

--- a/src/brevitas/utils/parametrization_utils.py
+++ b/src/brevitas/utils/parametrization_utils.py
@@ -141,3 +141,20 @@ def extract_trainable_rotation_matrices(model: nn.Module) -> List[nn.Parameter]:
                 ids_rot.add(id(module.rot_mat))
                 trainable_rotations.append(module.rot_mat)
     return trainable_rotations
+
+
+def cast_parameters_(parameters: List[nn.Parameter], dtype: Optional[torch.dtype] = None) -> None:
+    """In-place change the storage ``dtype`` of ``parameters``.
+
+    The underlying ``Parameter`` objects are preserved (only ``.data`` is
+    replaced), so any sharing/tying between modules is maintained. This is used
+    to keep trainable state (e.g. rotation matrices) in a higher precision than
+    the surrounding model without altering the forward path, which casts back to
+    the operating dtype at the point of use.
+    """
+    if dtype is None:
+        return
+    with torch.no_grad():
+        for param in parameters:
+            if param.dtype != dtype:
+                param.data = param.data.to(dtype=dtype)

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -80,6 +80,25 @@ def torch_partial_deepcopy(model):
     return model_copy
 
 
+def resolve_torch_dtype(dtype, option: str = "dtype", require_floating_point: bool = False):
+    """Resolve a dtype name or ``torch.dtype`` into a ``torch.dtype``.
+
+    ``None`` is returned unchanged. A descriptive ``ValueError`` is raised for
+    unknown names or, when requested, non-floating-point dtypes.
+    """
+    if dtype is None or isinstance(dtype, torch.dtype):
+        resolved = dtype
+    elif isinstance(dtype, str):
+        resolved = getattr(torch, dtype, None)
+        if not isinstance(resolved, torch.dtype):
+            raise ValueError(f"{option} must name a torch dtype, got {dtype!r}.")
+    else:
+        raise ValueError(f"{option} must be None, a str, or a torch.dtype, got {dtype!r}.")
+    if require_floating_point and resolved is not None and not resolved.is_floating_point:
+        raise ValueError(f"{option} must be a floating-point dtype, got {resolved}.")
+    return resolved
+
+
 def kthvalue(
     x: torch.Tensor,
     k: int,

--- a/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
+++ b/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
@@ -26,7 +26,6 @@ except:
 
 from brevitas.utils.parametrization_utils import cast_parameters_
 from brevitas.utils.parametrization_utils import extract_trainable_rotation_matrices
-from brevitas.utils.torch_utils import resolve_torch_dtype
 from brevitas_examples.common.accelerate_utils.accelerate import remove_hooks
 # Optimizer/scheduler building and trainer plumbing live in trainer_utils.
 from brevitas_examples.llm.llm_quant.trainer_utils import _build_optimizers_from_configs
@@ -92,12 +91,10 @@ class RotationTrainer(GeneralizedTrainer):
         before compilation captures it. Idempotent: re-running with the same
         ``args`` is a no-op once the dtype already matches.
         """
-        cast_parameters_(
-            extract_trainable_rotation_matrices(model),
-            resolve_torch_dtype(
-                args.rotation_parameter_dtype,
-                option="rotation_parameter_dtype",
-                require_floating_point=True))
+        dtype = (
+            getattr(torch, args.rotation_parameter_dtype)
+            if args.rotation_parameter_dtype is not None else None)
+        cast_parameters_(extract_trainable_rotation_matrices(model), dtype)
 
 
 def parse_rotation_optimization_args(

--- a/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
+++ b/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
@@ -3,11 +3,13 @@
 
 import copy
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Type
 
 from accelerate.utils import DistributedType
@@ -22,6 +24,7 @@ except:
     # This has changed in transformers v5
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
+from brevitas.utils.parametrization_utils import cast_parameters_
 from brevitas.utils.parametrization_utils import extract_trainable_rotation_matrices
 from brevitas_examples.common.accelerate_utils.accelerate import remove_hooks
 # Optimizer/scheduler building and trainer plumbing live in trainer_utils.
@@ -39,6 +42,15 @@ class RotationTrainingArguments(TrainingArguments):
     parameter group is optimized with ``CaileySGD`` on the Stiefel manifold.
     """
 
+    rotation_parameter_dtype: Optional[str] = field(
+        default=None,
+        metadata={
+            "help":
+                "Storage dtype for the trainable rotation matrices (e.g. 'float32'). "
+                "When set, rotation masters are kept in this dtype while the model and "
+                "the rotation forward remain in the model dtype. None keeps the model "
+                "dtype."})
+
     def __post_init__(self) -> None:
         super().__post_init__()
         if self.optimizer_scheduler_args is None:
@@ -51,6 +63,16 @@ class RotationTrainingArguments(TrainingArguments):
                         "lr": self.learning_rate,
                         "stiefel": True,
                         "dtype": self.optimizer_dtype,},}],}]
+
+
+def _resolve_dtype(name: Optional[str], option: str) -> Optional[torch.dtype]:
+    """Resolve a dtype name (e.g. ``'float32'``) into a ``torch.dtype``."""
+    if name is None:
+        return None
+    dtype = getattr(torch, name, None)
+    if not isinstance(dtype, torch.dtype):
+        raise ValueError(f"{option} must name a torch dtype, got {name!r}")
+    return dtype
 
 
 def _select_rotation_params(
@@ -69,6 +91,19 @@ class RotationTrainer(GeneralizedTrainer):
     the model has trainable rotation matrices and no custom trainer is provided.
     """
     training_args_cls: Type[transformers.TrainingArguments] = RotationTrainingArguments
+
+    @classmethod
+    def prepare_model_for_training(
+            cls, model: torch.nn.Module, args: RotationTrainingArguments) -> None:
+        """Set the requested storage dtype for trainable rotation matrices.
+
+        Runs before quant-proxy compilation so the parameter dtype is fixed
+        before compilation captures it. Idempotent: re-running with the same
+        ``args`` is a no-op once the dtype already matches.
+        """
+        cast_parameters_(
+            extract_trainable_rotation_matrices(model),
+            _resolve_dtype(args.rotation_parameter_dtype, "rotation_parameter_dtype"))
 
 
 def parse_rotation_optimization_args(
@@ -118,13 +153,61 @@ def _prepare_model(model: torch.nn.Module) -> torch.nn.Module:
     return model
 
 
+def _resolve_trainer_cls(model: torch.nn.Module,
+                         trainer_cls: Optional[Type[Trainer]]) -> Type[Trainer]:
+    """Resolve the trainer class used to prepare and optimize ``model``.
+
+    When no custom trainer is provided, default to :class:`RotationTrainer` if
+    the model has trainable rotation matrices, otherwise raise.
+    """
+    if trainer_cls is None:
+        if len(extract_trainable_rotation_matrices(model)) == 0:
+            raise RuntimeError(
+                "No Custom Trainer has been defined and no optimizable rotations are present in the model."
+            )
+        return RotationTrainer
+    return trainer_cls
+
+
+def _maybe_prepare_model_for_training(
+        trainer_cls: Type[Trainer],
+        model: torch.nn.Module,
+        training_args: transformers.TrainingArguments) -> None:
+    """Run the trainer's optional, idempotent pre-compilation hook, if any."""
+    prepare = getattr(trainer_cls, "prepare_model_for_training", None)
+    if prepare is not None:
+        prepare(model, training_args)
+
+
+def prepare_fine_tuning(
+        model: torch.nn.Module,
+        trainer_cls: Optional[Type[Trainer]] = None,
+        extra_args: Optional[List[str]] = None
+) -> Tuple[Type[Trainer], transformers.TrainingArguments]:
+    """Resolve the trainer/training-args and prepare the model before compile.
+
+    This is meant to be called after quantization/post-processing but *before*
+    quant-proxy compilation and the first calibration forward, so a trainer can
+    establish parameter sharing or storage dtypes before compilation captures
+    parameter identities/dtypes. It returns the resolved ``(trainer_cls,
+    training_args)`` so the caller can pass them straight to
+    :func:`apply_fine_tuning` without re-parsing.
+    """
+    trainer_cls = _resolve_trainer_cls(model, trainer_cls)
+    training_args = parse_rotation_optimization_args(
+        extra_args=extra_args if extra_args is not None else [], trainer_cls=trainer_cls)
+    _maybe_prepare_model_for_training(trainer_cls, model, training_args)
+    return trainer_cls, training_args
+
+
 def apply_fine_tuning(
         model: torch.nn.Module,
         tokenizer: PreTrainedTokenizerBase,
         train_dataset: Dataset,
         collate_fn: Callable,
         trainer_cls: Optional[Type[Trainer]] = None,
-        extra_args: Optional[List[str]] = None) -> None:
+        extra_args: Optional[List[str]] = None,
+        training_args: Optional[transformers.TrainingArguments] = None) -> None:
     """Fine-tune model weights and/or rotation matrices.
 
     The training arguments are parsed from *extra_args* via
@@ -157,25 +240,23 @@ def apply_fine_tuning(
     extra_args : list of str, optional
         Raw CLI-style extra arguments parsed into the training-arguments
         dataclass (see :func:`parse_rotation_optimization_args`).
+    training_args : transformers.TrainingArguments, optional
+        Pre-resolved training arguments, as returned by
+        :func:`prepare_fine_tuning`. When provided, *extra_args* is ignored and
+        the model-preparation hook is not re-run (it already ran in
+        :func:`prepare_fine_tuning`). When ``None``, the trainer is resolved and
+        the model is prepared here.
     """
 
-    # Resolve the trainer class up front so that its ``training_args_cls`` (which
-    # sets the ``optimizer_scheduler_args`` default) is used when parsing the
-    # training arguments. When no custom trainer is given but the model has
-    # trainable rotation matrices, default to RotationTrainer (CaileySGD on the
-    # rotations, expressed through the standard optimizer_scheduler_args mechanism).
-    if trainer_cls is None:
-        if len(extract_trainable_rotation_matrices(model)) == 0:
-            raise RuntimeError(
-                "No Custom Trainer has been defined and no optimizable rotations are present in the model."
-            )
-        trainer_cls = RotationTrainer
+    # Resolve the trainer class and training arguments. When training_args is
+    # not supplied, this also runs the (idempotent) pre-training model
+    # preparation hook so that direct callers get the same behaviour as the LLM
+    # entrypoint, which prepares the model before quant-proxy compilation.
+    if training_args is None:
+        trainer_cls, training_args = prepare_fine_tuning(
+            model=model, trainer_cls=trainer_cls, extra_args=extra_args)
     else:
-        trainer_cls = trainer_cls
-
-    # Parse the training arguments, resolving the training-args class from the
-    # (possibly defaulted) trainer.
-    training_args = parse_rotation_optimization_args(extra_args=extra_args, trainer_cls=trainer_cls)
+        trainer_cls = _resolve_trainer_cls(model, trainer_cls)
 
     # Prepare model for training
     model = _prepare_model(model)

--- a/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
+++ b/src/brevitas_examples/llm/llm_quant/rotation_optimization.py
@@ -26,6 +26,7 @@ except:
 
 from brevitas.utils.parametrization_utils import cast_parameters_
 from brevitas.utils.parametrization_utils import extract_trainable_rotation_matrices
+from brevitas.utils.torch_utils import resolve_torch_dtype
 from brevitas_examples.common.accelerate_utils.accelerate import remove_hooks
 # Optimizer/scheduler building and trainer plumbing live in trainer_utils.
 from brevitas_examples.llm.llm_quant.trainer_utils import _build_optimizers_from_configs
@@ -65,16 +66,6 @@ class RotationTrainingArguments(TrainingArguments):
                         "dtype": self.optimizer_dtype,},}],}]
 
 
-def _resolve_dtype(name: Optional[str], option: str) -> Optional[torch.dtype]:
-    """Resolve a dtype name (e.g. ``'float32'``) into a ``torch.dtype``."""
-    if name is None:
-        return None
-    dtype = getattr(torch, name, None)
-    if not isinstance(dtype, torch.dtype):
-        raise ValueError(f"{option} must name a torch dtype, got {name!r}")
-    return dtype
-
-
 def _select_rotation_params(
         model: torch.nn.Module,
         training_args: transformers.TrainingArguments) -> List[torch.nn.Parameter]:
@@ -103,7 +94,10 @@ class RotationTrainer(GeneralizedTrainer):
         """
         cast_parameters_(
             extract_trainable_rotation_matrices(model),
-            _resolve_dtype(args.rotation_parameter_dtype, "rotation_parameter_dtype"))
+            resolve_torch_dtype(
+                args.rotation_parameter_dtype,
+                option="rotation_parameter_dtype",
+                require_floating_point=True))
 
 
 def parse_rotation_optimization_args(

--- a/src/brevitas_examples/llm/main.py
+++ b/src/brevitas_examples/llm/main.py
@@ -74,6 +74,7 @@ from brevitas_examples.llm.llm_quant.prepare_for_quantize import make_dynamo_com
 from brevitas_examples.llm.llm_quant.prepare_for_quantize import \
     replace_sdpa_with_quantizable_layers
 from brevitas_examples.llm.llm_quant.rotation_optimization import apply_fine_tuning
+from brevitas_examples.llm.llm_quant.rotation_optimization import prepare_fine_tuning
 from brevitas_examples.llm.llm_quant.run_utils import fix_rewriter
 from brevitas_examples.llm.llm_quant.svd_quant import apply_svd_quant
 from brevitas_examples.llm.llm_quant.trainer_utils import TRAINER_REGISTRY
@@ -560,6 +561,25 @@ def quantize_llm(args, extra_args=None):
     if args.bias_corr:
         model = add_zero_bias_to_linear(model)
 
+    # Resolve the fine-tuning trainer and prepare the model before quant-proxy
+    # compilation. This gives the trainer a chance to establish parameter
+    # sharing/storage dtypes before compilation captures parameter identities.
+    custom_trainer_cls = None
+    training_args = None
+    fine_tune_extra_args = list(extra_args) if extra_args is not None else []
+    if args.fine_tune:
+        if args.custom_trainer is not None:
+            custom_trainer_config_name = parse_custom_trainer(args.custom_trainer)
+            custom_trainer_cls = TRAINER_REGISTRY.get(custom_trainer_config_name)
+        if args.load_checkpoint:
+            # Skip training when loading from a checkpoint by forcing max_steps to
+            # 0 through the training arguments. Appended last so that it overrides
+            # any user-provided --max_steps (the argument parser keeps the last
+            # value for a repeated flag).
+            fine_tune_extra_args += ["--max_steps", "0"]
+        custom_trainer_cls, training_args = prepare_fine_tuning(
+            model=model, trainer_cls=custom_trainer_cls, extra_args=fine_tune_extra_args)
+
     model = offload_model(model)
 
     dict_hooks = dict()
@@ -601,30 +621,17 @@ def quantize_llm(args, extra_args=None):
             print("Act calibration applied.")
 
         if args.fine_tune:
-            # Load custom training plugin if specified. The registered Trainer class
-            # carries its own ``training_args_cls`` class attribute (which in turn
-            # defines the optimizer setup via ``optimizer_scheduler_args``), consumed
-            # inside apply_fine_tuning.
-            custom_trainer_cls = None
-
-            if args.custom_trainer is not None:
-                custom_trainer_config_name = parse_custom_trainer(args.custom_trainer)
-                custom_trainer_cls = TRAINER_REGISTRY.get(custom_trainer_config_name)
-
-            fine_tune_extra_args = extra_args if extra_args is not None else []
-            if args.load_checkpoint:
-                # Skip training when loading from a checkpoint by forcing
-                # max_steps to 0 through the training arguments. Appended last so
-                # that it overrides any user-provided --max_steps (the argument
-                # parser keeps the last value for a repeated flag).
-                fine_tune_extra_args += ["--max_steps", "0"]
+            # The trainer and training arguments were resolved (and the model
+            # prepared) before compilation. Pass them straight through so that
+            # neither is re-parsed nor re-prepared here.
             apply_fine_tuning(
                 model=model,
                 tokenizer=tokenizer,
                 train_dataset=finetune_dataset,
                 collate_fn=collate_fn,
                 trainer_cls=custom_trainer_cls,
-                extra_args=fine_tune_extra_args)
+                extra_args=fine_tune_extra_args,
+                training_args=training_args)
             # Remove hooks from training
             remove_hooks(model)
             model = offload_model(model)

--- a/tests/brevitas/optim/test_cailey_sgd.py
+++ b/tests/brevitas/optim/test_cailey_sgd.py
@@ -131,3 +131,54 @@ class TestCaileySGD:
                 assert closure().item() > initial_value
             else:
                 assert closure().item() < initial_value
+
+    @device_dtype_parametrize
+    def test_per_group_dtype_master_weights(self, device, dtype):
+        # A per-group dtype (the path used by optimizer_scheduler_args) must be
+        # honoured: when it differs from the parameter dtype, a higher-precision
+        # master copy is kept while the parameter stays in its original dtype.
+        if torch_version < version.parse('2.3.1') and dtype in ["float16", "bfloat16"]:
+            pytest.skip("Half/BFloat16 unsupported for some ops before torch 2.3.1.")
+        torch.manual_seed(SEED)
+        param_dtype = getattr(torch, dtype)
+        N, P = 5, 3
+        weight_orthogonal = ortho_group(dim=N, seed=SEED).rvs()
+        weight_orthonormal = weight_orthogonal / np.linalg.norm(weight_orthogonal, ord=2, axis=0)
+        weight = Parameter(
+            torch.from_numpy(weight_orthonormal[:, :P].T).to(device=device, dtype=param_dtype))
+        # Build the optimizer via a param-group dict, mirroring how
+        # _build_optimizers_from_configs assembles optimizer_scheduler_args.
+        optimizer = CaileySGD([{"params": [weight], "stiefel": True, "dtype": "float32"}])
+
+        def closure():
+            optimizer.zero_grad()
+            loss = (weight - torch.eye(N, P, device=device, dtype=param_dtype).t()).pow(2).sum()
+            loss.backward()
+            return loss
+
+        closure()
+        optimizer.step()
+        # The parameter keeps its original storage dtype ...
+        assert weight.dtype == param_dtype
+        # ... while an FP32 master copy is maintained in the optimizer state
+        # whenever the compute dtype differs from the parameter dtype.
+        buffer = optimizer.state[weight].get("weight_buffer")
+        if param_dtype == torch.float32:
+            assert buffer is None
+        else:
+            assert buffer is not None and buffer.dtype == torch.float32
+
+    def test_invalid_dtype_raises(self):
+        weight = Parameter(torch.eye(3, 5))
+        with pytest.raises(ValueError):
+            CaileySGD([weight], stiefel=True, dtype="not_a_dtype")
+        with pytest.raises(ValueError):
+            CaileySGD([weight], stiefel=True, dtype="int32")
+
+    def test_non_stiefel_dtype_rejected(self):
+        # Master-weight (dtype) support is only defined for Stiefel updates.
+        weight = Parameter(torch.randn(3, 5, dtype=torch.bfloat16))
+        optimizer = CaileySGD([weight], stiefel=False, dtype="float32")
+        weight.grad = torch.randn_like(weight)
+        with pytest.raises(ValueError):
+            optimizer.step()


### PR DESCRIPTION
# Summary

Improve the robustness of BF16 rotation fine-tuning by supporting FP32 rotation master parameters and correctly honoring per-group CaileySGD compute dtypes.

This PR fixes a configuration gap where optimizer_dtype was supplied through optimizer_scheduler_args as a parameter-group value, but CaileySGD only read a constructor-level dtype. As a result, FP32 optimizer configuration could be silently ignored.

### Motivation
BF16 model execution should not require BF16 optimizer state for trainable rotation matrices. Keeping the rotation master and manifold update in FP32 preserves the Stiefel constraint while the forward path continues to use BF16 tensors.

### Changes
- Make CaileySGD consume and validate its per-group dtype setting.
  - Supports None, dtype names such as "float32", and torch.dtype values.
  - Rejects unknown and non-floating-point dtypes.
  - Uses the configured dtype for the Stiefel master/shadow parameter, gradient conversion, and momentum state.
  - Rejects mixed-dtype non-Stiefel usage rather than silently ignoring the requested master dtype.
- Add generic FP32 rotation master storage.
  - Introduce rotation_parameter_dtype in RotationTrainingArguments.
  - Preserve Parameter identity and sharing while changing storage dtype.
  - Keep the model/rotation forward in the model dtype; only the trainable master storage is promoted.
- Add a pre-compilation fine-tuning preparation lifecycle.
  - Resolve trainer class and training args after quantization/post-processing.
  - Invoke optional prepare_model_for_training() before calibration forward and compile_quant().
  - Pass the resolved trainer and args to apply_fine_tuning() to avoid duplicate parsing/preparation.
- Consolidate duplicate dtype resolution logic.
  - Add resolve_torch_dtype() in brevitas.utils.torch_utils.
  - Reuse it from CaileySGD and generic rotation preparation.
- Add CaileySGD coverage for:
  - FP32 per-group master/shadow behavior with low-precision parameters.
  - Invalid dtype rejection.
  - Rejection of unsupported non-Stiefel master-dtype configuration.
 

### Notable difference with `optimizer_dtype`

The main difference happens when using gradient_accumulation_steps>1

With the shadow approach, gradients accumulate in the BF16 parameter’s .grad buffer before CaileySGD converts them to FP32. With FP32 parameter storage, gradients accumulate in FP32. Therefore the two configurations are not mathematically identical whenever there are multiple microbatches, gradient clipping, hooks, or other code operating on p.grad.