### PR TITLE
Fix: avoid unused groupwise expansion

### DIFF
--- a/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_float_quant_tensor.py
@@ -88,10 +88,15 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, Quant
             kwargs = _unpack_quant_tensor(kwargs)
             return func(*args, **kwargs)
 
-    def expand(self):
+    def expand(self, expand_metadata=True):
         from brevitas.utils.quant_utils import groupwise_dequant_expand
         return groupwise_dequant_expand(
-            self.value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
+            self.value_,
+            self.scale_,
+            self.zero_point_,
+            self.group_dim,
+            self.dequant_shape,
+            expand_metadata=expand_metadata)
 
     @staticmethod
     def from_expanded(value, group_size, group_dim, compress=False):
@@ -112,7 +117,7 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, Quant
 
     @property
     def value(self):
-        new_value, new_scale, new_zp = self.expand()
+        new_value, _, _ = self.expand(expand_metadata=False)
         return new_value
 
     @property
@@ -124,6 +129,20 @@ class GroupwiseFloatQuantTensor(GroupwiseFloatQuantTensorBase, FloatMixin, Quant
     def zero_point(self):
         new_value, new_scale, new_zp = self.expand()
         return new_zp
+
+    @property
+    def device(self):
+        value_device = self.value_.device
+        is_same_device = True
+        for t in [self.scale_,
+                  self.zero_point_,
+                  self.exponent_bit_width,
+                  self.mantissa_bit_width,
+                  self.exponent_bias]:
+            is_same_device &= value_device == t.device
+        if not is_same_device:
+            raise RuntimeError("Value and metadata are on different devices")
+        return value_device
 
     @staticmethod
     def check_input_type(tensor):

--- a/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
@@ -75,10 +75,15 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
             kwargs = _unpack_quant_tensor(kwargs)
             return func(*args, **kwargs)
 
-    def expand(self):
+    def expand(self, expand_metadata=True):
         from brevitas.utils.quant_utils import groupwise_dequant_expand
         return groupwise_dequant_expand(
-            self.value_, self.scale_, self.zero_point_, self.group_dim, self.dequant_shape)
+            self.value_,
+            self.scale_,
+            self.zero_point_,
+            self.group_dim,
+            self.dequant_shape,
+            expand_metadata=expand_metadata)
 
     @staticmethod
     def from_expanded(value, group_size, group_dim, compress=False):
@@ -99,8 +104,8 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
 
     @property
     def value(self):
-        from brevitas.utils.quant_utils import groupwise_dequant_expand_value
-        return groupwise_dequant_expand_value(self.value_, self.group_dim, self.dequant_shape)
+        new_value, _, _ = self.expand(expand_metadata=False)
+        return new_value
 
     @property
     def scale(self):

--- a/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
+++ b/src/brevitas/quant_tensor/groupwise_int_quant_tensor.py
@@ -99,8 +99,8 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
 
     @property
     def value(self):
-        new_value, new_scale, new_zp = self.expand()
-        return new_value
+        from brevitas.utils.quant_utils import groupwise_dequant_expand_value
+        return groupwise_dequant_expand_value(self.value_, self.group_dim, self.dequant_shape)
 
     @property
     def scale(self):
@@ -116,11 +116,7 @@ class GroupwiseIntQuantTensor(GroupwisIntQuantTensorBase, IntMixin, QuantTensor)
     def device(self):
         value_device = self.value_.device
         is_same_device = True
-        for t in [self.scale,
-                  self.zero_point,
-                  self.exponent_bit_width,
-                  self.mantissa_bit_width,
-                  self.exponent_bias]:
+        for t in [self.scale_, self.zero_point_, self.bit_width]:
             is_same_device &= value_device == t.device
         if not is_same_device:
             raise RuntimeError("Value and metadata are on different devices")

--- a/src/brevitas/utils/quant_utils.py
+++ b/src/brevitas/utils/quant_utils.py
@@ -219,33 +219,12 @@ def float_to_int_impl_to_enum(module):
         return None
 
 
-# For old versions of pytorch (2.3.1), this is needed otherwise compile skips this function
 @brevitas_compiler.disable
-def groupwise_dequant_expand_value(value_, group_dim, dequant_shape):
-    start_dim = group_dim if group_dim >= 0 else group_dim - 1
-    new_value = value_.flatten(start_dim, start_dim + 1)
-
-    unpadding_shape = dequant_shape[group_dim]
-    residual = new_value.shape[group_dim] - unpadding_shape
-    if residual > 0:
-        new_value = torch.stack(
-            torch.unbind(new_value, dim=group_dim)[:unpadding_shape], dim=group_dim)
-    return new_value
-
-
-@brevitas_compiler.disable
-def groupwise_dequant_expand(value_, scale_, zero_point_, group_dim, dequant_shape):
+def groupwise_dequant_expand(
+        value_, scale_, zero_point_, group_dim, dequant_shape, expand_metadata=True):
     curr_shape = value_.shape
     start_dim = group_dim if group_dim >= 0 else group_dim - 1
     new_value = value_.flatten(start_dim, start_dim + 1)
-    if scale_.shape != ():
-        new_scale = scale_.expand(curr_shape).flatten(start_dim, start_dim + 1)
-    else:
-        new_scale = scale_
-    if zero_point_.shape != ():
-        new_zp = zero_point_.expand(curr_shape).flatten(start_dim, start_dim + 1)
-    else:
-        new_zp = zero_point_
 
     # If we padded during quantization, we unpad here:
     # First, we compute how much we padded along the group_dim shape
@@ -257,6 +236,20 @@ def groupwise_dequant_expand(value_, scale_, zero_point_, group_dim, dequant_sha
     if residual > 0:
         new_value = torch.stack(
             torch.unbind(new_value, dim=group_dim)[:unpadding_shape], dim=group_dim)
+
+    if not expand_metadata:
+        return new_value, scale_, zero_point_
+
+    if scale_.shape != ():
+        new_scale = scale_.expand(curr_shape).flatten(start_dim, start_dim + 1)
+    else:
+        new_scale = scale_
+    if zero_point_.shape != ():
+        new_zp = zero_point_.expand(curr_shape).flatten(start_dim, start_dim + 1)
+    else:
+        new_zp = zero_point_
+
+    if residual > 0:
         new_scale = torch.stack(
             torch.unbind(new_scale, dim=group_dim)[:unpadding_shape], dim=group_dim)
         if zero_point_.shape != ():

--- a/src/brevitas/utils/quant_utils.py
+++ b/src/brevitas/utils/quant_utils.py
@@ -221,6 +221,19 @@ def float_to_int_impl_to_enum(module):
 
 # For old versions of pytorch (2.3.1), this is needed otherwise compile skips this function
 @brevitas_compiler.disable
+def groupwise_dequant_expand_value(value_, group_dim, dequant_shape):
+    start_dim = group_dim if group_dim >= 0 else group_dim - 1
+    new_value = value_.flatten(start_dim, start_dim + 1)
+
+    unpadding_shape = dequant_shape[group_dim]
+    residual = new_value.shape[group_dim] - unpadding_shape
+    if residual > 0:
+        new_value = torch.stack(
+            torch.unbind(new_value, dim=group_dim)[:unpadding_shape], dim=group_dim)
+    return new_value
+
+
+@brevitas_compiler.disable
 def groupwise_dequant_expand(value_, scale_, zero_point_, group_dim, dequant_shape):
     curr_shape = value_.shape
     start_dim = group_dim if group_dim >= 0 else group_dim - 1

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -14,11 +14,14 @@ from brevitas.quant.float_quant_ocp import Fp8e5m2OCPActPerTensorFloat
 from brevitas.quant.mx_quant_ocp import MXFloat8e4m3Act
 from brevitas.quant_tensor import FloatQuantTensor
 from brevitas.quant_tensor import GroupwiseFloatQuantTensor
+from brevitas.quant_tensor import GroupwiseIntQuantTensor
 from brevitas.quant_tensor import IntQuantTensor
 from brevitas.quant_tensor import QuantTensor
 from brevitas.utils.quant_utils import _CachedIO
 from brevitas.utils.quant_utils import _CachedIOFloat
 from brevitas.utils.quant_utils import _CachedIOGroupwiseFloat
+from brevitas.utils.quant_utils import groupwise_dequant_expand
+from brevitas.utils.quant_utils import groupwise_dequant_expand_value
 
 
 class Operator(Enum):

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -235,23 +235,31 @@ def test_mx_quant_tensor(metadata_only, bit_width=8, exponent_bit_width=4, manti
 
 
 @pytest.mark.parametrize("device", ["cpu", "meta"])
-def test_groupwise_float_quant_tensor_device(device):
+@pytest.mark.parametrize(
+    "quant_tensor_class", [GroupwiseFloatQuantTensor, GroupwiseIntQuantTensor],
+    ids=["float", "int"])
+def test_groupwise_quant_tensor_device(device, quant_tensor_class):
     device = torch.device(device)
-    quant_tensor = GroupwiseFloatQuantTensor(
+    kwargs = dict(
         value=torch.empty((1, 1, 2), device=device),
         scale=torch.tensor(1.0, device=device),
         zero_point=torch.tensor(0.0, device=device),
         group_size=2,
         group_dim=1,
-        exponent_bit_width=torch.tensor(4.0, device=device),
-        mantissa_bit_width=torch.tensor(3.0, device=device),
-        exponent_bias=torch.tensor(7.0, device=device),
-        saturating=torch.tensor(True, device=device),
-        inf_values=[],
-        nan_values=[],
         signed=torch.tensor(True, device=device),
         training=torch.tensor(False, device=device),
         dequant_shape=(1, 2))
+    if quant_tensor_class is GroupwiseFloatQuantTensor:
+        kwargs.update(
+            exponent_bit_width=torch.tensor(4.0, device=device),
+            mantissa_bit_width=torch.tensor(3.0, device=device),
+            exponent_bias=torch.tensor(7.0, device=device),
+            saturating=torch.tensor(True, device=device),
+            inf_values=[],
+            nan_values=[])
+    else:
+        kwargs.update(bit_width=torch.tensor(8.0, device=device))
+    quant_tensor = quant_tensor_class(**kwargs)
 
     assert quant_tensor.device == device
 
@@ -259,20 +267,3 @@ def test_groupwise_float_quant_tensor_device(device):
     mismatched_quant_tensor = quant_tensor._replace(scale_=torch.tensor(1.0, device=other_device))
     with pytest.raises(RuntimeError, match="Value and metadata are on different devices"):
         mismatched_quant_tensor.device
-
-
-@pytest.mark.parametrize("device", ["cpu", "meta"])
-def test_groupwise_int_quant_tensor_device(device):
-    device = torch.device(device)
-    quant_tensor = GroupwiseIntQuantTensor(
-        value=torch.empty((1, 1, 2), device=device),
-        scale=torch.tensor(1.0, device=device),
-        zero_point=torch.tensor(0.0, device=device),
-        group_size=2,
-        group_dim=1,
-        bit_width=torch.tensor(8.0, device=device),
-        signed=torch.tensor(True, device=device),
-        training=torch.tensor(False, device=device),
-        dequant_shape=(1, 2))
-
-    assert quant_tensor.device == device

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -21,7 +21,6 @@ from brevitas.utils.quant_utils import _CachedIO
 from brevitas.utils.quant_utils import _CachedIOFloat
 from brevitas.utils.quant_utils import _CachedIOGroupwiseFloat
 from brevitas.utils.quant_utils import groupwise_dequant_expand
-from brevitas.utils.quant_utils import groupwise_dequant_expand_value
 
 
 class Operator(Enum):

--- a/tests/brevitas/quant_tensor/test_quant_tensor.py
+++ b/tests/brevitas/quant_tensor/test_quant_tensor.py
@@ -232,3 +232,47 @@ def test_mx_quant_tensor(metadata_only, bit_width=8, exponent_bit_width=4, manti
     assert cache.exponent_bit_width == exponent_bit_width
     assert cache.group_size == 32
     assert cache.group_dim == 1
+
+
+@pytest.mark.parametrize("device", ["cpu", "meta"])
+def test_groupwise_float_quant_tensor_device(device):
+    device = torch.device(device)
+    quant_tensor = GroupwiseFloatQuantTensor(
+        value=torch.empty((1, 1, 2), device=device),
+        scale=torch.tensor(1.0, device=device),
+        zero_point=torch.tensor(0.0, device=device),
+        group_size=2,
+        group_dim=1,
+        exponent_bit_width=torch.tensor(4.0, device=device),
+        mantissa_bit_width=torch.tensor(3.0, device=device),
+        exponent_bias=torch.tensor(7.0, device=device),
+        saturating=torch.tensor(True, device=device),
+        inf_values=[],
+        nan_values=[],
+        signed=torch.tensor(True, device=device),
+        training=torch.tensor(False, device=device),
+        dequant_shape=(1, 2))
+
+    assert quant_tensor.device == device
+
+    other_device = torch.device("meta" if device.type == "cpu" else "cpu")
+    mismatched_quant_tensor = quant_tensor._replace(scale_=torch.tensor(1.0, device=other_device))
+    with pytest.raises(RuntimeError, match="Value and metadata are on different devices"):
+        mismatched_quant_tensor.device
+
+
+@pytest.mark.parametrize("device", ["cpu", "meta"])
+def test_groupwise_int_quant_tensor_device(device):
+    device = torch.device(device)
+    quant_tensor = GroupwiseIntQuantTensor(
+        value=torch.empty((1, 1, 2), device=device),
+        scale=torch.tensor(1.0, device=device),
+        zero_point=torch.tensor(0.0, device=device),
+        group_size=2,
+        group_dim=1,
+        bit_width=torch.tensor(8.0, device=device),
+        signed=torch.tensor(True, device=device),
+        training=torch.tensor(False, device=device),
+        dequant_shape=(1, 2))
+
+    assert quant_tensor.device == device


### PR DESCRIPTION
## Reason for this PR
Currently we perform expansion of groupwise metadata (i.e., scale, zero point) for no reason.

This cleans that up.