### PR TITLE
Fix (nn): fix edge case in QSDA where fwd/bwd could become NaN

### DIFF
--- a/src/brevitas/nn/quant_sdpa.py
+++ b/src/brevitas/nn/quant_sdpa.py
@@ -217,10 +217,9 @@ class QuantScaledDotProductAttention(Module, LayerProtocol, ExportMixin):
                 attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
             else:
                 attn_bias += attn_mask
-        # A query row masked out entirely makes attn_bias all -inf, and softmax turns that
-        # into NaN. F.scaled_dot_product_attention returns 0 for such rows, so neutralise
-        # the bias here and zero the weights after the softmax to match, which keeps both
-        # the output and its gradient finite.
+        # A fully-masked query row makes attn_bias all -inf, which softmax turns into NaN.
+        # Neutralise it here and zero the weights after the softmax to match native SDPA,
+        # keeping both the output and its gradient finite.
         fully_masked_row = torch.isneginf(attn_bias).all(dim=-1, keepdim=True)
         attn_bias = attn_bias.masked_fill(fully_masked_row, 0.0)
         query, key, value = self.pre_process_q(query), self.pre_process_k(key), self.pre_process_v(value)

--- a/src/brevitas/nn/quant_sdpa.py
+++ b/src/brevitas/nn/quant_sdpa.py
@@ -217,6 +217,12 @@ class QuantScaledDotProductAttention(Module, LayerProtocol, ExportMixin):
                 attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
             else:
                 attn_bias += attn_mask
+        # A query row masked out entirely makes attn_bias all -inf, and softmax turns that
+        # into NaN. F.scaled_dot_product_attention returns 0 for such rows, so neutralise
+        # the bias here and zero the weights after the softmax to match, which keeps both
+        # the output and its gradient finite.
+        fully_masked_row = torch.isneginf(attn_bias).all(dim=-1, keepdim=True)
+        attn_bias = attn_bias.masked_fill(fully_masked_row, 0.0)
         query, key, value = self.pre_process_q(query), self.pre_process_k(key), self.pre_process_v(value)
 
         if enable_gqa:
@@ -229,6 +235,7 @@ class QuantScaledDotProductAttention(Module, LayerProtocol, ExportMixin):
         attn_weight += attn_bias
         attn_weight = self.softmax_input_quant(attn_weight)
         attn_weight = torch.softmax(attn_weight, dim=-1)
+        attn_weight = attn_weight.masked_fill(fully_masked_row, 0.0)
         attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
         attn_weight = self.attn_output_weights_quant(attn_weight)
         attn_output = attn_weight @ self.v_quant(value)

--- a/tests/brevitas/nn/test_sdpa.py
+++ b/tests/brevitas/nn/test_sdpa.py
@@ -1,12 +1,10 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from packaging import version
 import pytest
 import torch
 import torch.nn.functional as F
 
-from brevitas import torch_version
 from brevitas.nn import QuantScaledDotProductAttention
 from brevitas.nn import ScaledDotProductAttention
 from brevitas.quant import Int8ActPerTensorFloat
@@ -20,10 +18,8 @@ BATCH_SIZE = 2
 SEQUENCE_LENGTH = 4
 PAST_SEQUENCE_LENGTH = 5
 DROPOUT_SEED = 42
-FULLY_MASKED_SEED = 0
-# F.scaled_dot_product_attention only started returning 0 rather than NaN for a fully
-# masked attention row in 2.5.0. Before that it returns NaN, so it cannot serve as a
-# reference for any test that compares against it.
+# F.scaled_dot_product_attention returns NaN rather than 0 for a fully masked attention
+# row before 2.5.0, so it cannot serve as a reference for tests that compare against it.
 FULLY_MASKED_REF_VERSION = '2.5.0'
 
 
@@ -74,9 +70,6 @@ class TestScaledDotProductAttention:
                 checked = True
             assert checked, f"Unmatched kwarg: {k}"
 
-    # A random mask can fully mask out a query row, which `F.scaled_dot_product_attention`
-    # only handles from `FULLY_MASKED_REF_VERSION` onwards, so this comparison is not
-    # meaningful before then.
     @requires_pt_ge(FULLY_MASKED_REF_VERSION)
     @pytest.mark.parametrize("dropout_p", [0.0, 0.5])
     @pytest.mark.parametrize("is_causal", [True, False])
@@ -90,10 +83,6 @@ class TestScaledDotProductAttention:
             "is_causal": is_causal,
             "scale": scale,
             "enable_gqa": enable_gqa,}
-        if torch_version < version.parse('2.5.0'):
-            del extra_kwargs["enable_gqa"]
-        if torch_version < version.parse('2.1.0'):
-            del extra_kwargs["scale"]
 
         # GQA means that there is a ration between KV head_dim and Q head_dim, in this case 2:1
         if extra_kwargs.get("enable_gqa", False):
@@ -120,9 +109,6 @@ class TestScaledDotProductAttention:
         assert torch.isclose(out, ref_out, atol=ATOL).all()
         assert torch.isclose(out, ref_out, atol=ATOL).all()
 
-    # A random mask can fully mask out a query row, for which Brevitas returns 0 while
-    # `F.scaled_dot_product_attention` returns NaN before `FULLY_MASKED_REF_VERSION`, so
-    # this comparison is not meaningful before then.
     @requires_pt_ge(FULLY_MASKED_REF_VERSION)
     @pytest.mark.parametrize("dropout_p", [0.0, 0.5])
     @pytest.mark.parametrize("is_causal", [True, False])
@@ -135,12 +121,6 @@ class TestScaledDotProductAttention:
             "is_causal": is_causal,
             "scale": scale,
             "enable_gqa": enable_gqa,}
-
-        if torch_version < version.parse('2.5.0'):
-            del extra_kwargs["enable_gqa"]
-
-        if torch_version < version.parse('2.1.0'):
-            del extra_kwargs["scale"]
 
         # GQA means that there is a ration between KV head_dim and Q head_dim, in this case 2:1
         if extra_kwargs.get("enable_gqa", False):
@@ -175,9 +155,10 @@ class TestScaledDotProductAttention:
         assert torch.isclose(out, ref_out, atol=ATOL).all()
         assert torch.isclose(out, ref_out, atol=ATOL).all()
 
-    @requires_pt_ge('2.0')
+    @requires_pt_ge(FULLY_MASKED_REF_VERSION)
     def test_sdpa_quant_disabled_fully_masked_row(self):
         kv_length = PAST_SEQUENCE_LENGTH + SEQUENCE_LENGTH
+        m = ScaledDotProductAttention()
         qm = QuantScaledDotProductAttention(
             softmax_input_quant=None,
             attn_output_weights_quant=None,
@@ -186,27 +167,22 @@ class TestScaledDotProductAttention:
             v_quant=None,
             sdpa_output_quant=None,
         )
-        # Fixed seed: the gradient comparison below runs close to ATOL, so it must not
-        # depend on ambient RNG state and therefore on test execution order.
-        torch.manual_seed(FULLY_MASKED_SEED)
+        # Fixed seed: the gradient comparison runs close to ATOL, so keep it independent of
+        # ambient RNG state and therefore of test execution order.
+        torch.manual_seed(0)
         q = torch.randn(BATCH_SIZE, HEAD_DIM, SEQUENCE_LENGTH, EMBED_DIM, requires_grad=True)
         k = torch.randn(BATCH_SIZE, HEAD_DIM, kv_length, EMBED_DIM, requires_grad=True)
         v = torch.randn(BATCH_SIZE, HEAD_DIM, kv_length, EMBED_DIM, requires_grad=True)
         # Deterministically force one fully-masked query row.
         attn_mask = torch.ones(BATCH_SIZE, 1, SEQUENCE_LENGTH, kv_length, dtype=torch.bool)
         attn_mask[0, 0, 1, :] = False
+        ref_out = m(q, k, v, attn_mask)
         out = qm(q, k, v, attn_mask)
-        # Use autograd.grad rather than backward() so the reference pass below cannot
-        # accumulate into the same .grad buffers and make the comparison vacuous.
-        grads = torch.autograd.grad(out.sum(), (q, k, v))
-        # A fully-masked row must not produce NaN in either direction. This holds on every
-        # supported PyTorch version, since it only depends on the Brevitas implementation.
         assert not out.isnan().any()
-        assert all(g.isfinite().all() for g in grads)
-        # Where native SDPA is a usable reference, the values must match it too.
-        if torch_version >= version.parse(FULLY_MASKED_REF_VERSION):
-            ref_out = ScaledDotProductAttention()(q, k, v, attn_mask)
-            ref_grads = torch.autograd.grad(ref_out.sum(), (q, k, v))
-            assert torch.isclose(out, ref_out, atol=ATOL).all()
-            for g, ref_g in zip(grads, ref_grads):
-                assert torch.isclose(g, ref_g, atol=ATOL).all()
+        assert torch.isclose(out, ref_out, atol=ATOL).all()
+        # A fully-masked row must not poison gradients either. Use autograd.grad rather than
+        # backward() so the two passes cannot accumulate into the same .grad buffers.
+        ref_grads = torch.autograd.grad(ref_out.sum(), (q, k, v))
+        grads = torch.autograd.grad(out.sum(), (q, k, v))
+        for g, ref_g in zip(grads, ref_grads):
+            assert torch.isclose(g, ref_g, atol=ATOL).all()

--- a/tests/brevitas/nn/test_sdpa.py
+++ b/tests/brevitas/nn/test_sdpa.py
@@ -22,8 +22,9 @@ PAST_SEQUENCE_LENGTH = 5
 DROPOUT_SEED = 42
 FULLY_MASKED_SEED = 0
 # F.scaled_dot_product_attention only started returning 0 rather than NaN for a fully
-# masked attention row in 2.5.0, so it is not a usable reference before that.
-FULLY_MASKED_REF_VERSION = version.parse('2.5.0')
+# masked attention row in 2.5.0. Before that it returns NaN, so it cannot serve as a
+# reference for any test that compares against it.
+FULLY_MASKED_REF_VERSION = '2.5.0'
 
 
 class TestScaledDotProductAttention:
@@ -73,7 +74,10 @@ class TestScaledDotProductAttention:
                 checked = True
             assert checked, f"Unmatched kwarg: {k}"
 
-    @requires_pt_ge('2.0')
+    # A random mask can fully mask out a query row, which `F.scaled_dot_product_attention`
+    # only handles from `FULLY_MASKED_REF_VERSION` onwards, so this comparison is not
+    # meaningful before then.
+    @requires_pt_ge(FULLY_MASKED_REF_VERSION)
     @pytest.mark.parametrize("dropout_p", [0.0, 0.5])
     @pytest.mark.parametrize("is_causal", [True, False])
     @pytest.mark.parametrize("scale", [None, 0.3])
@@ -116,7 +120,10 @@ class TestScaledDotProductAttention:
         assert torch.isclose(out, ref_out, atol=ATOL).all()
         assert torch.isclose(out, ref_out, atol=ATOL).all()
 
-    @requires_pt_ge('2.0')
+    # A random mask can fully mask out a query row, for which Brevitas returns 0 while
+    # `F.scaled_dot_product_attention` returns NaN before `FULLY_MASKED_REF_VERSION`, so
+    # this comparison is not meaningful before then.
+    @requires_pt_ge(FULLY_MASKED_REF_VERSION)
     @pytest.mark.parametrize("dropout_p", [0.0, 0.5])
     @pytest.mark.parametrize("is_causal", [True, False])
     @pytest.mark.parametrize("scale", [None, 0.3])
@@ -197,7 +204,7 @@ class TestScaledDotProductAttention:
         assert not out.isnan().any()
         assert all(g.isfinite().all() for g in grads)
         # Where native SDPA is a usable reference, the values must match it too.
-        if torch_version >= FULLY_MASKED_REF_VERSION:
+        if torch_version >= version.parse(FULLY_MASKED_REF_VERSION):
             ref_out = ScaledDotProductAttention()(q, k, v, attn_mask)
             ref_grads = torch.autograd.grad(ref_out.sum(), (q, k, v))
             assert torch.isclose(out, ref_out, atol=ATOL).all()

--- a/tests/brevitas/nn/test_sdpa.py
+++ b/tests/brevitas/nn/test_sdpa.py
@@ -20,6 +20,10 @@ BATCH_SIZE = 2
 SEQUENCE_LENGTH = 4
 PAST_SEQUENCE_LENGTH = 5
 DROPOUT_SEED = 42
+FULLY_MASKED_SEED = 0
+# F.scaled_dot_product_attention only started returning 0 rather than NaN for a fully
+# masked attention row in 2.5.0, so it is not a usable reference before that.
+FULLY_MASKED_REF_VERSION = version.parse('2.5.0')
 
 
 class TestScaledDotProductAttention:
@@ -167,7 +171,6 @@ class TestScaledDotProductAttention:
     @requires_pt_ge('2.0')
     def test_sdpa_quant_disabled_fully_masked_row(self):
         kv_length = PAST_SEQUENCE_LENGTH + SEQUENCE_LENGTH
-        m = ScaledDotProductAttention()
         qm = QuantScaledDotProductAttention(
             softmax_input_quant=None,
             attn_output_weights_quant=None,
@@ -176,16 +179,27 @@ class TestScaledDotProductAttention:
             v_quant=None,
             sdpa_output_quant=None,
         )
+        # Fixed seed: the gradient comparison below runs close to ATOL, so it must not
+        # depend on ambient RNG state and therefore on test execution order.
+        torch.manual_seed(FULLY_MASKED_SEED)
         q = torch.randn(BATCH_SIZE, HEAD_DIM, SEQUENCE_LENGTH, EMBED_DIM, requires_grad=True)
         k = torch.randn(BATCH_SIZE, HEAD_DIM, kv_length, EMBED_DIM, requires_grad=True)
         v = torch.randn(BATCH_SIZE, HEAD_DIM, kv_length, EMBED_DIM, requires_grad=True)
         # Deterministically force one fully-masked query row.
         attn_mask = torch.ones(BATCH_SIZE, 1, SEQUENCE_LENGTH, kv_length, dtype=torch.bool)
         attn_mask[0, 0, 1, :] = False
-        ref_out = m(q, k, v, attn_mask)
         out = qm(q, k, v, attn_mask)
+        # Use autograd.grad rather than backward() so the reference pass below cannot
+        # accumulate into the same .grad buffers and make the comparison vacuous.
+        grads = torch.autograd.grad(out.sum(), (q, k, v))
+        # A fully-masked row must not produce NaN in either direction. This holds on every
+        # supported PyTorch version, since it only depends on the Brevitas implementation.
         assert not out.isnan().any()
-        assert torch.isclose(out, ref_out, atol=ATOL).all()
-        # A fully-masked row must not poison gradients either.
-        out.sum().backward()
-        assert q.grad.isfinite().all() and k.grad.isfinite().all() and v.grad.isfinite().all()
+        assert all(g.isfinite().all() for g in grads)
+        # Where native SDPA is a usable reference, the values must match it too.
+        if torch_version >= FULLY_MASKED_REF_VERSION:
+            ref_out = ScaledDotProductAttention()(q, k, v, attn_mask)
+            ref_grads = torch.autograd.grad(ref_out.sum(), (q, k, v))
+            assert torch.isclose(out, ref_out, atol=ATOL).all()
+            for g, ref_g in zip(grads, ref_grads):
+                assert torch.isclose(g, ref_g, atol=ATOL).all()

--- a/tests/brevitas/nn/test_sdpa.py
+++ b/tests/brevitas/nn/test_sdpa.py
@@ -163,3 +163,29 @@ class TestScaledDotProductAttention:
         out = qm(q, k, v, attn_mask, **extra_kwargs)
         assert torch.isclose(out, ref_out, atol=ATOL).all()
         assert torch.isclose(out, ref_out, atol=ATOL).all()
+
+    @requires_pt_ge('2.0')
+    def test_sdpa_quant_disabled_fully_masked_row(self):
+        kv_length = PAST_SEQUENCE_LENGTH + SEQUENCE_LENGTH
+        m = ScaledDotProductAttention()
+        qm = QuantScaledDotProductAttention(
+            softmax_input_quant=None,
+            attn_output_weights_quant=None,
+            q_scaled_quant=None,
+            k_transposed_quant=None,
+            v_quant=None,
+            sdpa_output_quant=None,
+        )
+        q = torch.randn(BATCH_SIZE, HEAD_DIM, SEQUENCE_LENGTH, EMBED_DIM, requires_grad=True)
+        k = torch.randn(BATCH_SIZE, HEAD_DIM, kv_length, EMBED_DIM, requires_grad=True)
+        v = torch.randn(BATCH_SIZE, HEAD_DIM, kv_length, EMBED_DIM, requires_grad=True)
+        # Deterministically force one fully-masked query row.
+        attn_mask = torch.ones(BATCH_SIZE, 1, SEQUENCE_LENGTH, kv_length, dtype=torch.bool)
+        attn_mask[0, 0, 1, :] = False
+        ref_out = m(q, k, v, attn_mask)
+        out = qm(q, k, v, attn_mask)
+        assert not out.isnan().any()
+        assert torch.isclose(out, ref_out, atol=ATOL).all()
+        # A fully-masked row must not poison gradients either.
+        out.sum().backward()
+        assert q.grad.isfinite().all() and k.grad.isfinite().all() and v.grad.isfinite().all()


### PR DESCRIPTION
# Fix NaN forward and backward output for fully-masked attention rows in QSDPA

[Example failure](https://github.com/Xilinx/brevitas/actions/runs/32520026332/job/96890019397).

## Summary

`QuantScaledDotProductAttention` implements attention in eager math rather than calling
`F.scaled_dot_product_attention`. A query row whose boolean `attn_mask` is entirely `False`
gets an all-`-inf` bias, and `torch.softmax` over that row yields `NaN`, which reaches both
the output and the `query`/`key`/`value` gradients. Native SDPA returns `0.0` there, so the
quantized layer silently diverged from its float reference. This makes the eager path
return `0.0` with finite gradients, and gates the tests that compare against native on the
PyTorch version from which native itself is well behaved.

## Changes

### Fully-masked rows (`src/brevitas/nn/quant_sdpa.py`)

Such rows are detected once after `attn_bias` is assembled and neutralised on both sides of
the softmax: the bias is reset to `0.0` beforehand, so the softmax sees finite scores, and
the resulting weights are zeroed afterwards to give native's `0.0` output.

Resetting *before* the softmax is what keeps gradients finite. Masking the `NaN` afterwards
still feeds `grad_output = 0` into softmax backward, which multiplies it by the `NaN`
softmax output, so `NaN` would continue to reach `query`, `key` and `value`.

Detection reduces the last dimension with `keepdim=True`, broadcasting over both the
mask-supplied and `(L, S)` causal bias shapes. Where no row is fully masked, `masked_fill`
with an all-`False` mask is a no-op, so the no-mask path, the causal path
(`tril(diagonal=0)` always retains `j=0`) and float masks using large finite negatives are
bit-identical to before. As a side effect, `-inf` no longer reaches `softmax_input_quant`,
where it would corrupt that quantizer's scale statistics.

### Version gating and tests (`tests/brevitas/nn/test_sdpa.py`)

Native SDPA's behaviour for these rows changed in PyTorch 2.5.0: `NaN` before, `0.0` from
then on. Bisecting the CPU builds confirms it — 2.2.2, 2.3.1 and 2.4.1 return `NaN`; 2.5.1,
2.6.0, 2.7.1 and 2.13.0 return `0.0`. Native is therefore unusable as a reference below
2.5.0, which breaks both existing comparisons: `test_sdpa_quant_disabled_fwd` compares
Brevitas' `0.0` against native's `NaN`, and `test_sdpa_fwd` compares native against native
— both `NaN`, which still fails because `torch.isclose` defaults to `equal_nan=False`.
Their random mask contains a fully-masked row about 1.55% of the time, which is why the
defect surfaced as an intermittent CI failure. Both are now gated on the single
`FULLY_MASKED_REF_VERSION = '2.5.0'` constant.

That gate leaves four in-test version guards unreachable (`< 2.5.0` dropping `enable_gqa`,
`< 2.1.0` dropping `scale`); they are removed, along with the `packaging.version` and
`brevitas.torch_version` imports left without users. The cost is that PyTorch 2.0 through
2.4 now run one test from this file instead of 66.

`test_sdpa_quant_disabled_fully_masked_row` forces one fully-masked row deterministically
and asserts the output is `NaN`-free and that both output and gradients match the
`ScaledDotProductAttention` reference within `ATOL`. Two deliberate details: gradients come
from `torch.autograd.grad`, since two `backward()` passes over shared leaves would
accumulate into the same `.grad` buffers and make the comparison vacuous; and the inputs
are seeded, because the gradient comparison runs close to `ATOL`.

## Verification

Python 3.11.15, PyTorch CPU builds:

| Check | Result |
| --- | --- |
| torch 2.13.0 | 66 passed, 0 skipped; new test fails with the source change reverted |
| torch 2.5.1 — gate boundary, and the release adding `enable_gqa` | 66 passed, 0 skipped; also confirms removing the guards is safe |
| torch 2.4.1 | 1 passed, 65 skipped (`Requires Pytorch >= 2.5.0`) |
| `pytest tests/brevitas/nn`, torch 2.13.0 | 13828 passed, 9952 skipped, 6 xfailed, 18 xpassed |
| `yapf` 0.32.0, `isort` 5.11.5 | no changes needed |

A soak of the affected `test_sdpa_quant_disabled_fwd` parametrization over 2000 mask draws
on torch 2.13.0: 31 draws contained a fully-masked row; before the change all 31 produced
`NaN` and diverged from native, after it none did.