### PR TITLE
Feat (utils): compile-friendly utils

### DIFF
--- a/src/brevitas/compiler.py
+++ b/src/brevitas/compiler.py
@@ -15,3 +15,10 @@ if torch_version > version.parse('2.1'):
     disable = torch._dynamo.disable
 else:
     disable = _disabled
+
+# PyTorch 2.3.1 can incorrectly eliminate small helper functions during compile.
+# Newer versions can trace these helpers directly.
+if version.parse('2.1') < torch_version < version.parse('2.4'):
+    disable_on_old_torch = torch._dynamo.disable
+else:
+    disable_on_old_torch = _disabled

--- a/src/brevitas/compiler.py
+++ b/src/brevitas/compiler.py
@@ -15,10 +15,3 @@ if torch_version > version.parse('2.1'):
     disable = torch._dynamo.disable
 else:
     disable = _disabled
-
-# PyTorch 2.3.1 can incorrectly eliminate small helper functions during compile.
-# Newer versions can trace these helpers directly.
-if version.parse('2.1') < torch_version < version.parse('2.4'):
-    disable_on_old_torch = torch._dynamo.disable
-else:
-    disable_on_old_torch = _disabled

--- a/src/brevitas/export/inference/handler.py
+++ b/src/brevitas/export/inference/handler.py
@@ -184,8 +184,8 @@ class GroupwiseMixin(torch.nn.Module):
             **kwargs) -> None:
         super().__init__(**kwargs)
         self.skip_create_quant_tensor = True
-        self._group_dim = 0
-        self._group_size = 1
+        self._group_dim = None
+        self._group_size = None
 
     @property
     def group_dim(self) -> int:

--- a/src/brevitas/export/inference/handler.py
+++ b/src/brevitas/export/inference/handler.py
@@ -184,23 +184,24 @@ class GroupwiseMixin(torch.nn.Module):
             **kwargs) -> None:
         super().__init__(**kwargs)
         self.skip_create_quant_tensor = True
-        self.register_buffer('group_dim_t', torch.ones((), dtype=torch.int, device=device))
-        self.register_buffer('group_size_t', torch.ones((), dtype=torch.int, device=device))
+        self._group_dim = 0
+        self._group_size = 1
 
     @property
-    def group_dim(self) -> torch.Tensor:
-        return self.group_dim_t.int()
+    def group_dim(self) -> int:
+        return self._group_dim
 
     @property
-    def group_size(self) -> torch.Tensor:
-        return self.group_size_t.int()
+    def group_size(self) -> int:
+        return self._group_size
 
     def prepare_for_export(self, module: nn.Module) -> None:
         if hasattr(super(), 'prepare_for_export'):
             super().prepare_for_export(module)
         if module.is_quant_enabled:
-            self.group_dim_t = torch.tensor(module.group_dim)
-            self.group_size_t = torch.tensor(module.group_size)
+            # Keep grouping metadata in Python so Dynamo treats it as static control flow.
+            self._group_dim = int(module.group_dim)
+            self._group_size = int(module.group_size)
 
     def reshape(self, x: Tensor, group_dim: int, group_size: int) -> Tensor:
         init_shape = list(x.shape)

--- a/src/brevitas/export/inference/handler.py
+++ b/src/brevitas/export/inference/handler.py
@@ -184,24 +184,16 @@ class GroupwiseMixin(torch.nn.Module):
             **kwargs) -> None:
         super().__init__(**kwargs)
         self.skip_create_quant_tensor = True
-        self._group_dim = None
-        self._group_size = None
-
-    @property
-    def group_dim(self) -> int:
-        return self._group_dim
-
-    @property
-    def group_size(self) -> int:
-        return self._group_size
+        self.group_dim = None
+        self.group_size = None
 
     def prepare_for_export(self, module: nn.Module) -> None:
         if hasattr(super(), 'prepare_for_export'):
             super().prepare_for_export(module)
         if module.is_quant_enabled:
             # Keep grouping metadata in Python so Dynamo treats it as static control flow.
-            self._group_dim = int(module.group_dim)
-            self._group_size = int(module.group_size)
+            self.group_dim = int(module.group_dim)
+            self.group_size = int(module.group_size)
 
     def reshape(self, x: Tensor, group_dim: int, group_size: int) -> Tensor:
         init_shape = list(x.shape)

--- a/src/brevitas/export/inference/vLLM/handler.py
+++ b/src/brevitas/export/inference/vLLM/handler.py
@@ -54,8 +54,8 @@ class StandaloneGroupwiseQuantMixin(DynamicScaleZeroPointMixin):
 class vLLMGroupwiseMetadataMixin:
 
     def __init__(self, **kwargs):
-        device = kwargs.get('device')
         super().__init__(**kwargs)
+        device = kwargs.get('device')
         self.register_buffer('group_dim_t', torch.zeros((), dtype=torch.int, device=device))
         self.register_buffer('group_size_t', torch.ones((), dtype=torch.int, device=device))
 

--- a/src/brevitas/export/inference/vLLM/handler.py
+++ b/src/brevitas/export/inference/vLLM/handler.py
@@ -20,7 +20,9 @@ from brevitas.utils.quant_utils import groupwise_dequant_expand
 from ..handler import DynamicFloatInferenceHandler
 from ..handler import DynamicScaleZeroPointMixin
 from ..handler import GroupwiseFloatInferenceHandler
+from ..handler import GroupwiseFloatWeightInferenceHandler
 from ..handler import GroupwiseIntInferenceHandler
+from ..handler import GroupwiseIntWeightInferenceHandler
 
 EPS = 1e-16
 
@@ -49,7 +51,19 @@ class StandaloneGroupwiseQuantMixin(DynamicScaleZeroPointMixin):
         return scale
 
 
-class vLLMGroupwiseIntInferenceHandler(GroupwiseIntInferenceHandler, StandaloneGroupwiseQuantMixin):
+class vLLMGroupwiseMetadataMixin:
+
+    def state_dict(self, destination=None, prefix='', keep_vars=False):
+        output_dict = super().state_dict(
+            destination=destination, prefix=prefix, keep_vars=keep_vars)
+        output_dict[prefix + 'group_dim_t'] = torch.tensor(self.group_dim, dtype=torch.int)
+        output_dict[prefix + 'group_size_t'] = torch.tensor(self.group_size, dtype=torch.int)
+        return output_dict
+
+
+class vLLMGroupwiseIntInferenceHandler(vLLMGroupwiseMetadataMixin,
+                                       GroupwiseIntInferenceHandler,
+                                       StandaloneGroupwiseQuantMixin):
 
     def forward(self, x: Tensor) -> Tuple[Tensor, ...]:
         inp_shape = x.shape
@@ -62,7 +76,8 @@ class vLLMGroupwiseIntInferenceHandler(GroupwiseIntInferenceHandler, StandaloneG
         return out, scale, zero_point, self.bit_width
 
 
-class vLLMGroupwiseFloatInferenceHandler(GroupwiseFloatInferenceHandler,
+class vLLMGroupwiseFloatInferenceHandler(vLLMGroupwiseMetadataMixin,
+                                         GroupwiseFloatInferenceHandler,
                                          StandaloneGroupwiseQuantMixin):
 
     def forward(self, x: Tensor) -> Tuple[Tensor, ...]:
@@ -74,6 +89,16 @@ class vLLMGroupwiseFloatInferenceHandler(GroupwiseFloatInferenceHandler,
         out = self.inner_forward(x, scale, zero_point)
         out = groupwise_dequant_expand(out, scale, zero_point, self.group_dim, inp_shape)[0]
         return out, scale, zero_point, self.exponent_bit_width, self.mantissa_bit_width, self.exponent_bias, self.saturating, self.inf_values, self.nan_values
+
+
+class vLLMGroupwiseIntWeightInferenceHandler(vLLMGroupwiseMetadataMixin,
+                                             GroupwiseIntWeightInferenceHandler):
+    pass
+
+
+class vLLMGroupwiseFloatWeightInferenceHandler(vLLMGroupwiseMetadataMixin,
+                                               GroupwiseFloatWeightInferenceHandler):
+    pass
 
 
 class vLLMDynamicPerRowFloatInferenceHandler(DynamicFloatInferenceHandler,

--- a/src/brevitas/export/inference/vLLM/handler.py
+++ b/src/brevitas/export/inference/vLLM/handler.py
@@ -56,15 +56,23 @@ class vLLMGroupwiseMetadataMixin:
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         device = kwargs.get('device')
-        self.register_buffer('group_dim_t', torch.zeros((), dtype=torch.int, device=device))
-        self.register_buffer('group_size_t', torch.ones((), dtype=torch.int, device=device))
+        self.register_buffer('group_dim_t', torch.empty((), dtype=torch.int, device=device))
+        self.register_buffer('group_size_t', torch.empty((), dtype=torch.int, device=device))
 
     def prepare_for_export(self, module):
         super().prepare_for_export(module)
-        self.group_dim_t = torch.tensor(
-            self.group_dim, dtype=torch.int, device=self.group_dim_t.device)
-        self.group_size_t = torch.tensor(
-            self.group_size, dtype=torch.int, device=self.group_size_t.device)
+        self.group_dim_t.fill_(self.group_dim)
+        self.group_size_t.fill_(self.group_size)
+
+    def _load_from_state_dict(
+            self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
+            error_msgs):
+        super()._load_from_state_dict(
+            state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
+        if prefix + 'group_dim_t' in state_dict:
+            self._group_dim = int(self.group_dim_t.item())
+        if prefix + 'group_size_t' in state_dict:
+            self._group_size = int(self.group_size_t.item())
 
 
 class vLLMGroupwiseIntInferenceHandler(vLLMGroupwiseMetadataMixin,

--- a/src/brevitas/export/inference/vLLM/handler.py
+++ b/src/brevitas/export/inference/vLLM/handler.py
@@ -53,12 +53,18 @@ class StandaloneGroupwiseQuantMixin(DynamicScaleZeroPointMixin):
 
 class vLLMGroupwiseMetadataMixin:
 
-    def state_dict(self, destination=None, prefix='', keep_vars=False):
-        output_dict = super().state_dict(
-            destination=destination, prefix=prefix, keep_vars=keep_vars)
-        output_dict[prefix + 'group_dim_t'] = torch.tensor(self.group_dim, dtype=torch.int)
-        output_dict[prefix + 'group_size_t'] = torch.tensor(self.group_size, dtype=torch.int)
-        return output_dict
+    def __init__(self, **kwargs):
+        device = kwargs.get('device')
+        super().__init__(**kwargs)
+        self.register_buffer('group_dim_t', torch.zeros((), dtype=torch.int, device=device))
+        self.register_buffer('group_size_t', torch.ones((), dtype=torch.int, device=device))
+
+    def prepare_for_export(self, module):
+        super().prepare_for_export(module)
+        self.group_dim_t = torch.tensor(
+            self.group_dim, dtype=torch.int, device=self.group_dim_t.device)
+        self.group_size_t = torch.tensor(
+            self.group_size, dtype=torch.int, device=self.group_size_t.device)
 
 
 class vLLMGroupwiseIntInferenceHandler(vLLMGroupwiseMetadataMixin,

--- a/src/brevitas/export/inference/vLLM/handler.py
+++ b/src/brevitas/export/inference/vLLM/handler.py
@@ -70,9 +70,9 @@ class vLLMGroupwiseMetadataMixin:
         super()._load_from_state_dict(
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
         if prefix + 'group_dim_t' in state_dict:
-            self._group_dim = int(self.group_dim_t.item())
+            self.group_dim = int(self.group_dim_t.item())
         if prefix + 'group_size_t' in state_dict:
-            self._group_size = int(self.group_size_t.item())
+            self.group_size = int(self.group_size_t.item())
 
 
 class vLLMGroupwiseIntInferenceHandler(vLLMGroupwiseMetadataMixin,

--- a/src/brevitas/export/inference/vLLM/layer.py
+++ b/src/brevitas/export/inference/vLLM/layer.py
@@ -22,11 +22,15 @@ from ..handler import IntInferenceHandler
 from ..handler import IntWeightInferencetHandler
 from .handler import vLLMDynamicPerRowFloatInferenceHandler
 from .handler import vLLMGroupwiseFloatInferenceHandler
+from .handler import vLLMGroupwiseFloatWeightInferenceHandler
 from .handler import vLLMGroupwiseIntInferenceHandler
+from .handler import vLLMGroupwiseIntWeightInferenceHandler
 
 class_mapping = {
     'vLLMGroupwiseFloatInferenceHandler': vLLMGroupwiseFloatInferenceHandler,
     'vLLMGroupwiseIntInferenceHandler': vLLMGroupwiseIntInferenceHandler,
+    'vLLMGroupwiseIntWeightInferenceHandler': vLLMGroupwiseIntWeightInferenceHandler,
+    'vLLMGroupwiseFloatWeightInferenceHandler': vLLMGroupwiseFloatWeightInferenceHandler,
     'GroupwiseIntWeightInferenceHandler': GroupwiseIntWeightInferenceHandler,
     'GroupwiseFloatWeightInferenceHandler': GroupwiseFloatWeightInferenceHandler,
     'FloatInferencetHandler': FloatInferencetHandler,

--- a/src/brevitas/export/inference/vLLM/manager.py
+++ b/src/brevitas/export/inference/vLLM/manager.py
@@ -38,13 +38,13 @@ from brevitas.proxy.quant_proxy import QuantProxyFromInjector
 
 from ..handler import FloatInferencetHandler
 from ..handler import FloatWeightInferencetHandler
-from ..handler import GroupwiseFloatWeightInferenceHandler
-from ..handler import GroupwiseIntWeightInferenceHandler
 from ..handler import IntInferenceHandler
 from ..handler import IntWeightInferencetHandler
 from .handler import vLLMDynamicPerRowFloatInferenceHandler
 from .handler import vLLMGroupwiseFloatInferenceHandler
+from .handler import vLLMGroupwiseFloatWeightInferenceHandler
 from .handler import vLLMGroupwiseIntInferenceHandler
+from .handler import vLLMGroupwiseIntWeightInferenceHandler
 
 
 @register_quantization_config("quant_brevitas")
@@ -152,9 +152,9 @@ class vLLMExportManager(BaseManager):
         IntWeightInferencetHandler,
         FloatWeightInferencetHandler,
         vLLMGroupwiseIntInferenceHandler,
-        GroupwiseIntWeightInferenceHandler,
+        vLLMGroupwiseIntWeightInferenceHandler,
         vLLMGroupwiseFloatInferenceHandler,
-        GroupwiseFloatWeightInferenceHandler]
+        vLLMGroupwiseFloatWeightInferenceHandler]
 
     @classmethod
     def set_export_mode(cls, model: Module, enabled: bool):

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -11,6 +11,7 @@ from typing import Tuple
 from typing import Union
 from warnings import warn
 
+from packaging import version
 import torch
 from torch import Tensor
 import torch.nn as nn
@@ -19,6 +20,7 @@ from typing_extensions import runtime_checkable
 
 from brevitas import config
 from brevitas import is_dynamo_compiling
+from brevitas import torch_version
 from brevitas.core.function_wrapper.misc import Identity
 from brevitas.function import max_int
 from brevitas.inject import BaseInjector as Injector
@@ -105,8 +107,8 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
             self.export_handler.inner_forward = torch.compile(
                 self.export_handler.inner_forward, dynamic=True, fullgraph=True)
         elif self.tensor_quant is not None:
-            # For groupwise weight quantization, we have graph breaks
-            fullgraph = not self.is_groupwise
+            # PyTorch < 2.4 cannot trace groupwise dequantization without graph breaks.
+            fullgraph = not self.is_groupwise or torch_version >= version.parse('2.4')
             self.tensor_quant = torch.compile(self.tensor_quant, dynamic=True, fullgraph=fullgraph)
 
     @property

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -105,11 +105,11 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
     def compile_quant(self, compile_export=False):
         if compile_export and hasattr(self, 'export_handler') and self.export_handler is not None:
             self.export_handler.inner_forward = torch.compile(
-                self.export_handler.inner_forward, dynamic=True, fullgraph=True)
+                self.export_handler.inner_forward, fullgraph=True)
         elif self.tensor_quant is not None:
             # PyTorch < 2.4 cannot trace groupwise dequantization without graph breaks.
             fullgraph = not self.is_groupwise or torch_version >= version.parse('2.4')
-            self.tensor_quant = torch.compile(self.tensor_quant, dynamic=True, fullgraph=fullgraph)
+            self.tensor_quant = torch.compile(self.tensor_quant, fullgraph=fullgraph)
 
     @property
     def is_proxy_compiled(self):

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -11,7 +11,6 @@ from typing import Tuple
 from typing import Union
 from warnings import warn
 
-from packaging import version
 import torch
 from torch import Tensor
 import torch.nn as nn
@@ -20,7 +19,6 @@ from typing_extensions import runtime_checkable
 
 from brevitas import config
 from brevitas import is_dynamo_compiling
-from brevitas import torch_version
 from brevitas.core.function_wrapper.misc import Identity
 from brevitas.function import max_int
 from brevitas.inject import BaseInjector as Injector
@@ -107,9 +105,7 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
             self.export_handler.inner_forward = torch.compile(
                 self.export_handler.inner_forward, fullgraph=True)
         elif self.tensor_quant is not None:
-            # PyTorch < 2.4 cannot trace groupwise dequantization without graph breaks.
-            fullgraph = not self.is_groupwise or torch_version >= version.parse('2.4')
-            self.tensor_quant = torch.compile(self.tensor_quant, fullgraph=fullgraph)
+            self.tensor_quant = torch.compile(self.tensor_quant, fullgraph=True)
 
     @property
     def is_proxy_compiled(self):

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -8,6 +8,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from packaging import version
 import torch
 from torch import nn
 from torch import Tensor
@@ -17,6 +18,7 @@ from typing_extensions import runtime_checkable
 
 import brevitas
 from brevitas import is_dynamo_compiling
+from brevitas import torch_version
 from brevitas.quant_tensor import IntQuantTensor
 from brevitas.quant_tensor import QuantTensor
 from brevitas.utils.quant_utils import _CachedIO
@@ -104,7 +106,8 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         self.skip_create_quant_tensor = False
 
     def compile_quant(self, compile_export=False):
-        fullgraph = not self.is_groupwise
+        # PyTorch < 2.4 cannot trace groupwise dequantization without graph breaks.
+        fullgraph = not self.is_groupwise or torch_version >= version.parse('2.4')
         if compile_export and hasattr(self, 'export_handler') and self.export_handler is not None:
             self.export_handler = torch.compile(
                 self.export_handler, dynamic=True, fullgraph=fullgraph)

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -107,17 +107,11 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
 
     def compile_quant(self, compile_export=False):
         fullgraph = not self.is_groupwise or torch_version >= version.parse('2.4')
-        # Groupwise padding indexes a Python list using the configured group dimension.
-        # Keep groupwise shapes static so Dynamo can specialize that index in a full graph.
-        dynamic = not self.is_groupwise
         if compile_export and hasattr(self, 'export_handler') and self.export_handler is not None:
-            self.export_handler = torch.compile(
-                self.export_handler, dynamic=dynamic, fullgraph=fullgraph)
+            self.export_handler = torch.compile(self.export_handler, fullgraph=fullgraph)
         elif self.fused_activation_quant_proxy is not None:
             self.fused_activation_quant_proxy.tensor_quant = torch.compile(
-                self.fused_activation_quant_proxy.tensor_quant,
-                dynamic=dynamic,
-                fullgraph=fullgraph)
+                self.fused_activation_quant_proxy.tensor_quant, fullgraph=fullgraph)
 
     @property
     def is_proxy_compiled(self):

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -8,6 +8,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from packaging import version
 import torch
 from torch import nn
 from torch import Tensor
@@ -17,6 +18,7 @@ from typing_extensions import runtime_checkable
 
 import brevitas
 from brevitas import is_dynamo_compiling
+from brevitas import torch_version
 from brevitas.quant_tensor import IntQuantTensor
 from brevitas.quant_tensor import QuantTensor
 from brevitas.utils.quant_utils import _CachedIO
@@ -104,14 +106,18 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         self.skip_create_quant_tensor = False
 
     def compile_quant(self, compile_export=False):
-        # Runtime groupwise scaling has data-dependent branches that require graph breaks.
-        fullgraph = not self.is_groupwise
+        fullgraph = not self.is_groupwise or torch_version >= version.parse('2.4')
+        # Groupwise padding indexes a Python list using the configured group dimension.
+        # Keep groupwise shapes static so Dynamo can specialize that index in a full graph.
+        dynamic = not self.is_groupwise
         if compile_export and hasattr(self, 'export_handler') and self.export_handler is not None:
             self.export_handler = torch.compile(
-                self.export_handler, dynamic=True, fullgraph=fullgraph)
+                self.export_handler, dynamic=dynamic, fullgraph=fullgraph)
         elif self.fused_activation_quant_proxy is not None:
             self.fused_activation_quant_proxy.tensor_quant = torch.compile(
-                self.fused_activation_quant_proxy.tensor_quant, dynamic=True, fullgraph=fullgraph)
+                self.fused_activation_quant_proxy.tensor_quant,
+                dynamic=dynamic,
+                fullgraph=fullgraph)
 
     @property
     def is_proxy_compiled(self):

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -8,7 +8,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from packaging import version
 import torch
 from torch import nn
 from torch import Tensor
@@ -18,7 +17,6 @@ from typing_extensions import runtime_checkable
 
 import brevitas
 from brevitas import is_dynamo_compiling
-from brevitas import torch_version
 from brevitas.quant_tensor import IntQuantTensor
 from brevitas.quant_tensor import QuantTensor
 from brevitas.utils.quant_utils import _CachedIO
@@ -106,8 +104,8 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         self.skip_create_quant_tensor = False
 
     def compile_quant(self, compile_export=False):
-        # PyTorch < 2.4 cannot trace groupwise dequantization without graph breaks.
-        fullgraph = not self.is_groupwise or torch_version >= version.parse('2.4')
+        # Runtime groupwise scaling has data-dependent branches that require graph breaks.
+        fullgraph = not self.is_groupwise
         if compile_export and hasattr(self, 'export_handler') and self.export_handler is not None:
             self.export_handler = torch.compile(
                 self.export_handler, dynamic=True, fullgraph=fullgraph)

--- a/src/brevitas/proxy/runtime_quant.py
+++ b/src/brevitas/proxy/runtime_quant.py
@@ -8,7 +8,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from packaging import version
 import torch
 from torch import nn
 from torch import Tensor
@@ -18,7 +17,6 @@ from typing_extensions import runtime_checkable
 
 import brevitas
 from brevitas import is_dynamo_compiling
-from brevitas import torch_version
 from brevitas.quant_tensor import IntQuantTensor
 from brevitas.quant_tensor import QuantTensor
 from brevitas.utils.quant_utils import _CachedIO
@@ -106,12 +104,11 @@ class ActQuantProxyFromInjectorBase(QuantProxyFromInjector, ActQuantProxyProtoco
         self.skip_create_quant_tensor = False
 
     def compile_quant(self, compile_export=False):
-        fullgraph = not self.is_groupwise or torch_version >= version.parse('2.4')
         if compile_export and hasattr(self, 'export_handler') and self.export_handler is not None:
-            self.export_handler = torch.compile(self.export_handler, fullgraph=fullgraph)
+            self.export_handler = torch.compile(self.export_handler, fullgraph=True)
         elif self.fused_activation_quant_proxy is not None:
             self.fused_activation_quant_proxy.tensor_quant = torch.compile(
-                self.fused_activation_quant_proxy.tensor_quant, fullgraph=fullgraph)
+                self.fused_activation_quant_proxy.tensor_quant, fullgraph=True)
 
     @property
     def is_proxy_compiled(self):

--- a/src/brevitas/utils/quant_utils.py
+++ b/src/brevitas/utils/quant_utils.py
@@ -3,7 +3,6 @@
 
 import torch
 
-import brevitas.compiler as brevitas_compiler
 from brevitas.core.bit_width import BitWidthParameter
 from brevitas.core.function_wrapper import *
 from brevitas.core.quant import RescalingIntQuant
@@ -219,8 +218,6 @@ def float_to_int_impl_to_enum(module):
         return None
 
 
-# For old versions of pytorch (2.3.1), this is needed otherwise compile skips this function
-@brevitas_compiler.disable_on_old_torch
 def groupwise_dequant_expand(
         value_, scale_, zero_point_, group_dim, dequant_shape, expand_metadata=True):
     curr_shape = value_.shape

--- a/src/brevitas/utils/quant_utils.py
+++ b/src/brevitas/utils/quant_utils.py
@@ -219,23 +219,16 @@ def float_to_int_impl_to_enum(module):
         return None
 
 
-@brevitas_compiler.disable
+# For old versions of pytorch (2.3.1), this is needed otherwise compile skips this function
+@brevitas_compiler.disable_on_old_torch
 def groupwise_dequant_expand(
         value_, scale_, zero_point_, group_dim, dequant_shape, expand_metadata=True):
     curr_shape = value_.shape
     start_dim = group_dim if group_dim >= 0 else group_dim - 1
     new_value = value_.flatten(start_dim, start_dim + 1)
 
-    # If we padded during quantization, we unpad here:
-    # First, we compute how much we padded along the group_dim shape
-    # Then, we unbind the tensor along the group_dim shape, and drop the padded columns
-    # Finally, we stack the remaining tensors
     unpadding_shape = dequant_shape[group_dim]
-    residual = new_value.shape[group_dim] - unpadding_shape
-
-    if residual > 0:
-        new_value = torch.stack(
-            torch.unbind(new_value, dim=group_dim)[:unpadding_shape], dim=group_dim)
+    new_value = torch.narrow(new_value, group_dim, 0, unpadding_shape)
 
     if not expand_metadata:
         return new_value, scale_, zero_point_
@@ -249,11 +242,9 @@ def groupwise_dequant_expand(
     else:
         new_zp = zero_point_
 
-    if residual > 0:
-        new_scale = torch.stack(
-            torch.unbind(new_scale, dim=group_dim)[:unpadding_shape], dim=group_dim)
-        if zero_point_.shape != ():
-            new_zp = torch.stack(
-                torch.unbind(new_zp, dim=group_dim)[:unpadding_shape], dim=group_dim)
+    if scale_.shape != ():
+        new_scale = torch.narrow(new_scale, group_dim, 0, unpadding_shape)
+    if zero_point_.shape != ():
+        new_zp = torch.narrow(new_zp, group_dim, 0, unpadding_shape)
 
     return new_value, new_scale, new_zp

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -151,12 +151,20 @@ def padding_to_multiple(x: torch.Tensor, dim_to_expand: int, dim_multiple: int) 
     # Given a tensor X, compute the padding along dim_multiple so that new dimension is a multiple of dim_multiple
     dim_to_expand = dim_to_expand % x.dim()
     padding_size = (-x.shape[dim_to_expand]) % dim_multiple
+    # Eager execution can allocate exactly padding_size elements. That path cannot be
+    # traced by PyTorch 2.4 when shapes are symbolic: new_zeros internally branches on
+    # whether the modulo-derived dimension is zero. During Dynamo tracing, allocate a
+    # fixed positive block and narrow it instead; this avoids the symbolic boolean guard.
+    compiling = brevitas.is_dynamo_compiling()
+    padding_dim = dim_multiple if compiling else padding_size
     padding_shape = [
-        dim_multiple if dim == dim_to_expand else size for dim, size in enumerate(x.shape)]
+        padding_dim if dim == dim_to_expand else size for dim, size in enumerate(x.shape)]
     padding = x.new_zeros(padding_shape)
     padded = torch.cat((x, padding), dim=dim_to_expand)
-    output_size = x.shape[dim_to_expand] + padding_size
-    return torch.narrow(padded, dim_to_expand, 0, output_size)
+    if compiling:
+        output_size = x.shape[dim_to_expand] + padding_size
+        padded = torch.narrow(padded, dim_to_expand, 0, output_size)
+    return padded
 
 
 def pad_to_dim(tensor: torch.Tensor, dim_to_expand: int, new_dim: int) -> torch.Tensor:

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -148,13 +148,12 @@ def float_internal_scale(
 
 
 @brevitas.jit.ignore
-@brevitas_compiler.disable
+@brevitas_compiler.disable_on_old_torch
 def padding_to_multiple(x: torch.Tensor, dim_to_expand: int, dim_multiple: int) -> torch.Tensor:
     # Given a tensor X, compute the padding along dim_multiple so that new dimension is a multiple of dim_multiple
     padding = [0, 0] * len(x.shape)
     size = x.shape
-    if size[dim_to_expand] % dim_multiple != 0:
-        padding[2 * dim_to_expand] = dim_multiple - size[dim_to_expand] % dim_multiple
+    padding[2 * dim_to_expand] = (-size[dim_to_expand]) % dim_multiple
     padding = list(reversed(padding))
     x = torch.nn.functional.pad(x, padding, mode='constant', value=0.)
     return x

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -152,9 +152,11 @@ def padding_to_multiple(x: torch.Tensor, dim_to_expand: int, dim_multiple: int) 
     dim_to_expand = dim_to_expand % x.dim()
     padding_size = (-x.shape[dim_to_expand]) % dim_multiple
     padding_shape = [
-        padding_size if dim == dim_to_expand else size for dim, size in enumerate(x.shape)]
+        dim_multiple if dim == dim_to_expand else size for dim, size in enumerate(x.shape)]
     padding = x.new_zeros(padding_shape)
-    return torch.cat((x, padding), dim=dim_to_expand)
+    padded = torch.cat((x, padding), dim=dim_to_expand)
+    output_size = x.shape[dim_to_expand] + padding_size
+    return torch.narrow(padded, dim_to_expand, 0, output_size)
 
 
 def pad_to_dim(tensor: torch.Tensor, dim_to_expand: int, new_dim: int) -> torch.Tensor:

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -149,12 +149,12 @@ def float_internal_scale(
 @brevitas.jit.ignore
 def padding_to_multiple(x: torch.Tensor, dim_to_expand: int, dim_multiple: int) -> torch.Tensor:
     # Given a tensor X, compute the padding along dim_multiple so that new dimension is a multiple of dim_multiple
-    padding = [0, 0] * len(x.shape)
-    size = x.shape
-    padding[2 * dim_to_expand] = (-size[dim_to_expand]) % dim_multiple
-    padding = list(reversed(padding))
-    x = torch.nn.functional.pad(x, padding, mode='constant', value=0.)
-    return x
+    dim_to_expand = dim_to_expand % x.dim()
+    padding_size = (-x.shape[dim_to_expand]) % dim_multiple
+    padding_shape = [
+        padding_size if dim == dim_to_expand else size for dim, size in enumerate(x.shape)]
+    padding = x.new_zeros(padding_shape)
+    return torch.cat((x, padding), dim=dim_to_expand)
 
 
 def pad_to_dim(tensor: torch.Tensor, dim_to_expand: int, new_dim: int) -> torch.Tensor:

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -13,7 +13,6 @@ from torch.nn import Sequential
 
 import brevitas
 from brevitas import torch_version
-import brevitas.compiler as brevitas_compiler
 from brevitas.function.ops_ste import floor_ste
 
 # Named tensors (Tensor.rename/rename_/names) were removed in PyTorch 2.13
@@ -148,7 +147,6 @@ def float_internal_scale(
 
 
 @brevitas.jit.ignore
-@brevitas_compiler.disable_on_old_torch
 def padding_to_multiple(x: torch.Tensor, dim_to_expand: int, dim_multiple: int) -> torch.Tensor:
     # Given a tensor X, compute the padding along dim_multiple so that new dimension is a multiple of dim_multiple
     padding = [0, 0] * len(x.shape)

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -151,20 +151,14 @@ def padding_to_multiple(x: torch.Tensor, dim_to_expand: int, dim_multiple: int) 
     # Given a tensor X, compute the padding along dim_multiple so that new dimension is a multiple of dim_multiple
     dim_to_expand = dim_to_expand % x.dim()
     padding_size = (-x.shape[dim_to_expand]) % dim_multiple
-    # Eager execution can allocate exactly padding_size elements. That path cannot be
-    # traced by PyTorch 2.4 when shapes are symbolic: new_zeros internally branches on
-    # whether the modulo-derived dimension is zero. During Dynamo tracing, allocate a
-    # fixed positive block and narrow it instead; this avoids the symbolic boolean guard.
-    compiling = brevitas.is_dynamo_compiling()
-    padding_dim = dim_multiple if compiling else padding_size
+    # Exact-size allocation cannot be traced when the symbolic modulo-derived padding
+    # dimension may be zero. Over-pad by a fixed positive block, then narrow to size.
     padding_shape = [
-        padding_dim if dim == dim_to_expand else size for dim, size in enumerate(x.shape)]
+        dim_multiple if dim == dim_to_expand else size for dim, size in enumerate(x.shape)]
     padding = x.new_zeros(padding_shape)
     padded = torch.cat((x, padding), dim=dim_to_expand)
-    if compiling:
-        output_size = x.shape[dim_to_expand] + padding_size
-        padded = torch.narrow(padded, dim_to_expand, 0, output_size)
-    return padded
+    output_size = x.shape[dim_to_expand] + padding_size
+    return torch.narrow(padded, dim_to_expand, 0, output_size)
 
 
 def pad_to_dim(tensor: torch.Tensor, dim_to_expand: int, new_dim: int) -> torch.Tensor:

--- a/src/brevitas/utils/torch_utils.py
+++ b/src/brevitas/utils/torch_utils.py
@@ -151,6 +151,11 @@ def padding_to_multiple(x: torch.Tensor, dim_to_expand: int, dim_multiple: int) 
     # Given a tensor X, compute the padding along dim_multiple so that new dimension is a multiple of dim_multiple
     dim_to_expand = dim_to_expand % x.dim()
     padding_size = (-x.shape[dim_to_expand]) % dim_multiple
+    # Eager fast path: when already a multiple, return as-is with no allocation. The
+    # `and` short-circuits under Dynamo, so the symbolic `padding_size == 0` comparison
+    # is never evaluated during tracing and cannot force a symbolic-to-bool conversion.
+    if not brevitas.is_dynamo_compiling() and padding_size == 0:
+        return x
     # Exact-size allocation cannot be traced when the symbolic modulo-derived padding
     # dimension may be zero. Over-pad by a fixed positive block, then narrow to size.
     padding_shape = [

--- a/tests/brevitas/export/test_inference_mode.py
+++ b/tests/brevitas/export/test_inference_mode.py
@@ -48,6 +48,22 @@ ACT_QUANTIZERS = {
     'mxfloat8': MXFloat8e4m3Act}
 
 
+@pytest.mark.parametrize('act_quantizer', [MXInt8Act, MXFloat8e4m3Act])
+def test_groupwise_inference_handler_group_metadata_is_static(act_quantizer):
+    identity = qnn.QuantIdentity(act_quantizer, group_dim=1)
+    inp = torch.randn(2, 16)
+    identity(inp)
+    identity.eval()
+
+    with quant_inference_mode(identity, compile=False):
+        identity(inp)
+        handler = identity.act_quant.export_handler
+        assert isinstance(handler.group_dim, int)
+        assert isinstance(handler.group_size, int)
+        assert handler.group_dim == 1
+        assert handler.group_size == 32
+
+
 @pytest_cases.parametrize('weight_quantizer', WEIGHT_QUANTIZERS.items())
 @given(weight=float_tensor_st(shape=(8, 16), max_val=1e10, min_val=-1e10))
 @requires_pt_ge('2.1')

--- a/tests/brevitas/export/test_vllm_inference_mode.py
+++ b/tests/brevitas/export/test_vllm_inference_mode.py
@@ -12,14 +12,14 @@ from brevitas.core.stats import StatsOp
 from brevitas.export.inference import quant_inference_mode
 from brevitas.export.inference.handler import FloatInferencetHandler
 from brevitas.export.inference.handler import FloatWeightInferencetHandler
-from brevitas.export.inference.handler import GroupwiseFloatWeightInferenceHandler
-from brevitas.export.inference.handler import GroupwiseIntWeightInferenceHandler
 from brevitas.export.inference.handler import IntInferenceHandler
 from brevitas.export.inference.handler import IntWeightInferencetHandler
 from brevitas.export.inference.manager import InferenceManager
 from brevitas.export.inference.vLLM.handler import vLLMDynamicPerRowFloatInferenceHandler
 from brevitas.export.inference.vLLM.handler import vLLMGroupwiseFloatInferenceHandler
+from brevitas.export.inference.vLLM.handler import vLLMGroupwiseFloatWeightInferenceHandler
 from brevitas.export.inference.vLLM.handler import vLLMGroupwiseIntInferenceHandler
+from brevitas.export.inference.vLLM.handler import vLLMGroupwiseIntWeightInferenceHandler
 import brevitas.nn as qnn
 from brevitas.proxy.float_runtime_quant import DynamicActFloatQuantProxyFromInjector
 from brevitas.quant import Int8ActPerTensorFloat
@@ -61,9 +61,9 @@ class vLLMTestManager(InferenceManager):
         IntWeightInferencetHandler,
         FloatWeightInferencetHandler,
         vLLMGroupwiseIntInferenceHandler,
-        GroupwiseIntWeightInferenceHandler,
+        vLLMGroupwiseIntWeightInferenceHandler,
         vLLMGroupwiseFloatInferenceHandler,
-        GroupwiseFloatWeightInferenceHandler,]
+        vLLMGroupwiseFloatWeightInferenceHandler,]
 
 
 WEIGHT_QUANTIZERS = {
@@ -80,6 +80,36 @@ ACT_QUANTIZERS = {
     'per_row_dynamic_fp8': FP8e4m3OCPDynamicActPerRowFloat,
     'mxint8': MXInt8Act,
     'mxfloat8': MXFloat8e4m3Act,}
+
+
+@pytest.mark.parametrize('act_quantizer', [MXInt8Act, MXFloat8e4m3Act])
+def test_vllm_groupwise_act_handler_exports_group_metadata(act_quantizer):
+    identity = qnn.QuantIdentity(act_quantizer, group_dim=1)
+    inp = torch.randn(2, 16)
+    identity(inp)
+    identity.eval()
+
+    with quant_inference_mode(identity, compile=False, export_manager=vLLMTestManager):
+        identity(inp)
+        state_dict = identity.act_quant.export_handler.state_dict()
+
+    assert torch.equal(state_dict['group_dim_t'], torch.tensor(1, dtype=torch.int))
+    assert torch.equal(state_dict['group_size_t'], torch.tensor(32, dtype=torch.int))
+
+
+@pytest.mark.parametrize('weight_quantizer', [MXInt8Weight, MXFloat8e4m3Weight])
+def test_vllm_groupwise_weight_handler_exports_group_metadata(weight_quantizer):
+    linear = qnn.QuantLinear(16, 8, weight_quant=weight_quantizer, group_dim=1)
+    inp = torch.randn(2, 16)
+    linear(inp)
+    linear.eval()
+
+    with quant_inference_mode(linear, compile=False, export_manager=vLLMTestManager):
+        linear(inp)
+        state_dict = linear.weight_quant.export_handler.state_dict()
+
+    assert torch.equal(state_dict['group_dim_t'], torch.tensor(1, dtype=torch.int))
+    assert torch.equal(state_dict['group_size_t'], torch.tensor(32, dtype=torch.int))
 
 
 @pytest_cases.parametrize('weight_quantizer', WEIGHT_QUANTIZERS.items())

--- a/tests/brevitas/export/test_vllm_inference_mode.py
+++ b/tests/brevitas/export/test_vllm_inference_mode.py
@@ -91,8 +91,10 @@ def test_vllm_groupwise_act_handler_exports_group_metadata(act_quantizer):
 
     with quant_inference_mode(identity, compile=False, export_manager=vLLMTestManager):
         identity(inp)
-        state_dict = identity.act_quant.export_handler.state_dict()
+        handler = identity.act_quant.export_handler
+        state_dict = handler.state_dict()
 
+    assert {'group_dim_t', 'group_size_t'} <= dict(handler.named_buffers()).keys()
     assert torch.equal(state_dict['group_dim_t'], torch.tensor(1, dtype=torch.int))
     assert torch.equal(state_dict['group_size_t'], torch.tensor(32, dtype=torch.int))
 
@@ -106,8 +108,10 @@ def test_vllm_groupwise_weight_handler_exports_group_metadata(weight_quantizer):
 
     with quant_inference_mode(linear, compile=False, export_manager=vLLMTestManager):
         linear(inp)
-        state_dict = linear.weight_quant.export_handler.state_dict()
+        handler = linear.weight_quant.export_handler
+        state_dict = handler.state_dict()
 
+    assert {'group_dim_t', 'group_size_t'} <= dict(handler.named_buffers()).keys()
     assert torch.equal(state_dict['group_dim_t'], torch.tensor(1, dtype=torch.int))
     assert torch.equal(state_dict['group_size_t'], torch.tensor(32, dtype=torch.int))
 

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -119,16 +119,33 @@ def test_compile_act(inp, act_quantizer):
 @requires_torch_compile()
 @jit_disabled_for_compile()
 @torch.no_grad()
-@pytest.mark.parametrize('act_quantizer', [MXInt8Act, MXFloat8e4m3Act])
-def test_compile_mx_quantizers_non_divisible_group(act_quantizer):
+@pytest.mark.parametrize('weight_quantizer', [MXInt8Weight, MXFloat8e4m3Weight])
+def test_compile_mx_weight_non_divisible_group(weight_quantizer):
     inp = torch.randn(2, 33)
-    linear = qnn.QuantLinear(
-        33, 16, weight_quant=MXFloat8e4m3Weight, input_quant=act_quantizer, group_dim=1)
+    linear = qnn.QuantLinear(33, 16, weight_quant=weight_quantizer, group_dim=1)
     linear.eval()
 
     expected = linear(inp)
     with quant_inference_mode(linear, compile=True):
         linear(inp)
         actual = linear(inp)
+
+    assert torch.allclose(expected, actual)
+
+
+@requires_pt_ge('2.4')
+@requires_torch_compile()
+@jit_disabled_for_compile()
+@torch.no_grad()
+@pytest.mark.parametrize('act_quantizer', [MXInt8Act, MXFloat8e4m3Act])
+def test_compile_mx_act_non_divisible_group(act_quantizer):
+    inp = torch.randn(2, 33)
+    identity = qnn.QuantIdentity(act_quantizer, group_dim=1)
+    identity.eval()
+
+    expected = identity(inp)
+    with quant_inference_mode(identity, compile=True):
+        identity(inp)
+        actual = identity(inp)
 
     assert torch.allclose(expected, actual)

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -115,7 +115,6 @@ def test_compile_act(inp, act_quantizer):
     assert torch.allclose(out, inference_out)
 
 
-@requires_pt_ge('2.4')
 @requires_torch_compile()
 @jit_disabled_for_compile()
 @torch.no_grad()
@@ -133,7 +132,6 @@ def test_compile_mx_weight_non_divisible_group(weight_quantizer):
     assert torch.allclose(expected, actual)
 
 
-@requires_pt_ge('2.4')
 @requires_torch_compile()
 @jit_disabled_for_compile()
 @torch.no_grad()

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -138,12 +138,12 @@ def test_compile_groupwise_quant_uses_fullgraph(monkeypatch):
 @requires_torch_compile()
 @jit_disabled_for_compile()
 @torch.no_grad()
-def test_fullgraph_compile_mx_weight_non_divisible_group():
-    inp = torch.randn(2, 33)
+def test_compile_mx_weight_non_divisible_group():
     linear = qnn.QuantLinear(33, 16, weight_quant=MXFloat8e4m3Weight)
     linear.eval()
 
-    expected = linear(inp)
-    actual = torch.compile(linear, fullgraph=True)(inp)
+    expected = linear.quant_weight().value
+    linear.weight_quant.compile_quant()
+    actual = linear.quant_weight().value
 
     assert torch.allclose(expected, actual)

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -116,36 +116,11 @@ def test_compile_act(inp, act_quantizer):
 
 
 @requires_pt_ge('2.4')
-@jit_disabled_for_compile()
-def test_compile_groupwise_quant_uses_supported_fullgraph(monkeypatch):
-    compile_args = []
-
-    def compile(module, **kwargs):
-        compile_args.append((kwargs['fullgraph'], kwargs['dynamic']))
-        return module
-
-    monkeypatch.setattr(torch, 'compile', compile)
-    weight_quant = qnn.QuantLinear(32, 16, weight_quant=MXFloat8e4m3Weight).weight_quant
-    act_quant = qnn.QuantIdentity(MXFloat8e4m3Act, group_dim=1).act_quant
-
-    weight_quant.compile_quant()
-    act_quant.compile_quant()
-
-    assert compile_args == [(True, True), (True, False)]
-
-
-@requires_pt_ge('2.4')
 @requires_torch_compile()
 @jit_disabled_for_compile()
 @torch.no_grad()
 @pytest.mark.parametrize('act_quantizer', [MXInt8Act, MXFloat8e4m3Act])
-def test_compile_mx_quantizers_non_divisible_group(act_quantizer, monkeypatch):
-    torch_compile = torch.compile
-
-    def compile_eager(module, **kwargs):
-        return torch_compile(module, backend='eager', **kwargs)
-
-    monkeypatch.setattr(torch, 'compile', compile_eager)
+def test_compile_mx_quantizers_non_divisible_group(act_quantizer):
     inp = torch.randn(2, 33)
     linear = qnn.QuantLinear(
         33, 16, weight_quant=MXFloat8e4m3Weight, input_quant=act_quantizer, group_dim=1)

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -113,3 +113,18 @@ def test_compile_act(inp, act_quantizer):
         inference_out = identity(inp)
     assert torch.allclose(out, quant_out)
     assert torch.allclose(out, inference_out)
+
+
+@requires_pt_ge('2.4')
+@requires_torch_compile()
+@jit_disabled_for_compile()
+@torch.no_grad()
+def test_fullgraph_compile_mx_weight_non_divisible_group():
+    inp = torch.randn(2, 33)
+    linear = qnn.QuantLinear(33, 16, weight_quant=MXFloat8e4m3Weight)
+    linear.eval()
+
+    expected = linear(inp)
+    actual = torch.compile(linear, fullgraph=True)(inp)
+
+    assert torch.allclose(expected, actual)

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -118,10 +118,10 @@ def test_compile_act(inp, act_quantizer):
 @requires_pt_ge('2.4')
 @jit_disabled_for_compile()
 def test_compile_groupwise_quant_uses_supported_fullgraph(monkeypatch):
-    fullgraph_args = []
+    compile_args = []
 
     def compile(module, **kwargs):
-        fullgraph_args.append(kwargs['fullgraph'])
+        compile_args.append((kwargs['fullgraph'], kwargs['dynamic']))
         return module
 
     monkeypatch.setattr(torch, 'compile', compile)
@@ -131,19 +131,29 @@ def test_compile_groupwise_quant_uses_supported_fullgraph(monkeypatch):
     weight_quant.compile_quant()
     act_quant.compile_quant()
 
-    assert fullgraph_args == [True, False]
+    assert compile_args == [(True, True), (True, False)]
 
 
 @requires_pt_ge('2.4')
 @requires_torch_compile()
 @jit_disabled_for_compile()
 @torch.no_grad()
-def test_compile_mx_weight_non_divisible_group():
-    linear = qnn.QuantLinear(33, 16, weight_quant=MXFloat8e4m3Weight)
+@pytest.mark.parametrize('act_quantizer', [MXInt8Act, MXFloat8e4m3Act])
+def test_compile_mx_quantizers_non_divisible_group(act_quantizer, monkeypatch):
+    torch_compile = torch.compile
+
+    def compile_eager(module, **kwargs):
+        return torch_compile(module, backend='eager', **kwargs)
+
+    monkeypatch.setattr(torch, 'compile', compile_eager)
+    inp = torch.randn(2, 33)
+    linear = qnn.QuantLinear(
+        33, 16, weight_quant=MXFloat8e4m3Weight, input_quant=act_quantizer, group_dim=1)
     linear.eval()
 
-    expected = linear.quant_weight().value
-    linear.weight_quant.compile_quant()
-    actual = linear.quant_weight().value
+    expected = linear(inp)
+    with quant_inference_mode(linear, compile=True):
+        linear(inp)
+        actual = linear(inp)
 
     assert torch.allclose(expected, actual)

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -117,7 +117,7 @@ def test_compile_act(inp, act_quantizer):
 
 @requires_pt_ge('2.4')
 @jit_disabled_for_compile()
-def test_compile_groupwise_quant_uses_fullgraph(monkeypatch):
+def test_compile_groupwise_quant_uses_supported_fullgraph(monkeypatch):
     fullgraph_args = []
 
     def compile(module, **kwargs):
@@ -131,7 +131,7 @@ def test_compile_groupwise_quant_uses_fullgraph(monkeypatch):
     weight_quant.compile_quant()
     act_quant.compile_quant()
 
-    assert fullgraph_args == [True, True]
+    assert fullgraph_args == [True, False]
 
 
 @requires_pt_ge('2.4')

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -120,6 +120,8 @@ def test_compile_act(inp, act_quantizer):
 @torch.no_grad()
 @pytest.mark.parametrize('weight_quantizer', [MXInt8Weight, MXFloat8e4m3Weight])
 def test_compile_mx_weight_non_divisible_group(weight_quantizer):
+    if platform.system() == "Windows":
+        pytest.skip("Skip compile + Windows because the CI runner has no C++ compiler")
     inp = torch.randn(2, 33)
     linear = qnn.QuantLinear(33, 16, weight_quant=weight_quantizer, group_dim=1)
     linear.eval()
@@ -137,6 +139,8 @@ def test_compile_mx_weight_non_divisible_group(weight_quantizer):
 @torch.no_grad()
 @pytest.mark.parametrize('act_quantizer', [MXInt8Act, MXFloat8e4m3Act])
 def test_compile_mx_act_non_divisible_group(act_quantizer):
+    if platform.system() == "Windows":
+        pytest.skip("Skip compile + Windows because the CI runner has no C++ compiler")
     inp = torch.randn(2, 33)
     identity = qnn.QuantIdentity(act_quantizer, group_dim=1)
     identity.eval()

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -116,6 +116,25 @@ def test_compile_act(inp, act_quantizer):
 
 
 @requires_pt_ge('2.4')
+@jit_disabled_for_compile()
+def test_compile_groupwise_quant_uses_fullgraph(monkeypatch):
+    fullgraph_args = []
+
+    def compile(module, **kwargs):
+        fullgraph_args.append(kwargs['fullgraph'])
+        return module
+
+    monkeypatch.setattr(torch, 'compile', compile)
+    weight_quant = qnn.QuantLinear(32, 16, weight_quant=MXFloat8e4m3Weight).weight_quant
+    act_quant = qnn.QuantIdentity(MXFloat8e4m3Act, group_dim=1).act_quant
+
+    weight_quant.compile_quant()
+    act_quant.compile_quant()
+
+    assert fullgraph_args == [True, True]
+
+
+@requires_pt_ge('2.4')
 @requires_torch_compile()
 @jit_disabled_for_compile()
 @torch.no_grad()

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -26,7 +26,6 @@ from brevitas.quant.mx_quant_ocp import MXInt8Weight
 from brevitas_examples.common.generative.quantize import Int8DynamicActPerTensorFloat
 from brevitas_examples.common.generative.quantizers import FP8e4m3OCPDynamicActPerRowFloat
 from tests.brevitas.hyp_helper import float_tensor_st
-from tests.marker import jit_disabled_for_compile
 from tests.marker import requires_pt_ge
 from tests.marker import requires_torch_compile
 
@@ -58,7 +57,6 @@ ACT_QUANTIZERS = {
 @given(weight=float_tensor_st(shape=(8, 16), max_val=1e10, min_val=-1e10))
 @requires_pt_ge('2.3.1')
 @requires_torch_compile()
-@jit_disabled_for_compile()
 def test_compile_weight(weight, weight_quantizer):
     name, quant = weight_quantizer
     if version.parse('2.8') <= torch_version < version.parse('2.9'):
@@ -88,7 +86,6 @@ def test_compile_weight(weight, weight_quantizer):
 @given(inp=float_tensor_st(shape=(8, 16), max_val=1e10, min_val=-1e10))
 @requires_pt_ge('2.3.1')
 @requires_torch_compile()
-@jit_disabled_for_compile()
 def test_compile_act(inp, act_quantizer):
     name, quant = act_quantizer
     if version.parse('2.8') <= torch_version < version.parse('2.9'):
@@ -116,7 +113,6 @@ def test_compile_act(inp, act_quantizer):
 
 
 @requires_torch_compile()
-@jit_disabled_for_compile()
 @torch.no_grad()
 @pytest.mark.parametrize('weight_quantizer', [MXInt8Weight, MXFloat8e4m3Weight])
 def test_compile_mx_weight_non_divisible_group(weight_quantizer):
@@ -135,7 +131,6 @@ def test_compile_mx_weight_non_divisible_group(weight_quantizer):
 
 
 @requires_torch_compile()
-@jit_disabled_for_compile()
 @torch.no_grad()
 @pytest.mark.parametrize('act_quantizer', [MXInt8Act, MXFloat8e4m3Act])
 def test_compile_mx_act_non_divisible_group(act_quantizer):

--- a/tests/brevitas/utils/test_compile.py
+++ b/tests/brevitas/utils/test_compile.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import math
+
+import pytest
+import torch
+
+from brevitas.utils.quant_utils import groupwise_dequant_expand
+from brevitas.utils.torch_utils import padding_to_multiple
+from tests.marker import jit_disabled_for_compile
+from tests.marker import requires_pt_ge
+from tests.marker import requires_torch_compile
+
+
+@pytest.mark.parametrize(
+    'shape, dim, multiple, expected_shape',
+    [((2, 5), 1, 4, (2, 8)), ((2, 8), 1, 4, (2, 8)), ((2, 3, 5), -1, 4, (2, 3, 8)),
+     ((5, 3), 0, 4, (8, 3))])
+@requires_pt_ge('2.2')
+@requires_torch_compile()
+@jit_disabled_for_compile()
+def test_compile_padding_to_multiple(shape, dim, multiple, expected_shape):
+    x = torch.arange(math.prod(shape), dtype=torch.float32).reshape(shape)
+    compiled_fn = torch.compile(padding_to_multiple, backend='eager', fullgraph=True)
+
+    actual = compiled_fn(x, dim, multiple)
+    expected = padding_to_multiple(x, dim, multiple)
+
+    assert actual.shape == expected_shape
+    assert torch.equal(actual, expected)
+    assert torch.equal(torch.narrow(actual, dim, 0, shape[dim]), x)
+
+    padding = expected_shape[dim] - shape[dim]
+    if padding:
+        padded_values = torch.narrow(actual, dim, shape[dim], padding)
+        assert torch.count_nonzero(padded_values) == 0
+
+
+@pytest.mark.parametrize('group_dim', [1, -1])
+@pytest.mark.parametrize('scalar_metadata', [False, True])
+@pytest.mark.parametrize('expand_metadata', [False, True])
+@requires_pt_ge('2.2')
+@requires_torch_compile()
+@jit_disabled_for_compile()
+def test_compile_groupwise_dequant_expand(group_dim, scalar_metadata, expand_metadata):
+    value = torch.arange(16, dtype=torch.float32).reshape(2, 2, 4)
+    if scalar_metadata:
+        scale = torch.tensor(2.)
+        zero_point = torch.tensor(1.)
+    else:
+        scale = torch.tensor([1., 2., 3., 4.]).reshape(2, 2, 1)
+        zero_point = torch.tensor([10., 20., 30., 40.]).reshape(2, 2, 1)
+    dequant_shape = (2, 5)
+    compiled_fn = torch.compile(groupwise_dequant_expand, backend='eager', fullgraph=True)
+
+    actual = compiled_fn(value, scale, zero_point, group_dim, dequant_shape, expand_metadata)
+    expected = groupwise_dequant_expand(
+        value, scale, zero_point, group_dim, dequant_shape, expand_metadata)
+
+    assert all(
+        torch.equal(actual_value, expected_value) for actual_value,
+        expected_value in zip(actual, expected))
+    assert torch.equal(actual[0], torch.tensor([[0., 1., 2., 3., 4.], [8., 9., 10., 11., 12.]]))
+
+    if not expand_metadata or scalar_metadata:
+        assert actual[1].shape == scale.shape
+        assert actual[2].shape == zero_point.shape
+    else:
+        assert torch.equal(actual[1], torch.tensor([[1., 1., 1., 1., 2.], [3., 3., 3., 3., 4.]]))
+        assert torch.equal(
+            actual[2], torch.tensor([[10., 10., 10., 10., 20.], [30., 30., 30., 30., 40.]]))

--- a/tests/brevitas/utils/test_compile.py
+++ b/tests/brevitas/utils/test_compile.py
@@ -29,6 +29,7 @@ def test_compile_padding_to_multiple(shape, dim, multiple, expected_shape):
 
     assert actual.shape == expected_shape
     assert torch.equal(actual, expected)
+    assert expected.is_contiguous()
     assert torch.equal(torch.narrow(actual, dim, 0, shape[dim]), x)
 
     padding = expected_shape[dim] - shape[dim]

--- a/tests/brevitas/utils/test_compile.py
+++ b/tests/brevitas/utils/test_compile.py
@@ -8,7 +8,6 @@ import torch
 
 from brevitas.utils.quant_utils import groupwise_dequant_expand
 from brevitas.utils.torch_utils import padding_to_multiple
-from tests.marker import jit_disabled_for_compile
 from tests.marker import requires_pt_ge
 from tests.marker import requires_torch_compile
 
@@ -19,7 +18,6 @@ from tests.marker import requires_torch_compile
      ((5, 3), 0, 4, (8, 3))])
 @requires_pt_ge('2.2')
 @requires_torch_compile()
-@jit_disabled_for_compile()
 def test_compile_padding_to_multiple(shape, dim, multiple, expected_shape):
     x = torch.arange(math.prod(shape), dtype=torch.float32).reshape(shape)
     compiled_fn = torch.compile(padding_to_multiple, backend='eager', fullgraph=True)
@@ -43,7 +41,6 @@ def test_compile_padding_to_multiple(shape, dim, multiple, expected_shape):
 @pytest.mark.parametrize('expand_metadata', [False, True])
 @requires_pt_ge('2.2')
 @requires_torch_compile()
-@jit_disabled_for_compile()
 def test_compile_groupwise_dequant_expand(group_dim, scalar_metadata, expand_metadata):
     value = torch.arange(16, dtype=torch.float32).reshape(2, 2, 4)
     if scalar_metadata:

--- a/tests/brevitas/utils/test_compile.py
+++ b/tests/brevitas/utils/test_compile.py
@@ -27,7 +27,6 @@ def test_compile_padding_to_multiple(shape, dim, multiple, expected_shape):
 
     assert actual.shape == expected_shape
     assert torch.equal(actual, expected)
-    assert expected.is_contiguous()
     assert torch.equal(torch.narrow(actual, dim, 0, shape[dim]), x)
 
     padding = expected_shape[dim] - shape[dim]

--- a/tests/marker.py
+++ b/tests/marker.py
@@ -15,13 +15,14 @@ from brevitas import torch_version
 def requires_torch_compile():
     # Newest Python versions have only limited supports for torch.compile on
     # older torch versions
-    skip = ((torch_version <= parse('2.9.1') and python_version >= parse('3.14')) or
-            (torch_version <= parse('2.3.1') and python_version >= parse('3.12')))
+    unsupported = ((torch_version <= parse('2.9.1') and python_version >= parse('3.14')) or
+                   (torch_version <= parse('2.3.1') and python_version >= parse('3.12')))
+    skip = config.JIT_ENABLED or unsupported
 
     return pytest.mark.skipif(
         skip,
         reason=(
-            'Upstream torch incompatibility: torch.compile is unsupported for '
+            'Compile requires JIT to be disabled and torch.compile to be supported for '
             'PyTorch <= 2.9.1 on Python >= 3.14 and '
             'PyTorch <= 2.3.1 on Python >= 3.12'))
 
@@ -72,15 +73,6 @@ def jit_disabled_for_mock():
 
     def skip_wrapper(f):
         return pytest.mark.skipif(skip, reason=f'Mock requires JIT to be disabled')(f)
-
-    return skip_wrapper
-
-
-def jit_disabled_for_compile():
-    skip = config.JIT_ENABLED
-
-    def skip_wrapper(f):
-        return pytest.mark.skipif(skip, reason=f'Compile requires JIT to be disabled')(f)
 
     return skip_wrapper
 


### PR DESCRIPTION
## Reason for this PR
Currently we can't compile the groupwise quantizers with `fullgraph=True` due to some utils being not compile-friendly.

This PR addresses this issue.


During quant_inference_mode, we need `group_size` and `group_dim` to be integer to avoid data-conditional failures during compile (they are registered as constant). However, for some export paths (e.g., vLLM), we need them as torch buffers so that they are part of the state dict.
For this reason, we add a thin mixin just for the vLLM export flow so that both behaviours co-exist.