### PR TITLE
Docs: fix spelling mistakes in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Please follow the steps below and be sure that your contribution complies with o
 
 1. If you are looking for some issues to get started with, we have a list of <a href="https://github.com/Xilinx/brevitas/labels/good%20first%20issue">good first issues</a> in the issue tracker.
 
-2. If you have some suggestion for features or have encoutered any bugs, don't hesitate to reach out through <a href="https://github.com/Xilinx/brevitas/issues">Brevitas Issue</a>
+2. If you have some suggestion for features or have encountered any bugs, don't hesitate to reach out through <a href="https://github.com/Xilinx/brevitas/issues">Brevitas Issue</a>
 
 	We welcome submissions for:
 

--- a/docsrc/source/index.rst
+++ b/docsrc/source/index.rst
@@ -27,7 +27,7 @@ Brevitas
    About <about>
 
 Brevitas implements a set of building blocks at different levels of abstraction to model a reduced precision hardware data-path at training time.
-It provides a platform both for researchers interested in implementing new quantization-aware training techinques, as well as for practitioners interested in applying current techniques to their models.
+It provides a platform both for researchers interested in implementing new quantization-aware training techniques, as well as for practitioners interested in applying current techniques to their models.
 
 Brevitas supports a super-set of quantization schemes implemented across various frameworks and compilers under a single unified API.
 For certain combinations of layers and types of of quantization inference acceleration is supported by exporting to *FINN*, *onnxruntime* or *Pytorch*'s own quantized operators.

--- a/docsrc/source/papers/qronos.rst
+++ b/docsrc/source/papers/qronos.rst
@@ -243,7 +243,7 @@ QuaRot with INT4 and MXFP4
 QuaRot [3] is a rotation-based quantization method that applies Hadamard transformations to 
 neural network weights and activations to remove outliers before quantization, enabling 
 accurate low-bit quantization. With Brevitas, you can similarly apply and fuse Hadamard 
-rotations then apply Qronos (or other adaptive rounding alorithms). The following table 
+rotations then apply Qronos (or other adaptive rounding algorithms). The following table 
 summarizes the results of quantizing the weights and activations of Llama-3.2-1B to INT4 or 
 MXFP4. We compare Qronos with GPTQ and GPFQ and provide RTN as a baseline.
 

--- a/docsrc/source/settings.rst
+++ b/docsrc/source/settings.rst
@@ -2,7 +2,7 @@
 Settings
 ========
 
-Brevitas supports a few boolean global flags can be set through enviromental variables and/or at runtime in the `brevitas.config` package.
+Brevitas supports a few boolean global flags can be set through environmental variables and/or at runtime in the `brevitas.config` package.
 
 `BREVITAS_JIT` (Default: 0) - `brevitas.config.JIT_ENABLED`
 Enable just-in-time compilation of built-in quantizers written in TorchScript and of gradient estimators written in C++.

--- a/docsrc/source/setup.rst
+++ b/docsrc/source/setup.rst
@@ -52,7 +52,7 @@ except for some distributed training scenarios with ``BREVITAS_JIT=1``.
 .. note::
 
     The custom C++ autograd functions are implemented in a single `.cpp` file distributed together with Brevitas that is internally compiled and loaded at runtime through the ``torch.utils.cpp_extension.load()`` mechanism.
-    This simplifies the packaging of Brevitas, since it avoids to mantain precompiled binaries for every possible supported platform, but it puts on the user the burden of making sure an appropriate compiler is present.
+    This simplifies the packaging of Brevitas, since it avoids to maintain precompiled binaries for every possible supported platform, but it puts on the user the burden of making sure an appropriate compiler is present.
 
 
 Optional Inference Requirements

--- a/docsrc/source/user_guide/architecture.rst
+++ b/docsrc/source/user_guide/architecture.rst
@@ -15,7 +15,7 @@ and C++, found under *brevitas/csrc*.
 This is because to date Python Autograd functions cannot be compiled
 by Pytorch's JIT compiler, but C++ Autograd functions can. Compiling the C++ extension is performed at runtime
 in order to simplify packaging and distribution (only a single .cpp source file is distributed).
-This requires the user to have an appropriate C++ compiler, so a Python implemention is provided as fallback.
+This requires the user to have an appropriate C++ compiler, so a Python implementation is provided as fallback.
 
 Because of this, as long as `BREVITAS_JIT=0` (which it is by default), the C++ backend is not loaded.
 Wrapping and switching between the two implementations happens in `brevitas.function.ops_ste`.
@@ -28,7 +28,7 @@ Core ScriptModules
 
 The algorithmic core of Brevitas can be found under `brevitas.core`.
 The core implements all the various building blocks required to assemble an affine quantizer.
-All building blocks are implemented as a ScriptModule in the *old-style* TorchScript scriping API
+All building blocks are implemented as a ScriptModule in the *old-style* TorchScript scripting API
 (i.e. inheriting from `torch.jit.ScriptModule`). Many of the functions described in the section above
 are called from within one of the core ScriptModules.
 Any module within `brevitas.core` is required to be a ScriptModule compatible with Pytorch 1.3.0 JIT compiler,
@@ -37,7 +37,7 @@ Implementing everything in TorchScript enables compute and memory optimizations 
 which for more complicated quantization pipelines can be quite significant, thus reducing the intrinsic
 training-time cost of quantization-aware training.
 
-Adhering to the restriction imposed by TorchScript pose a challange in terms of how to achieve flexibility
+Adhering to the restriction imposed by TorchScript pose a challenge in terms of how to achieve flexibility
 while minimizing redundancy. Because the flavour of TorchScript adopted by Brevitas does not allow
 for inheritance, Brevitas' core is highly biased towards leveraging composition.
 In particular, the implementation favours inversion of control through dependency injection (DI),


### PR DESCRIPTION
Fixes eight spelling mistakes in the documentation.

- `CONTRIBUTING.md` — "encoutered" -> "encountered"
- `docsrc/source/index.rst` — "techinques" -> "techniques"
- `docsrc/source/settings.rst` — "enviromental" -> "environmental"
- `docsrc/source/setup.rst` — "mantain" -> "maintain"
- `docsrc/source/papers/qronos.rst` — "alorithms" -> "algorithms"
- `docsrc/source/user_guide/architecture.rst` — "implemention" -> "implementation",
  "scriping" -> "scripting", "challange" -> "challenge"

Documentation only; no code or API changes.
