### PR TITLE
Fix (docs): Make docs generation more easily reproducible

### DIFF
--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -21,18 +21,43 @@ import subprocess
 import sys
 
 
-# nbsphinx renders notebook markdown cells through pandoc, which nbconvert locates on PATH.
-# The `pypandoc-binary` docs dependency ships a pandoc executable inside site-packages rather
-# than on PATH, so expose it here. A system-wide pandoc, if present, takes precedence.
-if shutil.which('pandoc') is None:
-    try:
-        import pypandoc
-    except ImportError:
-        pass
-    else:
-        bundled_pandoc_dir = Path(pypandoc.__file__).resolve().parent / 'files'
-        if (bundled_pandoc_dir / 'pandoc').is_file():
-            os.environ['PATH'] = os.pathsep.join((str(bundled_pandoc_dir), os.environ['PATH']))
+# The pandoc version bundled by the pinned `pypandoc-binary` release. Notebook markdown cells are
+# rendered by pandoc, and its HTML output changes between releases, so a mismatch here means the
+# generated documentation no longer matches what is committed under `docs/`.
+EXPECTED_PANDOC_VERSION = '3.9'
+
+# nbsphinx renders notebook markdown cells through pandoc, which nbconvert resolves by calling
+# `shutil.which('pandoc')` and then running it as a bare `pandoc`. Prepending the executable
+# bundled by `pypandoc-binary` to PATH is therefore the only way to select it. An unpinned system
+# pandoc is deliberately ignored: it is a different version and silently changes the output.
+try:
+    import pypandoc
+except ImportError as exc:
+    raise RuntimeError(
+        "Building the documentation requires the `pypandoc-binary` package, which bundles a "
+        "pinned pandoc executable. Install the documentation dependencies with "
+        "`pip install -e .[docs]`.") from exc
+
+bundled_pandoc_dir = Path(pypandoc.__file__).resolve().parent / 'files'
+# `shutil.which` honours PATHEXT on Windows and checks the executable bit on POSIX.
+bundled_pandoc = shutil.which('pandoc', path=str(bundled_pandoc_dir))
+if bundled_pandoc is None:
+    raise RuntimeError(
+        f"No usable pandoc executable was found in {bundled_pandoc_dir}. This usually means plain "
+        "`pypandoc` is installed instead of `pypandoc-binary`; reinstall the documentation "
+        "dependencies with `pip install -e .[docs]`.")
+os.environ['PATH'] = os.pathsep.join((str(bundled_pandoc_dir), os.environ.get('PATH', '')))
+
+bundled_pandoc_version = subprocess.run([bundled_pandoc, '--version'],
+                                        capture_output=True,
+                                        text=True,
+                                        check=True).stdout.split()[1]
+if bundled_pandoc_version != EXPECTED_PANDOC_VERSION:
+    raise RuntimeError(
+        f"Expected pandoc {EXPECTED_PANDOC_VERSION} but {bundled_pandoc} reports "
+        f"{bundled_pandoc_version}. pandoc renders notebook markdown cells and its output changes "
+        "between releases, so update the `pypandoc-binary` pin in requirements/requirements-docs."
+        "txt and EXPECTED_PANDOC_VERSION together, then rebuild and review the diff under `docs/`.")
 
 
 # sphinx-multiversion copies each selected ref to this source directory. Put that ref's `src/`

--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -16,48 +16,24 @@
 
 import os
 from pathlib import Path
-import shutil
 import subprocess
 import sys
 
+import pypandoc
 
-# The pandoc version bundled by the pinned `pypandoc-binary` release. Notebook markdown cells are
-# rendered by pandoc, and its HTML output changes between releases, so a mismatch here means the
-# generated documentation no longer matches what is committed under `docs/`.
+
+# nbsphinx renders notebook markdown cells with pandoc, which nbconvert looks up on PATH.
+# `pypandoc-binary` ships a pinned pandoc inside site-packages, so put it first: a system pandoc
+# would be a different version and would silently change the generated HTML.
+pandoc_dir = Path(pypandoc.__file__).resolve().parent / 'files'
+os.environ['PATH'] = os.pathsep.join((str(pandoc_dir), os.environ['PATH']))
+
+# Keep in sync with the `pypandoc-binary` pin in requirements/requirements-docs.txt.
 EXPECTED_PANDOC_VERSION = '3.9'
-
-# nbsphinx renders notebook markdown cells through pandoc, which nbconvert resolves by calling
-# `shutil.which('pandoc')` and then running it as a bare `pandoc`. Prepending the executable
-# bundled by `pypandoc-binary` to PATH is therefore the only way to select it. An unpinned system
-# pandoc is deliberately ignored: it is a different version and silently changes the output.
-try:
-    import pypandoc
-except ImportError as exc:
-    raise RuntimeError(
-        "Building the documentation requires the `pypandoc-binary` package, which bundles a "
-        "pinned pandoc executable. Install the documentation dependencies with "
-        "`pip install -e .[docs]`.") from exc
-
-bundled_pandoc_dir = Path(pypandoc.__file__).resolve().parent / 'files'
-# `shutil.which` honours PATHEXT on Windows and checks the executable bit on POSIX.
-bundled_pandoc = shutil.which('pandoc', path=str(bundled_pandoc_dir))
-if bundled_pandoc is None:
-    raise RuntimeError(
-        f"No usable pandoc executable was found in {bundled_pandoc_dir}. This usually means plain "
-        "`pypandoc` is installed instead of `pypandoc-binary`; reinstall the documentation "
-        "dependencies with `pip install -e .[docs]`.")
-os.environ['PATH'] = os.pathsep.join((str(bundled_pandoc_dir), os.environ.get('PATH', '')))
-
-bundled_pandoc_version = subprocess.run([bundled_pandoc, '--version'],
-                                        capture_output=True,
-                                        text=True,
-                                        check=True).stdout.split()[1]
-if bundled_pandoc_version != EXPECTED_PANDOC_VERSION:
-    raise RuntimeError(
-        f"Expected pandoc {EXPECTED_PANDOC_VERSION} but {bundled_pandoc} reports "
-        f"{bundled_pandoc_version}. pandoc renders notebook markdown cells and its output changes "
-        "between releases, so update the `pypandoc-binary` pin in requirements/requirements-docs."
-        "txt and EXPECTED_PANDOC_VERSION together, then rebuild and review the diff under `docs/`.")
+pandoc_version = subprocess.run(['pandoc', '--version'], capture_output=True, text=True,
+                                check=True).stdout.split()[1]
+if pandoc_version != EXPECTED_PANDOC_VERSION:
+    raise RuntimeError(f"Expected pandoc {EXPECTED_PANDOC_VERSION}, found {pandoc_version}")
 
 
 # sphinx-multiversion copies each selected ref to this source directory. Put that ref's `src/`

--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -16,8 +16,23 @@
 
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
+
+
+# nbsphinx renders notebook markdown cells through pandoc, which nbconvert locates on PATH.
+# The `pypandoc-binary` docs dependency ships a pandoc executable inside site-packages rather
+# than on PATH, so expose it here. A system-wide pandoc, if present, takes precedence.
+if shutil.which('pandoc') is None:
+    try:
+        import pypandoc
+    except ImportError:
+        pass
+    else:
+        bundled_pandoc_dir = Path(pypandoc.__file__).resolve().parent / 'files'
+        if (bundled_pandoc_dir / 'pandoc').is_file():
+            os.environ['PATH'] = os.pathsep.join((str(bundled_pandoc_dir), os.environ['PATH']))
 
 
 # sphinx-multiversion copies each selected ref to this source directory. Put that ref's `src/`

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -1,7 +1,13 @@
 m2r2==0.3.3.post2
+# Provides the `ipython3` Pygments lexer entry point used by nbsphinx code cells.
+ipython==8.39.0
 nbsphinx==0.9.3
 nbsphinx-link==1.3.0
 pydata-sphinx-theme==0.15.3
+# 2.21.0 stopped HTML-escaping quotes in the HtmlFormatter, which rewrites every code block.
+pygments==2.20.0
+# Bundles the pandoc executable that nbconvert needs to render notebook markdown cells.
+pypandoc-binary==1.17
 sphinx==5.3.0
 sphinx-autodoc-typehints==1.21.8
 sphinx-gallery==0.10.1


### PR DESCRIPTION
In the latest release, there were some docs reproducibility issues. This PR looks to address this by pinning more required environment packages and by pinning the `pandoc` version via `pypandoc-binary`. I've also pinned some other dependencies (pygments, ipython) to further improve the reliability of the output.

The environment can be setup as (note `python<3.13` is required):

```bash
uv venv -p 3.12
source .venv/bin/activate
uv pip install -e .[docs] 'sphinx-multiversion @ git+https://github.com/Holzhaus/sphinx-multiversion.git@ec101ba44132ddf1bd32e462912dd60296856387' --torch-backend cpu
cd docsrc/
make github BUILD_VERSION=master
```

After building, the results diff is:

```diff
diff --git a/docs/index.html b/docs/index.html
index ebd0ca49..4050fd43 100644
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="refresh" content="0; URL='https://xilinx.github.io/brevitas/v0.13.2'" />
+  <meta http-equiv="refresh" content="0; URL='https://xilinx.github.io/brevitas/update/to/latest/'" />
   <title>Redirecting...</title>
 </head>
 <body>
-  <p>If you are not redirected automatically, <a href="https://xilinx.github.io/brevitas/v0.13.2">click here</a>.</p>
+  <p>If you are not redirected automatically, <a href="https://xilinx.github.io/brevitas/update/to/latest/">click here</a>.</p>
 </body>
 </html>
\ No newline at end of file
diff --git a/docs/master/.buildinfo b/docs/master/.buildinfo
index 8c96a2ba..914873db 100644
--- a/docs/master/.buildinfo
+++ b/docs/master/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: 608b7db2084cac7fa4c55f65a4e9d29a
+config: d67cb59d8f96747c874524c0776b1553
 tags: 645f666f9bcd5a90fca523b33c5a78b7
diff --git a/docs/master/_static/documentation_options.js b/docs/master/_static/documentation_options.js
index f3163d5c..5092f7d6 100644
--- a/docs/master/_static/documentation_options.js
+++ b/docs/master/_static/documentation_options.js
@@ -1,6 +1,6 @@
 var DOCUMENTATION_OPTIONS = {
     URL_ROOT: document.getElementById("documentation_options").getAttribute('data-url_root'),
-    VERSION: '0.13.2',
+    VERSION: '0.13.3.dev4+gf3d4997c6',
     LANGUAGE: 'en',
     COLLAPSE_INDEX: false,
     BUILDER: 'html',
```

which I believe is the minimal possible diff for any new changes.