### PR TITLE
Feat (graph/gpxq): faster groupwise per-column quantization

### DIFF
--- a/src/brevitas/core/function_wrapper/shape.py
+++ b/src/brevitas/core/function_wrapper/shape.py
@@ -202,6 +202,23 @@ def dynamic_over_sub_channel_block_view(
     return x
 
 
+def extract_groupwise_block(x: torch.Tensor, group_dim: int, group_size: int,
+                            group_index: int) -> Tuple[torch.Tensor, int]:
+    """Extract one physical group and return it in canonical expanded layout."""
+    group_dim = group_dim if group_dim >= 0 else group_dim + x.ndim
+    group_start = group_index * group_size
+    group_end = min(group_start + group_size, x.shape[group_dim])
+    logical_group_size = group_end - group_start
+    group = x.narrow(group_dim, group_start, logical_group_size)
+    if logical_group_size < group_size:
+        pad = [0] * (2 * x.ndim)
+        pad_index = 2 * (x.ndim - group_dim - 1) + 1
+        pad[pad_index] = group_size - logical_group_size
+        group = torch.nn.functional.pad(group, pad)
+    group = torch.unsqueeze(group, group_dim)
+    return group, logical_group_size
+
+
 class StatsInputViewShapeImpl(object):
     """
     Enum-like object to collect pointers to variants of ScriptModules that perform a view on a tensor.

--- a/src/brevitas/core/function_wrapper/shape.py
+++ b/src/brevitas/core/function_wrapper/shape.py
@@ -219,6 +219,17 @@ def extract_groupwise_block(x: torch.Tensor, group_dim: int, group_size: int,
     return group, logical_group_size
 
 
+def select_groupwise_metadata(
+        value: torch.Tensor, group_dim: int, group_index: torch.Tensor) -> torch.Tensor:
+    """Select one compact groupwise metadata entry while preserving broadcast dimensions."""
+    if value.ndim == 0:
+        return value
+    group_dim = group_dim if group_dim >= 0 else group_dim + value.ndim - 1
+    if group_dim >= value.ndim:
+        raise RuntimeError("Groupwise metadata is incompatible with the requested group")
+    return value.narrow(group_dim, group_index, 1)
+
+
 class StatsInputViewShapeImpl(object):
     """
     Enum-like object to collect pointers to variants of ScriptModules that perform a view on a tensor.

--- a/src/brevitas/core/quant/float.py
+++ b/src/brevitas/core/quant/float.py
@@ -85,10 +85,10 @@ class FloatQuant(brevitas.jit.ScriptModule):
         return self.forward_with_scale(x, scale)
 
     @brevitas.jit.ignore
-    def forward_group(self, x):
+    def forward_group(self, x, group_index: torch.Tensor, group_dim: int):
         """Quantize an already-expanded physical group through the canonical float path."""
         float_scaling_impl_value = self.float_scaling_value()
-        scale = self.scaling_impl.forward_group(x, float_scaling_impl_value)
+        scale = self.scaling_impl.forward_group(x, float_scaling_impl_value, group_index, group_dim)
         return self.forward_with_scale(x, scale)
 
     @brevitas.jit.script_method

--- a/src/brevitas/core/quant/float.py
+++ b/src/brevitas/core/quant/float.py
@@ -80,14 +80,29 @@ class FloatQuant(brevitas.jit.ScriptModule):
 
     @brevitas.jit.script_method
     def forward(self, x):
+        float_scaling_impl_value = self.float_scaling_value()
+        scale = self.scaling_impl(x, float_scaling_impl_value)
+        return self.forward_with_scale(x, scale)
+
+    @brevitas.jit.ignore
+    def forward_group(self, x):
+        """Quantize an already-expanded physical group through the canonical float path."""
+        float_scaling_impl_value = self.float_scaling_value()
+        scale = self.scaling_impl.forward_group(x, float_scaling_impl_value)
+        return self.forward_with_scale(x, scale)
+
+    @brevitas.jit.script_method
+    def float_scaling_value(self) -> Optional[torch.Tensor]:
         if self.float_scaling_impl is not None:
-            float_scaling_impl_value = self.float_scaling_impl(
+            return self.float_scaling_impl(
                 self.exponent_bit_width_impl(),
                 self.compute_max_mantissa(self.mantissa_bit_width_impl()),
                 self.exponent_bias_impl())
         else:
-            float_scaling_impl_value = None
-        scale = self.scaling_impl(x, float_scaling_impl_value)
+            return None
+
+    @brevitas.jit.script_method
+    def forward_with_scale(self, x, scale):
         if self.observer_only:
             y = x
             saturating, inf_values, nan_values = self.float_clamp_impl.saturating, self.float_clamp_impl.inf_values, self.float_clamp_impl.nan_values

--- a/src/brevitas/core/quant/int.py
+++ b/src/brevitas/core/quant/int.py
@@ -158,6 +158,19 @@ class RescalingIntQuant(brevitas.jit.ScriptModule):
         bit_width = self.msb_clamp_bit_width_impl()
         int_threshold = self.int_scaling_impl(bit_width)
         scale = self.scaling_impl(x, int_threshold)
+        return self.forward_with_scale(x, scale, bit_width)
+
+    @brevitas.jit.ignore
+    def forward_group(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Quantize an already-expanded physical group through the canonical integer path."""
+        bit_width = self.msb_clamp_bit_width_impl()
+        int_threshold = self.int_scaling_impl(bit_width)
+        scale = self.scaling_impl.forward_group(x, int_threshold)
+        return self.forward_with_scale(x, scale, bit_width)
+
+    @brevitas.jit.script_method
+    def forward_with_scale(self, x: Tensor, scale: Tensor,
+                           bit_width: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         zero_point = self.zero_point_impl(x, scale, bit_width)
         if self.observer_only:
             y = x

--- a/src/brevitas/core/quant/int.py
+++ b/src/brevitas/core/quant/int.py
@@ -161,17 +161,24 @@ class RescalingIntQuant(brevitas.jit.ScriptModule):
         return self.forward_with_scale(x, scale, bit_width)
 
     @brevitas.jit.ignore
-    def forward_group(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    def forward_group(self, x: Tensor, group_index: Tensor,
+                      group_dim: int) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         """Quantize an already-expanded physical group through the canonical integer path."""
         bit_width = self.msb_clamp_bit_width_impl()
         int_threshold = self.int_scaling_impl(bit_width)
-        scale = self.scaling_impl.forward_group(x, int_threshold)
-        return self.forward_with_scale(x, scale, bit_width)
+        scale = self.scaling_impl.forward_group(x, int_threshold, group_index, group_dim)
+        zero_point = self.zero_point_impl.forward_group(x, scale, bit_width, group_index, group_dim)
+        return self.forward_with_qparams(x, scale, zero_point, bit_width)
 
     @brevitas.jit.script_method
     def forward_with_scale(self, x: Tensor, scale: Tensor,
                            bit_width: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         zero_point = self.zero_point_impl(x, scale, bit_width)
+        return self.forward_with_qparams(x, scale, zero_point, bit_width)
+
+    @brevitas.jit.script_method
+    def forward_with_qparams(self, x: Tensor, scale: Tensor, zero_point: Tensor,
+                             bit_width: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         if self.observer_only:
             y = x
         else:

--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -78,7 +78,11 @@ class StatsFromParameterScaling(brevitas.jit.ScriptModule):
 
     @brevitas.jit.ignore
     def forward_group(
-            self, x: torch.Tensor, threshold: Optional[torch.Tensor] = None) -> torch.Tensor:
+            self,
+            x: torch.Tensor,
+            threshold: Optional[torch.Tensor],
+            group_index: torch.Tensor,
+            group_dim: int) -> torch.Tensor:
         """Compute scale from an already-expanded physical group.
 
         Region-capable groupwise proxies pass tensors in canonical

--- a/src/brevitas/core/scaling/runtime.py
+++ b/src/brevitas/core/scaling/runtime.py
@@ -41,6 +41,8 @@ class StatsFromParameterScaling(brevitas.jit.ScriptModule):
             dtype: Optional[torch.dtype] = None,
             device: Optional[torch.device] = None) -> None:
         super(StatsFromParameterScaling, self).__init__()
+        self.supports_groupwise_region = scaling_affine_rescaling_init is None and len(
+            tracked_parameter_list) == 1 and not force_parameter
 
         # Ensure retro-compatibility with shared threshold/scaling restrict
         if restrict_threshold_impl is None:
@@ -70,6 +72,20 @@ class StatsFromParameterScaling(brevitas.jit.ScriptModule):
             x: Optional[torch.Tensor],
             threshold: Optional[torch.Tensor] = None) -> torch.Tensor:
         stats = self.parameter_list_stats(x)
+        if threshold is None:
+            threshold = torch.ones(1).type_as(stats)
+        return self.stats_scaling_impl(stats, threshold)
+
+    @brevitas.jit.ignore
+    def forward_group(
+            self, x: torch.Tensor, threshold: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Compute scale from an already-expanded physical group.
+
+        Region-capable groupwise proxies pass tensors in canonical
+        ``[..., num_groups=1, group_size]`` layout, so the full-parameter view and output reshape
+        performed by ``_ParameterListStats`` are intentionally unnecessary here.
+        """
+        stats = self.parameter_list_stats.stats.stats_impl(x)
         if threshold is None:
             threshold = torch.ones(1).type_as(stats)
         return self.stats_scaling_impl(stats, threshold)

--- a/src/brevitas/core/scaling/standalone.py
+++ b/src/brevitas/core/scaling/standalone.py
@@ -15,6 +15,7 @@ import brevitas
 import brevitas.config as config
 from brevitas.core.function_wrapper import OverBatchOverTensorView
 from brevitas.core.function_wrapper import TensorClamp
+from brevitas.core.function_wrapper.shape import select_groupwise_metadata
 from brevitas.core.restrict_val import _ClampValue
 from brevitas.core.restrict_val import _RestrictClampValue
 from brevitas.core.restrict_val import _RestrictValue
@@ -201,6 +202,19 @@ class ParameterScaling(brevitas.jit.ScriptModule):
         value = self.restrict_clamp_scale_threshold(value / threshold)
         return value
 
+    supports_groupwise_region = True
+
+    @brevitas.jit.ignore
+    def forward_group(
+            self, placeholder: Tensor, threshold: Optional[Tensor], group_index: Tensor,
+            group_dim: int) -> Tensor:
+        if threshold is None:
+            threshold = torch.ones(1).type_as(placeholder)
+        threshold = self.restrict_clamp_threshold(self.restrict_threshold_pre(threshold))
+        value = select_groupwise_metadata(self.value, group_dim, group_index)
+        value = self.restrict_clamp_scaling(value)
+        return self.restrict_clamp_scale_threshold(value / threshold)
+
     def _load_from_state_dict(
             self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
             error_msgs):
@@ -305,6 +319,8 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
 
         self.value = Parameter(torch.full(scaling_shape, 1.0, dtype=dtype, device=device))
 
+        self.supports_groupwise_region = True
+
     @brevitas.jit.script_method
     def forward(self, x: Tensor, threshold: Optional[Tensor] = None) -> Tensor:
         if threshold is None:
@@ -333,6 +349,20 @@ class ParameterFromStatsFromParameterScaling(brevitas.jit.ScriptModule):
             value = self.stats_scaling_impl.restrict_clamp_scale_threshold(value / threshold)
             self.init_done = True
             return value
+
+    @brevitas.jit.ignore
+    def forward_group(
+            self, x: Tensor, threshold: Optional[Tensor], group_index: Tensor,
+            group_dim: int) -> Tensor:
+        if not self.init_done:
+            raise RuntimeError("Parameter-from-stats scale is not ready for regional quantization")
+        if threshold is None:
+            threshold = torch.ones(1).type_as(x)
+        threshold = self.stats_scaling_impl.restrict_clamp_threshold(
+            self.restrict_threshold_pre(threshold))
+        value = select_groupwise_metadata(self.value, group_dim, group_index)
+        value = self.stats_scaling_impl.restrict_clamp_scaling(value)
+        return self.stats_scaling_impl.restrict_clamp_scale_threshold(value / threshold)
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         output_dict = super(ParameterFromStatsFromParameterScaling, self).state_dict(

--- a/src/brevitas/core/zero_point.py
+++ b/src/brevitas/core/zero_point.py
@@ -14,6 +14,7 @@ from torch.nn import Parameter
 import brevitas
 from brevitas import config
 from brevitas.core.function_wrapper import Identity
+from brevitas.core.function_wrapper.shape import select_groupwise_metadata
 from brevitas.core.scaling.runtime import _AffineRescaling
 from brevitas.core.stats import _ParameterListStats
 from brevitas.core.stats import DEFAULT_MOMENTUM
@@ -47,6 +48,12 @@ class ZeroZeroPoint(brevitas.jit.ScriptModule):
     @brevitas.jit.script_method
     def forward(self, x: Tensor, scale: Tensor, bit_width: Tensor) -> Tensor:
         return self.zero_point()
+
+    @brevitas.jit.ignore
+    def forward_group(
+            self, x: Tensor, scale: Tensor, bit_width: Tensor, group_index: Tensor,
+            group_dim: int) -> Tensor:
+        return self.forward(x, scale, bit_width)
 
 
 class _ScaleShiftZeroPoint(brevitas.jit.ScriptModule):
@@ -111,6 +118,9 @@ class StatsFromParameterZeroPoint(brevitas.jit.ScriptModule):
             dtype: Optional[torch.dtype] = None,
             device: Optional[torch.device] = None) -> None:
         super(StatsFromParameterZeroPoint, self).__init__()
+        self.supports_groupwise_region = (
+            zero_point_affine_rescaling_init is None and len(tracked_parameter_list) == 1 and
+            scale_shift_zero_point_impl is None)
         self.parameter_list_stats = _ParameterListStats(
             zero_point_stats_impl,
             zero_point_shape,
@@ -142,6 +152,13 @@ class StatsFromParameterZeroPoint(brevitas.jit.ScriptModule):
     def forward(self, x: Tensor, scale: Tensor, bit_width: Tensor) -> torch.Tensor:
         stats = self.parameter_list_stats(x)
         stats = self.affine_rescaling(stats)
+        return self.scale_shift_zero_point(-stats, scale, bit_width)
+
+    @brevitas.jit.ignore
+    def forward_group(
+            self, x: Tensor, scale: Tensor, bit_width: Tensor, group_index: Tensor,
+            group_dim: int) -> torch.Tensor:
+        stats = self.parameter_list_stats.stats.stats_impl(x)
         return self.scale_shift_zero_point(-stats, scale, bit_width)
 
 
@@ -276,12 +293,21 @@ class ParameterZeroPoint(brevitas.jit.ScriptModule):
                 zero_point_shape, zero_point_init, dtype=dtype, device=device)
         self.value = Parameter(zero_point_init)
         self.scale_shift_zero_point = _ScaleShiftZeroPoint(int_quant, quantize_zero_point)
+        self.supports_groupwise_region = True
 
     @brevitas.jit.script_method
     def forward(self, x: Tensor, scale: Tensor, bit_width: Tensor) -> Tensor:
         out = abs_binary_sign_grad(self.value)
         out = self.scale_shift_zero_point(out, scale, bit_width)
         return out
+
+    @brevitas.jit.ignore
+    def forward_group(
+            self, x: Tensor, scale: Tensor, bit_width: Tensor, group_index: Tensor,
+            group_dim: int) -> Tensor:
+        value = select_groupwise_metadata(self.value, group_dim, group_index)
+        value = abs_binary_sign_grad(value)
+        return self.scale_shift_zero_point(value, scale, bit_width)
 
     def _load_from_state_dict(
             self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
@@ -314,6 +340,9 @@ class ParameterFromStatsFromParameterZeroPoint(brevitas.jit.ScriptModule):
             dtype: Optional[torch.dtype] = None,
             device: Optional[torch.device] = None) -> None:
         super(ParameterFromStatsFromParameterZeroPoint, self).__init__()
+        self.supports_groupwise_region = (
+            zero_point_affine_rescaling_init is None and len(tracked_parameter_list) == 1 and
+            scale_shift_zero_point_impl is None)
         self.parameter_list_stats = _ParameterListStats(
             zero_point_stats_impl,
             zero_point_shape,
@@ -360,6 +389,17 @@ class ParameterFromStatsFromParameterZeroPoint(brevitas.jit.ScriptModule):
             value = self.scale_shift_zero_point(value, scale, bit_width)
             self.init_done = True
             return value
+
+    @brevitas.jit.ignore
+    def forward_group(
+            self, x: Tensor, scale: Tensor, bit_width: Tensor, group_index: Tensor,
+            group_dim: int) -> Tensor:
+        if not self.init_done:
+            raise RuntimeError(
+                "Parameter-from-stats zero point is not ready for regional quantization")
+        value = select_groupwise_metadata(self.value, group_dim, group_index)
+        value = abs_binary_sign_grad(value)
+        return self.scale_shift_zero_point(value, scale, bit_width)
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         output_dict = super(ParameterFromStatsFromParameterZeroPoint, self).state_dict(

--- a/src/brevitas/core/zero_point.py
+++ b/src/brevitas/core/zero_point.py
@@ -35,6 +35,8 @@ __all__ = [
 
 class ZeroZeroPoint(brevitas.jit.ScriptModule):
 
+    supports_groupwise_region = True
+
     def __init__(
             self,
             dtype: Optional[torch.dtype] = None,

--- a/src/brevitas/graph/gpfq.py
+++ b/src/brevitas/graph/gpfq.py
@@ -181,7 +181,7 @@ class GPFQ(GPxQ):
         del self.H, self.G  # memory management
 
         for t in range(weight.shape[-1]):
-            q_groups = self.get_quant_weights(t, 0, permutation_list, with_quant_history=True)
+            q_groups = self.get_quant_weight_history(t, permutation_list)
             for group_index in range(self.groups):
                 # t := time step (Lg, Lh, and Ds are re-ordered in time)
                 # i := input channel index (weight and error are not re-ordered)

--- a/src/brevitas/graph/gptq.py
+++ b/src/brevitas/graph/gptq.py
@@ -173,7 +173,7 @@ class GPTQ(GPxQ):
 
             h_inv_block = h_inv[:, i1:i2, i1:i2]
             for i in range(count):
-                q_groups = self.get_quant_weights(i, i1, permutation_list)  # [groups, OC/groups]
+                q_groups = self.get_quant_weight(i, i1, permutation_list)  # [groups, OC/groups]
                 for group_index in range(self.groups):
                     perm = permutation_list[group_index]
                     q = q_groups[group_index].to(self.dtype)  # [OC/groups]

--- a/src/brevitas/graph/gpxq.py
+++ b/src/brevitas/graph/gpxq.py
@@ -24,6 +24,7 @@ from brevitas.graph.utils import get_batch_dim
 from brevitas.graph.utils import is_conv_transposed
 from brevitas.graph.utils import is_quant_module
 import brevitas.nn as qnn
+from brevitas.nn.mixin import WeightRegion
 from brevitas.quant_tensor import _unpack_quant_tensor
 from brevitas.quant_tensor import QuantTensor
 from brevitas.utils.torch_utils import rename_tensor
@@ -36,6 +37,56 @@ SUPPORTED_CONV_OP = (
 class LayerHandler:
     layer_names: Set = field(default_factory=set)
     forward_count: int = 0
+
+
+class GPxQWeightReader:
+    """Read quantized weights in GPxQ's ``[groups, rows, columns]`` layout."""
+
+    def __init__(self, owner):
+        self.owner = owner
+
+    def _check_initialized(self):
+        for module in self.owner.layer.weight_quant.modules():
+            if hasattr(module, 'init_done') and not module.init_done:
+                raise RuntimeError(
+                    "Weight quantizer not initialized. Run a forward pass after quantization and try again."
+                )
+
+    def _full(self):
+        quant_weight = self.owner.layer.quant_weight(quant_input=self.owner.quant_metadata)
+        quant_weight = _unpack_quant_tensor(quant_weight)
+        if isinstance(self.owner.layer, qnn.QuantLinear):
+            return quant_weight.unsqueeze(0)
+        if is_conv_transposed(self.owner.layer):
+            quant_weight = quant_weight.transpose(1, 0)
+        quant_weight = quant_weight.flatten(1)
+        return quant_weight.view(self.owner.groups, -1, quant_weight.shape[-1])
+
+    def current(self, position, permutation_list):
+        """Return one current quantized column as ``[groups, rows, 1]``."""
+        self._check_initialized()
+        if isinstance(self.owner.layer, qnn.QuantLinear):
+            index = int(permutation_list[0][position])
+            region = WeightRegion((None, (index, index + 1)))
+            quant_weight = self.owner.layer.quant_weight_region(
+                region=region, quant_input=self.owner.quant_metadata)
+            return quant_weight.unsqueeze(0)
+
+        quant_weight = self._full()
+        columns = []
+        for group_index, permutation in enumerate(permutation_list):
+            index = permutation[position]
+            columns.append(quant_weight[group_index, :, index:index + 1])
+        return torch.stack(columns)
+
+    def history(self, end, permutation_list):
+        """Return the quantized permutation prefix as ``[groups, rows, end]``."""
+        self._check_initialized()
+        quant_weight = self._full()
+        history = []
+        for group_index, permutation in enumerate(permutation_list):
+            history.append(quant_weight[group_index].index_select(1, permutation[:end]))
+        return torch.stack(history)
 
 
 class gpxq_mode(quantization_status_manager):
@@ -230,6 +281,7 @@ class GPxQ(ABC):
         self.disable_pre_forward_hook = False
         # Some layers require knowledge from quant inputs to compute quant weights
         self.quant_metadata = None
+        self.weight_reader = GPxQWeightReader(self)
 
     @property
     def use_intermediate_buffer(self):
@@ -310,83 +362,8 @@ class GPxQ(ABC):
     def single_layer_update(self):
         pass
 
-    def get_quant_weights(self, i, i1, permutation_list, with_quant_history=False):
+    def get_quant_weight(self, i, i1, permutation_list):
+        return self.weight_reader.current(i1 + i, permutation_list).squeeze(2)
 
-        # If the weight quantizer has not been initialized, raise an error
-        for m in self.layer.weight_quant.modules():
-            if hasattr(m, 'init_done') and not m.init_done:
-                raise RuntimeError(
-                    "Weight quantizer not initialized. Run a forward pass after quantization and try again."
-                )
-
-        # We need to recompute quant weights at runtime since our float weights are being updated
-        # Add offset in case of blockwise computation
-        i = i1 + i
-
-        # For QuantLinear and for some QuantConvolutional layers, we exploit the possibility
-        # of quantizing only a subset of the entire matrix speeding up the computation of GPxQ
-        no_slice = False
-        # Groupwise Quantization does not support slicing
-        no_slice = no_slice or self.layer.weight_quant.is_groupwise
-        # If we need quantization of past channels, we do not use slicing
-        no_slice = no_slice or with_quant_history
-        # If we are in export mode (i.e., inference mode), we do not slice for torch.compile
-        # compatibility
-        no_slice = no_slice or self.layer.weight_quant.export_mode
-
-        if isinstance(self.layer, qnn.QuantLinear):
-            if no_slice:
-
-                # No slicing, not optimized
-                q = self.layer.quant_weight(quant_input=self.quant_metadata)
-                q = _unpack_quant_tensor(q).unsqueeze(0)  # [1, OC, IC]
-                if with_quant_history:
-                    return q[:, :, permutation_list[0][:i]]  # [1, OC, i]
-                index = permutation_list[0][i]  # only 1 group for linear layers
-                q = q[:, :, index:index + 1]  # [1, OC, 1]
-            else:
-                index = permutation_list[0][i]
-                subtensor_slice_list = [None, (index, index + 1)]
-                q = _unpack_quant_tensor(
-                    self.layer.quant_weight(
-                        subtensor_slice_list=subtensor_slice_list,
-                        quant_input=self.quant_metadata)).unsqueeze(0)  # [1, OC, 1]
-        elif isinstance(self.layer, SUPPORTED_CONV_OP):
-            # Depthwise and ConvTranspose does not support slicing
-            no_slice_conv = no_slice or (self.groups > 1 or is_conv_transposed(self.layer))
-
-            if no_slice_conv:
-
-                quant_weight = self.layer.quant_weight(quant_input=self.quant_metadata)
-                quant_weight = _unpack_quant_tensor(quant_weight)
-
-                if is_conv_transposed(self.layer):
-                    quant_weight = quant_weight.transpose(1, 0)  # This performs a view
-                quant_weight = quant_weight.flatten(1)
-                quant_weight = quant_weight.view(self.groups, -1, quant_weight.shape[-1])
-
-                if self.act_order:
-                    for ii, perm in enumerate(permutation_list):
-                        quant_weight[ii, :, :] = quant_weight[ii, :, perm]
-
-                if with_quant_history:
-                    return quant_weight[:, :, :i]  # [groups, OC/groups, i]
-                q = quant_weight[:, :, i:i + 1]  # [groups, OC/groups, 1]
-            else:
-                index = permutation_list[0][i]
-                shapes = self.layer.weight.shape[1:]
-                index_2d_to_nd = []
-                residual_index = index.item()
-                for shape in shapes[::-1]:
-                    index_2d_to_nd.append((residual_index % shape, residual_index % shape + 1))
-                    residual_index = residual_index // shape
-                index_2d_to_nd = index_2d_to_nd[::-1]
-                index_2d_to_nd.insert(0, None)
-                q = _unpack_quant_tensor(
-                    self.layer.quant_weight(
-                        subtensor_slice_list=index_2d_to_nd,
-                        quant_input=self.quant_metadata)).flatten(1)  # [OC, 1]
-                q = q.unsqueeze(0)  # [1, OC, 1]
-        # We need to remove the last dim
-        q = q.squeeze(2)  # [groups, OC/groups] or [1, OC]
-        return q
+    def get_quant_weight_history(self, end, permutation_list):
+        return self.weight_reader.history(end, permutation_list)

--- a/src/brevitas/graph/qronos.py
+++ b/src/brevitas/graph/qronos.py
@@ -103,6 +103,13 @@ class Qronos(GPFQ):
         if self.use_intermediate_buffer:
             del self.B  # free memory
 
+        def cleanup_and_offload(*buffer_names):
+            for buffer_name in buffer_names:
+                if hasattr(self, buffer_name):
+                    delattr(self, buffer_name)
+            if hasattr(self.layer, 'offload_params'):
+                self.layer.offload_params(self.layer)
+
         weight: Tensor = self.layer.weight.data
         weight_orig: Tensor = self.layer.weight_orig.data
         dev = weight.device
@@ -175,6 +182,7 @@ class Qronos(GPFQ):
                 f'Failed to compute the inverse of H for layer {self.name} '
                 f'Forward error correction will be a null operation. '
                 f'Increasing the number of samples might fix this issue.')
+            cleanup_and_offload('G', 'H', 'iH')
             return
 
         self.iH = self.iH.to(dev)
@@ -185,7 +193,7 @@ class Qronos(GPFQ):
         dtype_max = torch.finfo(dtype).max
 
         # Qronos - step 1
-        q_groups = self.get_quant_weights(0, 0, permutation_list, with_quant_history=True)
+        q_groups = self.get_quant_weight_history(0, permutation_list)
         for group_index in range(self.groups):
             perm = permutation_list[group_index]
             q: Tensor = q_groups[group_index].to(self.dtype)
@@ -197,6 +205,12 @@ class Qronos(GPFQ):
             assert (q_arg >= dtype_min).all() and (q_arg <= dtype_max).all()
             weight[group_index, :, perm[0]] = q_arg.to(dtype)
 
+        # The first-column update completes the algorithm when there are no remaining columns.
+        # Avoid constructing and factorizing an empty trailing inverse in that case.
+        if self.columns == 1:
+            cleanup_and_offload('G', 'H', 'iH')
+            return
+
         # Sherman-Morrison-Woodbury update rule
         A = self.iH[:, 1:, 1:]
         for group_index in range(self.groups):
@@ -205,7 +219,7 @@ class Qronos(GPFQ):
             A[group_index] -= (b.matmul(b.T)) / c
         self.iH = A
 
-        q_groups = self.get_quant_weights(0, 1, permutation_list, with_quant_history=True)
+        q_groups = self.get_quant_weight_history(1, permutation_list)
         for group_index in range(self.groups):
             perm = permutation_list[group_index]
             q: Tensor = q_groups[group_index].to(self.dtype)
@@ -229,6 +243,7 @@ class Qronos(GPFQ):
                 f'Failed to compute Cholesky decomposition for layer {self.name} '
                 f'Forward error correction will be a null operation. '
                 f'Increasing the number of samples might fix this issue.')
+            cleanup_and_offload('iH', 'L')
             return
         del self.iH  # memory management
 
@@ -243,7 +258,7 @@ class Qronos(GPFQ):
             # correct error within the block
             for i in range(count):
                 # error diffusion
-                q_groups = self.get_quant_weights(i, i1, permutation_list)  # [groups, OC/groups]
+                q_groups = self.get_quant_weight(i, i1, permutation_list)  # [groups, OC/groups]
                 for group_index in range(self.groups):
                     perm = permutation_list[group_index]
                     q = q_groups[group_index].to(self.dtype)  # [OC/groups]

--- a/src/brevitas/nn/mixin/__init__.py
+++ b/src/brevitas/nn/mixin/__init__.py
@@ -11,3 +11,4 @@ from .parameter import BiasQuantType
 from .parameter import QuantBiasMixin
 from .parameter import QuantWeightMixin
 from .parameter import WeightQuantType
+from .parameter import WeightRegion

--- a/src/brevitas/nn/mixin/parameter.py
+++ b/src/brevitas/nn/mixin/parameter.py
@@ -3,6 +3,7 @@
 
 from abc import ABCMeta
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -21,6 +22,28 @@ from .base import QuantProxyMixin
 
 WeightQuantType = Union[WeightQuantProxyProtocol, Type[Injector], Type[ExtendedInjector]]
 BiasQuantType = Union[BiasQuantProxyProtocol, Type[Injector], Type[ExtendedInjector]]
+
+
+@dataclass(frozen=True)
+class WeightRegion:
+    bounds: Tuple[Optional[Tuple[Optional[int], Optional[int]]], ...]
+
+    def normalize(self, shape) -> List[Tuple[int, int]]:
+        if len(self.bounds) != len(shape):
+            raise ValueError(
+                f"Expected {len(shape)} weight-region dimensions, received {len(self.bounds)}")
+        normalized = []
+        for dim, bound in zip(shape, self.bounds):
+            if bound is None:
+                normalized.append((0, dim))
+            else:
+                if len(bound) != 2:
+                    raise ValueError("Weight-region bounds must be (start, end) pairs")
+                start, end, step = slice(bound[0], bound[1]).indices(dim)
+                if step != 1:
+                    raise ValueError("Weight regions do not support strided slices")
+                normalized.append((start, end))
+        return normalized
 
 
 class QuantWeightMixin(QuantProxyMixin):
@@ -64,22 +87,43 @@ class QuantWeightMixin(QuantProxyMixin):
                     if hasattr(m, 'subtensor_slice_list'):
                         self._cached_sub_tensor_slice_list_modules.append(m)
                         m.subtensor_slice_list = subtensor_slice_list
-            # generate slices for the weight tensor based on the list passed in
+
+            # Generate slices for the weight tensor based on the list passed in.
             weight_slice_tuple = tuple(
                 slice(*s) if s is not None else slice(s) for s in subtensor_slice_list)
         else:
             weight_slice_tuple = slice(None)
-        if self.weight_quant.requires_quant_input:
-            out = self.weight_quant(weights_to_quantize[weight_slice_tuple], quant_input)
-        else:
-            out = self.weight_quant(weights_to_quantize[weight_slice_tuple])
-        if subtensor_slice_list is not None:
-            # Restore the quantizer behaviour to full tensor quantization
-            # The modules to slice should have been cached already at this point
-            assert self._cached_sub_tensor_slice_list_modules is not None, "Missing cache of modules to slice."
-            for m in self._cached_sub_tensor_slice_list_modules:
-                m.subtensor_slice_list = [None]
+        try:
+            if self.weight_quant.requires_quant_input:
+                out = self.weight_quant(weights_to_quantize[weight_slice_tuple], quant_input)
+            else:
+                out = self.weight_quant(weights_to_quantize[weight_slice_tuple])
+        finally:
+            if subtensor_slice_list is not None:
+                # Restore the quantizer behaviour to full tensor quantization.
+                assert self._cached_sub_tensor_slice_list_modules is not None, \
+                    "Missing cache of modules to slice."
+                for m in self._cached_sub_tensor_slice_list_modules:
+                    m.subtensor_slice_list = [None]
         return out
+
+    def quant_weight_region(self, region: WeightRegion, quant_input: Optional[QuantTensor] = None):
+        """Return a dequantized region equivalent to full quantization followed by slicing."""
+        bounds = region.normalize(self.weight.shape)
+        weight = self.weight
+        if not self.weight_quant.is_quant_enabled and hasattr(self, 'weight_orig'):
+            weight = self.weight_orig.to(self.weight.device)
+        supports_region = getattr(self.weight_quant, 'supports_quant_weight_region', False)
+        quantize_region = getattr(self.weight_quant, 'quantize_weight_region', None)
+        out = quantize_region(
+            weight, bounds,
+            quant_input) if supports_region and quantize_region is not None else None
+        if out is not None:
+            return out
+        out = self.quant_weight(quant_input=quant_input)
+        out = out.value if isinstance(out, QuantTensor) else out
+        slices = tuple(slice(start, end) for start, end in bounds)
+        return out[slices]
 
     def register_parameter(self, name, value):
         super(QuantWeightMixin, self).register_parameter(name, value)

--- a/src/brevitas/proxy/groupwise_float_parameter_quant.py
+++ b/src/brevitas/proxy/groupwise_float_parameter_quant.py
@@ -54,10 +54,13 @@ class GroupwiseWeightFloatQuantProxyFromInjector(WeightFloatQuantProxyFromInject
         start_dim = self.group_dim if self.group_dim >= 0 else self.group_dim - 1
         return x.flatten(start_dim, start_dim + 1)
 
+    def _region_components_ready(self):
+        return bool(getattr(self.tensor_quant.scaling_impl, 'init_done', True))
+
     def quantize_weight_group(self, weight: torch.Tensor,
                               group_index: int) -> Optional[torch.Tensor]:
-        if (not self.supports_quant_weight_region or not self.is_quant_enabled or
-                self.export_mode or self.training):
+        if (not self.supports_quant_weight_region or not self._region_components_ready() or
+                not self.is_quant_enabled or self.export_mode or self.training):
             return None
         if weight.ndim != 2 or self.group_dim != 1 or self.region_quant is None:
             return None
@@ -66,7 +69,8 @@ class GroupwiseWeightFloatQuantProxyFromInjector(WeightFloatQuantProxyFromInject
             return None
         group, logical_group_size = extract_groupwise_block(
             weight, self.group_dim, self.group_size, group_index)
-        quantized_group = self.region_quant(group)[0]
+        group_index_tensor = torch.tensor(group_index, device=weight.device)
+        quantized_group = self.region_quant(group, group_index_tensor, self.group_dim)[0]
         quantized_group = quantized_group.squeeze(self.group_dim)
         return quantized_group.narrow(self.group_dim, 0, logical_group_size)
 

--- a/src/brevitas/proxy/groupwise_float_parameter_quant.py
+++ b/src/brevitas/proxy/groupwise_float_parameter_quant.py
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Any
+from typing import List
+from typing import Optional
 from typing import Tuple
 
+import torch
 import torch.nn as nn
 
+from brevitas.core.function_wrapper.shape import extract_groupwise_block
 from brevitas.inject import BaseInjector as Injector
 from brevitas.proxy.float_parameter_quant import WeightFloatQuantProxyFromInjectorBase
 from brevitas.quant_tensor import GroupwiseFloatQuantTensor
@@ -17,6 +21,19 @@ class GroupwiseWeightFloatQuantProxyFromInjector(WeightFloatQuantProxyFromInject
     def __init__(self, quant_layer: nn.Module, quant_injector: Injector) -> None:
         super().__init__(quant_layer, quant_injector)
         self.cache_class = _CachedIOGroupwiseFloat
+        self._refresh_region_quant()
+
+    def _refresh_region_quant(self):
+        self.supports_quant_weight_region = (
+            bool(getattr(self.tensor_quant.scaling_impl, 'supports_groupwise_region', False)) and
+            self.rounding_mode != 'STOCHASTIC_ROUND')
+        self.region_quant = self.tensor_quant.forward_group if self.supports_quant_weight_region else None
+        self.is_region_quant_compiled = False
+
+    def init_tensor_quant(self, preserve_state_dict=False):
+        super().init_tensor_quant(preserve_state_dict)
+        if hasattr(self, 'region_quant'):
+            self._refresh_region_quant()
 
     def scale_(self):
         return self.retrieve_attribute('scale_')
@@ -36,6 +53,43 @@ class GroupwiseWeightFloatQuantProxyFromInjector(WeightFloatQuantProxyFromInject
         x = super().apply_input_view(x)
         start_dim = self.group_dim if self.group_dim >= 0 else self.group_dim - 1
         return x.flatten(start_dim, start_dim + 1)
+
+    def quantize_weight_group(self, weight: torch.Tensor,
+                              group_index: int) -> Optional[torch.Tensor]:
+        if (not self.supports_quant_weight_region or not self.is_quant_enabled or
+                self.export_mode or self.training):
+            return None
+        if weight.ndim != 2 or self.group_dim != 1 or self.region_quant is None:
+            return None
+        group_start = group_index * self.group_size
+        if group_index < 0 or group_start >= weight.shape[self.group_dim]:
+            return None
+        group, logical_group_size = extract_groupwise_block(
+            weight, self.group_dim, self.group_size, group_index)
+        quantized_group = self.region_quant(group)[0]
+        quantized_group = quantized_group.squeeze(self.group_dim)
+        return quantized_group.narrow(self.group_dim, 0, logical_group_size)
+
+    def quantize_weight_region(
+            self,
+            weight: torch.Tensor,
+            bounds: List[Tuple[int, int]],
+            quant_input=None) -> Optional[torch.Tensor]:
+        if weight.ndim != 2 or len(bounds) != 2:
+            return None
+        row_start, row_end = bounds[0]
+        col_start, col_end = bounds[1]
+        if col_start == col_end:
+            return weight[row_start:row_end, col_start:col_end]
+        group_index = col_start // self.group_size
+        group_start = group_index * self.group_size
+        group_end = min(group_start + self.group_size, weight.shape[1])
+        if col_end > group_end:
+            return None
+        group = self.quantize_weight_group(weight, group_index)
+        if group is None:
+            return None
+        return group[row_start:row_end, col_start - group_start:col_end - group_start]
 
     def create_quant_tensor(self, qt_args: Tuple[Any]) -> GroupwiseFloatQuantTensor:
         shape = self.tracked_parameter_list[0].shape

--- a/src/brevitas/proxy/groupwise_int_parameter_quant.py
+++ b/src/brevitas/proxy/groupwise_int_parameter_quant.py
@@ -55,10 +55,15 @@ class GroupwiseWeightQuantProxyFromInjector(WeightQuantProxyFromInjector):
         start_dim = self.group_dim if self.group_dim >= 0 else self.group_dim - 1
         return x.flatten(start_dim, start_dim + 1)
 
+    def _region_components_ready(self):
+        scale_ready = getattr(self.tensor_quant.scaling_impl, 'init_done', True)
+        zero_point_ready = getattr(self.tensor_quant.zero_point_impl, 'init_done', True)
+        return bool(scale_ready) and bool(zero_point_ready)
+
     def quantize_weight_group(self, weight: torch.Tensor,
                               group_index: int) -> Optional[torch.Tensor]:
-        if (not self.supports_quant_weight_region or not self.is_quant_enabled or
-                self.export_mode or self.training):
+        if (not self.supports_quant_weight_region or not self._region_components_ready() or
+                not self.is_quant_enabled or self.export_mode or self.training):
             return None
         if weight.ndim != 2 or self.group_dim != 1 or self.region_quant is None:
             return None
@@ -67,7 +72,8 @@ class GroupwiseWeightQuantProxyFromInjector(WeightQuantProxyFromInjector):
             return None
         group, logical_group_size = extract_groupwise_block(
             weight, self.group_dim, self.group_size, group_index)
-        quantized_group = self.region_quant(group)[0]
+        group_index_tensor = torch.tensor(group_index, device=weight.device)
+        quantized_group = self.region_quant(group, group_index_tensor, self.group_dim)[0]
         quantized_group = quantized_group.squeeze(self.group_dim)
         return quantized_group.narrow(self.group_dim, 0, logical_group_size)
 

--- a/src/brevitas/proxy/groupwise_int_parameter_quant.py
+++ b/src/brevitas/proxy/groupwise_int_parameter_quant.py
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Any
+from typing import List
+from typing import Optional
 from typing import Tuple
 
+import torch
 import torch.nn as nn
 
+from brevitas.core.function_wrapper.shape import extract_groupwise_block
 from brevitas.inject import BaseInjector as Injector
 from brevitas.proxy.parameter_quant import WeightQuantProxyFromInjector
 from brevitas.quant_tensor import GroupwiseIntQuantTensor
@@ -17,6 +21,20 @@ class GroupwiseWeightQuantProxyFromInjector(WeightQuantProxyFromInjector):
     def __init__(self, quant_layer: nn.Module, quant_injector: Injector) -> None:
         super().__init__(quant_layer, quant_injector)
         self.cache_class = _CachedIOGroupwiseInt
+        self._refresh_region_quant()
+
+    def _refresh_region_quant(self):
+        self.supports_quant_weight_region = (
+            bool(getattr(self.tensor_quant.scaling_impl, 'supports_groupwise_region', False)) and
+            bool(getattr(self.tensor_quant.zero_point_impl, 'supports_groupwise_region', False)) and
+            self.rounding_mode != 'STOCHASTIC_ROUND')
+        self.region_quant = self.tensor_quant.forward_group if self.supports_quant_weight_region else None
+        self.is_region_quant_compiled = False
+
+    def init_tensor_quant(self, preserve_state_dict=False):
+        super().init_tensor_quant(preserve_state_dict)
+        if hasattr(self, 'region_quant'):
+            self._refresh_region_quant()
 
     def scale_(self):
         return self.retrieve_attribute('scale_')
@@ -36,6 +54,43 @@ class GroupwiseWeightQuantProxyFromInjector(WeightQuantProxyFromInjector):
         x = super().apply_input_view(x)
         start_dim = self.group_dim if self.group_dim >= 0 else self.group_dim - 1
         return x.flatten(start_dim, start_dim + 1)
+
+    def quantize_weight_group(self, weight: torch.Tensor,
+                              group_index: int) -> Optional[torch.Tensor]:
+        if (not self.supports_quant_weight_region or not self.is_quant_enabled or
+                self.export_mode or self.training):
+            return None
+        if weight.ndim != 2 or self.group_dim != 1 or self.region_quant is None:
+            return None
+        group_start = group_index * self.group_size
+        if group_index < 0 or group_start >= weight.shape[self.group_dim]:
+            return None
+        group, logical_group_size = extract_groupwise_block(
+            weight, self.group_dim, self.group_size, group_index)
+        quantized_group = self.region_quant(group)[0]
+        quantized_group = quantized_group.squeeze(self.group_dim)
+        return quantized_group.narrow(self.group_dim, 0, logical_group_size)
+
+    def quantize_weight_region(
+            self,
+            weight: torch.Tensor,
+            bounds: List[Tuple[int, int]],
+            quant_input=None) -> Optional[torch.Tensor]:
+        if weight.ndim != 2 or len(bounds) != 2:
+            return None
+        row_start, row_end = bounds[0]
+        col_start, col_end = bounds[1]
+        if col_start == col_end:
+            return weight[row_start:row_end, col_start:col_end]
+        group_index = col_start // self.group_size
+        group_start = group_index * self.group_size
+        group_end = min(group_start + self.group_size, weight.shape[1])
+        if col_end > group_end:
+            return None
+        group = self.quantize_weight_group(weight, group_index)
+        if group is None:
+            return None
+        return group[row_start:row_end, col_start - group_start:col_end - group_start]
 
     def create_quant_tensor(self, qt_args: Tuple[Any]) -> GroupwiseIntQuantTensor:
         shape = self.tracked_parameter_list[0].shape

--- a/src/brevitas/proxy/parameter_quant.py
+++ b/src/brevitas/proxy/parameter_quant.py
@@ -99,15 +99,35 @@ class WeightQuantProxyFromInjectorBase(ParameterQuantProxyFromInjector,
         self.cache_class = None  # To be redefined by each class
         self.quant_tensor_class = None  # To be redefined by each class
         self.skip_create_quant_tensor = False
+        self.supports_quant_weight_region = False
+        self.region_quant = None
+        self.is_region_quant_compiled = False
 
     def compile_quant(self, compile_export=False):
         if compile_export and hasattr(self, 'export_handler') and self.export_handler is not None:
             self.export_handler.inner_forward = torch.compile(
                 self.export_handler.inner_forward, dynamic=True, fullgraph=True)
         elif self.tensor_quant is not None:
+            if self.region_quant is not None:
+                self.region_quant = torch.compile(
+                    self.region_quant, dynamic=True, fullgraph=not self.is_groupwise)
+                self.is_region_quant_compiled = True
             # For groupwise weight quantization, we have graph breaks
             fullgraph = not self.is_groupwise
             self.tensor_quant = torch.compile(self.tensor_quant, dynamic=True, fullgraph=fullgraph)
+
+    def quantize_weight_group(self, weight: torch.Tensor,
+                              group_index: int) -> Optional[torch.Tensor]:
+        """Return one exactly quantized physical group, or ``None`` when unsupported."""
+        return None
+
+    def quantize_weight_region(
+            self,
+            weight: torch.Tensor,
+            bounds: List[Tuple[int, int]],
+            quant_input: Optional[QuantTensor] = None) -> Optional[torch.Tensor]:
+        """Return an exact dequantized weight region, or ``None`` to request full fallback."""
+        return None
 
     @property
     def is_proxy_compiled(self):

--- a/src/brevitas_examples/common/axe.py
+++ b/src/brevitas_examples/common/axe.py
@@ -376,7 +376,7 @@ class A2GPTQ(AXEMixin, GPTQ):
                         q_arg.abs() - thresholds[group_index, block_index])
                     q_arg.clamp_(q_min, q_max)  # clamping to bounds
                     weight[group_index, :, perm[i1:i2][i]] = q_arg.to(dtype)
-                q_groups = self.get_quant_weights(i, i1, permutation_list)  # [Groups, OC/groups]
+                q_groups = self.get_quant_weight(i, i1, permutation_list)  # [Groups, OC/groups]
                 for group_index in range(self.groups):
                     perm = permutation_list[group_index]
                     q = q_groups[group_index].to(self.dtype)  # [OC/groups]
@@ -533,7 +533,7 @@ class A2GPFQ(AXEMixin, GPFQ):
         max_limits = ((2 ** (self.max_accumulator_bit_width.to(lim_dtype) - 1)) - 1)
 
         for t in range(weight.shape[-1]):
-            q_groups = self.get_quant_weights(t, 0, permutation_list, with_quant_history=True)
+            q_groups = self.get_quant_weight_history(t, permutation_list)
             for group_index in range(self.groups):
                 # t := time step (Lg, Lh, and Ds are re-ordered in time)
                 # i := input channel index (weight and error are not re-ordered)
@@ -565,7 +565,7 @@ class A2GPFQ(AXEMixin, GPFQ):
                 weight[group_index, :, i] = q_arg.to(dtype)
 
             # update the tracking mechanisms
-            q_groups = self.get_quant_weights(t, 0, permutation_list)  # [Groups, OC/groups]
+            q_groups = self.get_quant_weight(t, 0, permutation_list)  # [Groups, OC/groups]
             for group_index in range(self.groups):
                 i = permutation_list[group_index][t]
                 block_index = get_block_index(i)  # block index

--- a/tests/brevitas/graph/test_gpxq.py
+++ b/tests/brevitas/graph/test_gpxq.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 from torch.utils.data import DataLoader
 from torch.utils.data import TensorDataset
 
+from brevitas.core.zero_point import ParameterFromStatsFromParameterZeroPoint
 from brevitas.graph.gpfq import GPFQ
 from brevitas.graph.gpfq import gpfq_mode
 from brevitas.graph.gptq import gptq_mode
@@ -23,6 +24,7 @@ from brevitas.quant.mx_quant_ocp import MXFloat8e4m3Weight
 from brevitas.quant.mx_quant_ocp import MXInt8Weight
 from brevitas.quant.scaled_int import Int8WeightPerChannelFloat
 from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
+from brevitas.quant.shifted_scaled_int import ShiftedUint8WeightGroupQuantFloat
 from brevitas_examples.common.axe import a2gpfq_mode
 from brevitas_examples.common.axe import a2gptq_mode
 from brevitas_examples.common.axe import AXEMixin
@@ -594,12 +596,13 @@ def test_gptq_linear_region_quantization_non_groupwise(monkeypatch, weight_quant
 
 
 @torch.no_grad()
-def test_groupwise_weight_region_unsupported_quantizer_falls_back(monkeypatch):
+def test_groupwise_parameter_from_stats_region_initializes_then_uses_fast_path(monkeypatch):
     weight_quant = MXInt8Weight.let(scaling_impl_type='parameter_from_stats')
     layer = qnn.QuantLinear(33, 4, bias=False, weight_quant=weight_quant)
     layer.eval()
-    layer(torch.randn(2, 33))
-    assert not layer.weight_quant.supports_quant_weight_region
+    scaling_impl = layer.weight_quant.tensor_quant.scaling_impl
+    assert layer.weight_quant.supports_quant_weight_region
+    assert not scaling_impl.init_done
 
     full_calls = 0
     quant_weight = layer.quant_weight
@@ -610,10 +613,79 @@ def test_groupwise_weight_region_unsupported_quantizer_falls_back(monkeypatch):
         return quant_weight(*args, **kwargs)
 
     monkeypatch.setattr(layer, 'quant_weight', record_quant_weight)
-    expected = quant_weight().value[:, 7:8]
-    actual = layer.quant_weight_region(WeightRegion((None, (7, 8))))
+    first = layer.quant_weight_region(WeightRegion((None, (7, 8))))
 
     assert full_calls == 1
+    assert scaling_impl.init_done
+    expected = quant_weight().value[:, 7:8]
+    torch.testing.assert_close(first, expected)
+
+    def fail_full_quantization(*args, **kwargs):
+        raise AssertionError("Initialized parameter-from-stats region used full quantization")
+
+    monkeypatch.setattr(layer, 'quant_weight', fail_full_quantization)
+    actual = layer.quant_weight_region(WeightRegion((None, (7, 8))))
+    torch.testing.assert_close(actual, expected)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("quantize_zero_point", [True, False])
+def test_groupwise_asymmetric_weight_region(monkeypatch, quantize_zero_point):
+    weight_quant = ShiftedUint8WeightGroupQuantFloat.let(
+        group_size=32, quantize_zero_point=quantize_zero_point)
+    layer = qnn.QuantLinear(33, 4, bias=False, weight_quant=weight_quant)
+    with torch.no_grad():
+        layer.weight.copy_(torch.linspace(-2.0, 3.0, layer.weight.numel()).view_as(layer.weight))
+    layer.eval()
+    layer(torch.randn(2, 33))
+    assert layer.weight_quant.supports_quant_weight_region
+    full_quant_weight = layer.quant_weight().value
+    quant_weight = layer.quant_weight
+
+    def fail_full_quantization(*args, **kwargs):
+        raise AssertionError("Asymmetric region used full-weight quantization")
+
+    monkeypatch.setattr(layer, 'quant_weight', fail_full_quantization)
+    for index in (0, 31, 32):
+        actual = layer.quant_weight_region(WeightRegion((None, (index, index + 1))))
+        torch.testing.assert_close(actual, full_quant_weight[:, index:index + 1])
+    monkeypatch.setattr(layer, 'quant_weight', quant_weight)
+
+
+@torch.no_grad()
+def test_groupwise_asymmetric_parameter_from_stats_region(monkeypatch):
+    weight_quant = ShiftedUint8WeightGroupQuantFloat.let(
+        group_size=32,
+        scaling_impl_type='parameter_from_stats',
+        zero_point_impl=ParameterFromStatsFromParameterZeroPoint)
+    layer = qnn.QuantLinear(33, 4, bias=False, weight_quant=weight_quant)
+    layer.eval()
+    scaling_impl = layer.weight_quant.tensor_quant.scaling_impl
+    zero_point_impl = layer.weight_quant.tensor_quant.zero_point_impl
+    assert not scaling_impl.init_done
+    assert not zero_point_impl.init_done
+
+    full_calls = 0
+    quant_weight = layer.quant_weight
+
+    def record_quant_weight(*args, **kwargs):
+        nonlocal full_calls
+        full_calls += 1
+        return quant_weight(*args, **kwargs)
+
+    monkeypatch.setattr(layer, 'quant_weight', record_quant_weight)
+    first = layer.quant_weight_region(WeightRegion((None, (32, 33))))
+    assert full_calls == 1
+    assert scaling_impl.init_done
+    assert zero_point_impl.init_done
+    expected = quant_weight().value[:, 32:33]
+    torch.testing.assert_close(first, expected)
+
+    def fail_full_quantization(*args, **kwargs):
+        raise AssertionError("Initialized asymmetric stateful region used full quantization")
+
+    monkeypatch.setattr(layer, 'quant_weight', fail_full_quantization)
+    actual = layer.quant_weight_region(WeightRegion((None, (32, 33))))
     torch.testing.assert_close(actual, expected)
 
 
@@ -663,7 +735,11 @@ def test_groupwise_weight_region_training_falls_back(monkeypatch):
 
 @torch.no_grad()
 @pytest.mark.parametrize(
-    "weight_quant", [IntWeightSymmetricGroupQuant, Fp8e4m3WeightSymmetricGroupQuant])
+    "weight_quant",
+    [
+        IntWeightSymmetricGroupQuant,
+        Fp8e4m3WeightSymmetricGroupQuant,
+        ShiftedUint8WeightGroupQuantFloat])
 def test_qronos_groupwise_linear_uses_region_quantization(monkeypatch, weight_quant):
     torch.manual_seed(SEED)
     model = nn.Sequential(

--- a/tests/brevitas/graph/test_gpxq.py
+++ b/tests/brevitas/graph/test_gpxq.py
@@ -18,10 +18,16 @@ from brevitas.graph.gpxq import SUPPORTED_CONV_OP
 from brevitas.graph.magr import magr_mode
 from brevitas.graph.qronos import Qronos
 import brevitas.nn as qnn
+from brevitas.nn.mixin import WeightRegion
+from brevitas.quant.mx_quant_ocp import MXFloat8e4m3Weight
+from brevitas.quant.mx_quant_ocp import MXInt8Weight
+from brevitas.quant.scaled_int import Int8WeightPerChannelFloat
 from brevitas.quant.scaled_int import Int8WeightPerTensorFloat
 from brevitas_examples.common.axe import a2gpfq_mode
 from brevitas_examples.common.axe import a2gptq_mode
 from brevitas_examples.common.axe import AXEMixin
+from brevitas_examples.common.generative.quantizers import Fp8e4m3WeightSymmetricGroupQuant
+from brevitas_examples.common.generative.quantizers import IntWeightSymmetricGroupQuant
 
 from .equalization_fixtures import *
 
@@ -291,6 +297,51 @@ class TestQronosUpdateBatch:
                         torch.testing.assert_close(data, data_before)
 
 
+@torch.no_grad()
+@pytest.mark.parametrize("act_order", [True, False])
+def test_qronos_single_column_update_cleans_buffers_and_offloads(monkeypatch, act_order):
+    torch.manual_seed(SEED)
+    model = nn.Sequential(qnn.QuantLinear(1, 3, bias=False, weight_quant=MXInt8Weight))
+    inp = torch.randn(8, 1)
+    model.eval()
+    model(inp)  # Initialize the weight quantizer.
+
+    layer = model[0]
+    weight_before = layer.weight.detach().clone()
+    offload_calls = []
+    monkeypatch.setattr(
+        layer, 'offload_params', lambda module: offload_calls.append(module), raising=False)
+
+    cholesky = torch.linalg.cholesky
+    cholesky_inverse = torch.cholesky_inverse
+    factorized_shapes = []
+
+    def record_cholesky(matrix, *args, **kwargs):
+        factorized_shapes.append(matrix.shape[-2:])
+        assert matrix.shape[-1] > 0
+        return cholesky(matrix, *args, **kwargs)
+
+    def record_cholesky_inverse(matrix, *args, **kwargs):
+        assert matrix.shape[-1] > 0
+        return cholesky_inverse(matrix, *args, **kwargs)
+
+    monkeypatch.setattr(torch.linalg, 'cholesky', record_cholesky)
+    monkeypatch.setattr(torch, 'cholesky_inverse', record_cholesky_inverse)
+
+    with gpfq_mode(model, act_order=act_order, algorithm_impl=Qronos) as algo:
+        algo.model(inp)
+        qronos = algo.gpxq_layers['0']
+        assert qronos.columns == 1
+        algo.update()
+
+    assert factorized_shapes == [torch.Size([1, 1])]
+    assert offload_calls == [layer]
+    for buffer_name in ('B', 'G', 'H', 'iH', 'L'):
+        assert not hasattr(qronos, buffer_name)
+    torch.testing.assert_close(layer.weight, weight_before)
+    assert torch.isfinite(model(inp)).all()
+
+
 @pytest.mark.parametrize("act_order", [True, False])
 @pytest.mark.parametrize("use_quant_activations", [True, False])
 @pytest.mark.parametrize(
@@ -446,6 +497,195 @@ def test_gpxq_quant_mha(quant_mha_gpxq_model, gpxq_key):
     with torch.no_grad():
         out = model(inp[:MHA_BATCH_SIZE])
     assert torch.isfinite(out).all()
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("act_order", [True, False])
+@pytest.mark.parametrize(
+    "weight_quant",
+    [
+        MXInt8Weight,
+        MXFloat8e4m3Weight,
+        IntWeightSymmetricGroupQuant,
+        Fp8e4m3WeightSymmetricGroupQuant])
+def test_gptq_groupwise_linear_single_column_slicing(monkeypatch, act_order, weight_quant):
+    # The final input feature belongs to a padded group, while the first input feature belongs to
+    # a full group. Both slices must use the scale calculated from their complete group.
+    torch.manual_seed(SEED)
+    model = nn.Sequential(
+        qnn.QuantLinear(33, 4, bias=False, weight_quant=weight_quant.let(group_size=32)))
+    inp = torch.randn(8, 33)
+    model.eval()
+    model(inp)  # Initialize groupwise quantizer state.
+
+    layer = model[0]
+    assert layer.weight_quant.supports_quant_weight_region
+    full_quant_weight = layer.quant_weight().value
+    for index in (0, 32):
+        quant_column = layer.quant_weight_region(WeightRegion((None, (index, index + 1))))
+        assert quant_column.shape == (4, 1)
+        torch.testing.assert_close(quant_column, full_quant_weight[:, index:index + 1])
+    quant_block = layer.quant_weight_region(WeightRegion(((1, 3), (32, 33))))
+    torch.testing.assert_close(quant_block, full_quant_weight[1:3, 32:33])
+
+    group_calls = []
+    quantize_weight_group = layer.weight_quant.quantize_weight_group
+
+    def record_quantize_weight_group(*args, **kwargs):
+        out = quantize_weight_group(*args, **kwargs)
+        group_calls.append(out is not None)
+        return out
+
+    monkeypatch.setattr(layer.weight_quant, 'quantize_weight_group', record_quantize_weight_group)
+
+    region_calls = []
+    quant_weight_region = layer.quant_weight_region
+    quant_weight = layer.quant_weight
+
+    def record_quant_weight_region(*args, **kwargs):
+        region_calls.append(kwargs.get('region'))
+        return quant_weight_region(*args, **kwargs)
+
+    monkeypatch.setattr(layer, 'quant_weight_region', record_quant_weight_region)
+    with gptq_mode(model, act_order=act_order, num_blocks=4) as gptq:
+        gptq.model(inp)
+
+        def fail_full_quantization(*args, **kwargs):
+            raise AssertionError("GPTQ groupwise update used full-weight quantization")
+
+        monkeypatch.setattr(layer, 'quant_weight', fail_full_quantization)
+        gptq.update()
+
+    assert any(call is not None for call in region_calls)
+    assert group_calls and all(group_calls)
+    monkeypatch.setattr(layer, 'quant_weight', quant_weight)
+    assert torch.isfinite(model(inp)).all()
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("weight_quant", [Int8WeightPerTensorFloat, Int8WeightPerChannelFloat])
+def test_gptq_linear_region_quantization_non_groupwise(monkeypatch, weight_quant):
+    torch.manual_seed(SEED)
+    model = nn.Sequential(qnn.QuantLinear(33, 4, bias=False, weight_quant=weight_quant))
+    inp = torch.randn(8, 33)
+    model.eval()
+    model(inp)
+
+    layer = model[0]
+    full_quant_weight = layer.quant_weight().value
+    quant_column = layer.quant_weight_region(WeightRegion((None, (7, 8))))
+    assert quant_column.shape == (4, 1)
+    torch.testing.assert_close(quant_column, full_quant_weight[:, 7:8])
+
+    region_calls = []
+    quant_weight_region = layer.quant_weight_region
+
+    def record_quant_weight_region(*args, **kwargs):
+        region_calls.append(kwargs.get('region'))
+        return quant_weight_region(*args, **kwargs)
+
+    monkeypatch.setattr(layer, 'quant_weight_region', record_quant_weight_region)
+    with gptq_mode(model, act_order=False, num_blocks=4) as gptq:
+        gptq.model(inp)
+        gptq.update()
+
+    assert any(call is not None for call in region_calls)
+    assert torch.isfinite(model(inp)).all()
+
+
+@torch.no_grad()
+def test_groupwise_weight_region_unsupported_quantizer_falls_back(monkeypatch):
+    weight_quant = MXInt8Weight.let(scaling_impl_type='parameter_from_stats')
+    layer = qnn.QuantLinear(33, 4, bias=False, weight_quant=weight_quant)
+    layer.eval()
+    layer(torch.randn(2, 33))
+    assert not layer.weight_quant.supports_quant_weight_region
+
+    full_calls = 0
+    quant_weight = layer.quant_weight
+
+    def record_quant_weight(*args, **kwargs):
+        nonlocal full_calls
+        full_calls += 1
+        return quant_weight(*args, **kwargs)
+
+    monkeypatch.setattr(layer, 'quant_weight', record_quant_weight)
+    expected = quant_weight().value[:, 7:8]
+    actual = layer.quant_weight_region(WeightRegion((None, (7, 8))))
+
+    assert full_calls == 1
+    torch.testing.assert_close(actual, expected)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("weight_quant", [MXInt8Weight, MXFloat8e4m3Weight])
+def test_groupwise_cross_group_region_falls_back(monkeypatch, weight_quant):
+    layer = qnn.QuantLinear(33, 4, bias=False, weight_quant=weight_quant)
+    layer.eval()
+    layer(torch.randn(2, 33))
+    expected = layer.quant_weight().value[1:3, 31:33]
+    full_calls = 0
+    quant_weight = layer.quant_weight
+
+    def record_quant_weight(*args, **kwargs):
+        nonlocal full_calls
+        full_calls += 1
+        return quant_weight(*args, **kwargs)
+
+    monkeypatch.setattr(layer, 'quant_weight', record_quant_weight)
+    actual = layer.quant_weight_region(WeightRegion(((1, 3), (31, 33))))
+
+    assert full_calls == 1
+    torch.testing.assert_close(actual, expected)
+
+
+@torch.no_grad()
+def test_groupwise_weight_region_training_falls_back(monkeypatch):
+    layer = qnn.QuantLinear(33, 4, bias=False, weight_quant=MXInt8Weight)
+    layer.eval()
+    layer(torch.randn(2, 33))
+    expected = layer.quant_weight().value[:, 7:8]
+    layer.train()
+    full_calls = 0
+    quant_weight = layer.quant_weight
+
+    def record_quant_weight(*args, **kwargs):
+        nonlocal full_calls
+        full_calls += 1
+        return quant_weight(*args, **kwargs)
+
+    monkeypatch.setattr(layer, 'quant_weight', record_quant_weight)
+    actual = layer.quant_weight_region(WeightRegion((None, (7, 8))))
+
+    assert full_calls == 1
+    torch.testing.assert_close(actual, expected)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "weight_quant", [IntWeightSymmetricGroupQuant, Fp8e4m3WeightSymmetricGroupQuant])
+def test_qronos_groupwise_linear_uses_region_quantization(monkeypatch, weight_quant):
+    torch.manual_seed(SEED)
+    model = nn.Sequential(
+        qnn.QuantLinear(33, 4, bias=False, weight_quant=weight_quant.let(group_size=32)))
+    inp = torch.randn(8, 33)
+    model.eval()
+    model(inp)
+    layer = model[0]
+    group_calls = 0
+    quantize_weight_group = layer.weight_quant.quantize_weight_group
+
+    def record_quantize_weight_group(*args, **kwargs):
+        nonlocal group_calls
+        group_calls += 1
+        return quantize_weight_group(*args, **kwargs)
+
+    monkeypatch.setattr(layer.weight_quant, 'quantize_weight_group', record_quantize_weight_group)
+    loader = DataLoader(TensorDataset(inp, inp), batch_size=4)
+    apply_qronos(calib_loader=loader, model=model, act_order=False, use_quant_activations=False)
+
+    assert group_calls > 0
+    assert torch.isfinite(model(inp)).all()
 
 
 class _MockAXEMixin(AXEMixin):

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -12,7 +12,9 @@ import torch
 
 from brevitas import torch_version
 from brevitas.export.inference import quant_inference_mode
+from brevitas.graph.gptq import gptq_mode
 import brevitas.nn as qnn
+from brevitas.nn.mixin import WeightRegion
 from brevitas.quant import Int8ActPerTensorFloat
 from brevitas.quant import Int8WeightPerTensorFloat
 from brevitas.quant import ShiftedUint8ActPerTensorFloat
@@ -25,6 +27,8 @@ from brevitas.quant.mx_quant_ocp import MXInt8Act
 from brevitas.quant.mx_quant_ocp import MXInt8Weight
 from brevitas_examples.common.generative.quantize import Int8DynamicActPerTensorFloat
 from brevitas_examples.common.generative.quantizers import FP8e4m3OCPDynamicActPerRowFloat
+from brevitas_examples.common.generative.quantizers import Fp8e4m3WeightSymmetricGroupQuant
+from brevitas_examples.common.generative.quantizers import IntWeightSymmetricGroupQuant
 from tests.brevitas.hyp_helper import float_tensor_st
 from tests.marker import jit_disabled_for_compile
 from tests.marker import requires_pt_ge
@@ -82,6 +86,76 @@ def test_compile_weight(weight, weight_quantizer):
         inference_out = linear.quant_weight()
     assert torch.allclose(out, quant_out)
     assert torch.allclose(out, inference_out)
+
+
+@pytest.mark.parametrize(
+    'weight_quantizer',
+    [
+        MXInt8Weight,
+        MXFloat8e4m3Weight,
+        IntWeightSymmetricGroupQuant.let(group_size=32),
+        Fp8e4m3WeightSymmetricGroupQuant.let(group_size=32)])
+@requires_pt_ge('2.3.1')
+@requires_torch_compile()
+@jit_disabled_for_compile()
+def test_compile_groupwise_weight_region(monkeypatch, weight_quantizer):
+    if platform.system() == "Windows":
+        pytest.skip("Skip compile + windows because of unknown failure")
+    if version.parse('2.5.0') <= torch_version < version.parse('2.8.0'):
+        pytest.skip("Unknown compile error on torch versions above 2.5")
+
+    linear = qnn.QuantLinear(33, 8, bias=False, weight_quant=weight_quantizer)
+    linear.eval()
+    linear(torch.randn(2, 33))
+    region = WeightRegion((None, (32, 33)))
+    expected = linear.quant_weight_region(region)
+
+    linear.weight_quant.compile_quant()
+
+    def fail_full_quantization(*args, **kwargs):
+        raise AssertionError("Compiled region request fell back to full-weight quantization")
+
+    monkeypatch.setattr(linear, 'quant_weight', fail_full_quantization)
+    actual = linear.quant_weight_region(region)
+
+    assert linear.weight_quant.supports_quant_weight_region
+    assert linear.weight_quant.is_region_quant_compiled
+    assert torch.allclose(expected, actual)
+
+
+@pytest.mark.parametrize(
+    'weight_quantizer',
+    [
+        MXInt8Weight,
+        MXFloat8e4m3Weight,
+        IntWeightSymmetricGroupQuant.let(group_size=32),
+        Fp8e4m3WeightSymmetricGroupQuant.let(group_size=32)])
+@requires_pt_ge('2.3.1')
+@requires_torch_compile()
+@jit_disabled_for_compile()
+def test_gptq_with_compiled_groupwise_weight_region(monkeypatch, weight_quantizer):
+    if platform.system() == "Windows":
+        pytest.skip("Skip compile + windows because of unknown failure")
+    if version.parse('2.5.0') <= torch_version < version.parse('2.8.0'):
+        pytest.skip("Unknown compile error on torch versions above 2.5")
+
+    model = qnn.QuantLinear(33, 8, bias=False, weight_quant=weight_quantizer)
+    model.eval()
+    inp = torch.randn(4, 33)
+    model(inp)
+    model.weight_quant.compile_quant()
+
+    with gptq_mode(model, act_order=True, num_blocks=4) as gptq:
+        gptq.model(inp)
+
+        def fail_full_quantization(*args, **kwargs):
+            raise AssertionError("Compiled GPTQ update fell back to full-weight quantization")
+
+        monkeypatch.setattr(model, 'quant_weight', fail_full_quantization)
+        gptq.update()
+
+    assert model.weight_quant.is_region_quant_compiled
+    assert torch.isfinite(model.weight).all()
 
 
 @pytest_cases.parametrize('act_quantizer', ACT_QUANTIZERS.items())

--- a/tests/brevitas/proxy/test_compile.py
+++ b/tests/brevitas/proxy/test_compile.py
@@ -11,6 +11,7 @@ import pytest_cases
 import torch
 
 from brevitas import torch_version
+from brevitas.core.zero_point import ParameterFromStatsFromParameterZeroPoint
 from brevitas.export.inference import quant_inference_mode
 from brevitas.graph.gptq import gptq_mode
 import brevitas.nn as qnn
@@ -25,6 +26,7 @@ from brevitas.quant.mx_quant_ocp import MXFloat8e4m3Act
 from brevitas.quant.mx_quant_ocp import MXFloat8e4m3Weight
 from brevitas.quant.mx_quant_ocp import MXInt8Act
 from brevitas.quant.mx_quant_ocp import MXInt8Weight
+from brevitas.quant.shifted_scaled_int import ShiftedUint8WeightGroupQuantFloat
 from brevitas_examples.common.generative.quantize import Int8DynamicActPerTensorFloat
 from brevitas_examples.common.generative.quantizers import FP8e4m3OCPDynamicActPerRowFloat
 from brevitas_examples.common.generative.quantizers import Fp8e4m3WeightSymmetricGroupQuant
@@ -94,7 +96,8 @@ def test_compile_weight(weight, weight_quantizer):
         MXInt8Weight,
         MXFloat8e4m3Weight,
         IntWeightSymmetricGroupQuant.let(group_size=32),
-        Fp8e4m3WeightSymmetricGroupQuant.let(group_size=32)])
+        Fp8e4m3WeightSymmetricGroupQuant.let(group_size=32),
+        ShiftedUint8WeightGroupQuantFloat.let(group_size=32)])
 @requires_pt_ge('2.3.1')
 @requires_torch_compile()
 @jit_disabled_for_compile()
@@ -107,8 +110,7 @@ def test_compile_groupwise_weight_region(monkeypatch, weight_quantizer):
     linear = qnn.QuantLinear(33, 8, bias=False, weight_quant=weight_quantizer)
     linear.eval()
     linear(torch.randn(2, 33))
-    region = WeightRegion((None, (32, 33)))
-    expected = linear.quant_weight_region(region)
+    expected = linear.quant_weight().value
 
     linear.weight_quant.compile_quant()
 
@@ -116,11 +118,41 @@ def test_compile_groupwise_weight_region(monkeypatch, weight_quantizer):
         raise AssertionError("Compiled region request fell back to full-weight quantization")
 
     monkeypatch.setattr(linear, 'quant_weight', fail_full_quantization)
-    actual = linear.quant_weight_region(region)
-
     assert linear.weight_quant.supports_quant_weight_region
     assert linear.weight_quant.is_region_quant_compiled
-    assert torch.allclose(expected, actual)
+    for index in (0, 32, 0):
+        actual = linear.quant_weight_region(WeightRegion((None, (index, index + 1))))
+        assert torch.allclose(expected[:, index:index + 1], actual)
+
+
+@requires_pt_ge('2.3.1')
+@requires_torch_compile()
+@jit_disabled_for_compile()
+def test_compile_groupwise_parameter_from_stats_region(monkeypatch):
+    if platform.system() == "Windows":
+        pytest.skip("Skip compile + windows because of unknown failure")
+    if version.parse('2.5.0') <= torch_version < version.parse('2.8.0'):
+        pytest.skip("Unknown compile error on torch versions above 2.5")
+
+    quantizer = ShiftedUint8WeightGroupQuantFloat.let(
+        group_size=32,
+        scaling_impl_type='parameter_from_stats',
+        zero_point_impl=ParameterFromStatsFromParameterZeroPoint)
+    linear = qnn.QuantLinear(33, 8, bias=False, weight_quant=quantizer)
+    linear.eval()
+    linear(torch.randn(2, 33))
+    expected = linear.quant_weight().value
+
+    linear.weight_quant.compile_quant()
+
+    def fail_full_quantization(*args, **kwargs):
+        raise AssertionError("Compiled stateful region fell back to full quantization")
+
+    monkeypatch.setattr(linear, 'quant_weight', fail_full_quantization)
+    assert linear.weight_quant.is_region_quant_compiled
+    for index in (0, 32, 0):
+        actual = linear.quant_weight_region(WeightRegion((None, (index, index + 1))))
+        assert torch.allclose(expected[:, index:index + 1], actual)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Reason for this PR

When running algorithms in the GPxQ family, we need to quantize one column at the time.
For groupwise quantization, currently there is no way to quantize a single column without quantizing wastefully the entire matrix.

The main issue is related to the groupwise dependency on adjacent columns, and the shape manipulation we do when applying groupwise quantization.

This PR addresses that.
Some results for the following configuration:

End-to-end GPTQ

Groupwise INT8, eager
- Llama 8b
    - current: 30m
    - PR: 24m

- Qwen3 14B
    - current: 1h
    - PR: 45m 


Groupwise quantization, layer shape [4096, 14436]

- MXINT8
    - torch.compile
        - current: 0.52 s
        - PR: 0.06 s
    - eager
        - current: 1.43 s
        - PR: 0.16 s

- MXFP8
    - torch.compile
        - current: 0.55 s
        - PR: 0.06 s
    - eager
        - current: 2.24 s
        - PR: 0.20 s 

- Groupwise INT8 (with zero point)
    - torch.compile
        - current: 0.34 s
        - PR: 0.16 s
    - eager
        - current: 1.03 s
        - PR: 0.23 s

These were measured with the following utility

```python
import argparse
import time

import torch

from brevitas.core.zero_point import ParameterFromStatsFromParameterZeroPoint
import brevitas.nn as qnn
from brevitas.nn.mixin import WeightRegion
from brevitas.quant.mx_quant_ocp import MXFloat8e4m3Weight
from brevitas.quant.mx_quant_ocp import MXInt8Weight
from brevitas.quant.shifted_scaled_int import ShiftedUint8WeightGroupQuantFloat


def synchronize(device):
    if device.type == 'cuda':
        torch.cuda.synchronize(device)


def measure(fn, repeats, device):
    samples = []
    for _ in range(repeats):
        synchronize(device)
        start = time.perf_counter()
        fn()
        synchronize(device)
        samples.append(time.perf_counter() - start)
    return torch.tensor(samples).median().item()


def main():
    parser = argparse.ArgumentParser(description="Benchmark GPxQ weight-region quantization")
    parser.add_argument('--out-features', type=int, default=4096)
    parser.add_argument('--in-features', type=int, default=4096)
    parser.add_argument('--group-size', type=int, default=32)
    parser.add_argument('--columns', type=int, default=128)
    parser.add_argument('--repeats', type=int, default=5)
    parser.add_argument('--format', choices=['int8', 'uint8', 'float8'], default='int8')
    parser.add_argument('--parameter-from-stats', action='store_true')
    parser.add_argument('--device', default='cuda')
    parser.add_argument('--compile', action='store_true')
    args = parser.parse_args()

    device = torch.device(args.device)
    quantizers = {
        'int8': MXInt8Weight,
        'uint8': ShiftedUint8WeightGroupQuantFloat,
        'float8': MXFloat8e4m3Weight}
    quantizer = quantizers[args.format]
    quantizer = quantizer.let(group_size=args.group_size)
    if args.parameter_from_stats:
        quantizer = quantizer.let(scaling_impl_type='parameter_from_stats')
        if args.format == 'uint8':
            quantizer = quantizer.let(
                zero_point_impl=ParameterFromStatsFromParameterZeroPoint)
    layer = qnn.QuantLinear(
        args.in_features,
        args.out_features,
        bias=False,
        weight_quant=quantizer,
        device=device)
    layer.eval()
    layer(torch.randn(1, args.in_features, device=device))
    if args.compile:
        layer.weight_quant.compile_quant()

    columns = torch.randperm(args.in_features)[:args.columns].tolist()

    def full_quantize_columns():
        for column in columns:
            layer.quant_weight().value[:, column:column + 1]

    def region_quantize_columns():
        for column in columns:
            layer.quant_weight_region(WeightRegion((None, (column, column + 1))))

    for column in columns[:min(4, len(columns))]:
        expected = layer.quant_weight().value[:, column:column + 1]
        actual = layer.quant_weight_region(WeightRegion((None, (column, column + 1))))
        torch.testing.assert_close(actual, expected)

    full_quantize_columns()
    region_quantize_columns()
    full_time = measure(full_quantize_columns, args.repeats, device)
    region_time = measure(region_quantize_columns, args.repeats, device)

    print(f"full median:   {full_time:.6f}s")
    print(f"region median: {region_time:.6f}s")
    print(f"speedup:       {full_time / region_time:.2f}x")


if __name__ == '__main__':
    main()

```