### PR TITLE
Fix (graph/hadamard): remove matmul_hadUt_cuda, which raises TypeError on every call

### DIFF
--- a/src/brevitas/graph/hadamard.py
+++ b/src/brevitas/graph/hadamard.py
@@ -155,10 +155,6 @@ def matmul_hadU_cuda(X, hadK, K):
     return input.reshape(X.shape)
 
 
-def matmul_hadUt_cuda(X, hadK, K):
-    return matmul_hadU_cuda(X, hadK, K, transpose=True)
-
-
 def apply_exact_had_to_linear(module, had_dim=-1, output=False):
     assert isinstance(module, torch.nn.Linear)
     in_features, out_features = module.in_features, module.out_features


### PR DESCRIPTION
## Problem

`matmul_hadUt_cuda` cannot be called — it forwards a `transpose` keyword that
`matmul_hadU_cuda` does not accept:

```python
def matmul_hadU_cuda(X, hadK, K):          # L144 — no `transpose` parameter
    n = X.shape[-1]
    if K == 1:
        return fast_hadamard_transform.hadamard_transform(...)
    # if transpose:
    #     hadK = hadK.T.contiguous()
    ...

def matmul_hadUt_cuda(X, hadK, K):         # L158
    return matmul_hadU_cuda(X, hadK, K, transpose=True)   # L159
```

Any call raises:

```
TypeError: matmul_hadU_cuda() got an unexpected keyword argument 'transpose'
```

The commented-out `# if transpose:` block directly above is the residue: `transpose`
support was dropped from `matmul_hadU_cuda`, but this wrapper was never updated.

## Why removal rather than restoring `transpose`

- `matmul_hadUt_cuda` has **no call sites** anywhere in the repo (`grep` over `src/`,
  `tests/`, `brevitas_examples/`). Only `matmul_hadU_cuda` is imported and used —
  in `graph/equalize.py:1527`, `nn/equalized_layer.py:110,128`, and
  `graph/hadamard.py:178,181`.
- Re-adding the parameter would mean re-enabling the commented-out transpose branch,
  i.e. resurrecting behaviour that was deliberately disabled. That's a semantic decision
  for maintainers, not a bug fix.
- Because the function has never been callable, deleting it cannot break any working
  caller, in-tree or out.

The CPU counterpart is unaffected and keeps working, since `matmul_hadU` *does* take
`transpose`:

```python
def matmul_hadU(X, transpose=False): ...   # L107
def matmul_hadUt(X):                       # L131
    return matmul_hadU(X, transpose=True)  # L132  <-- binds fine
```

## Verification

Binding each wrapper's call against its callee's real signature, with the working CPU
pair as a control:

```
matmul_hadU_cuda(X, hadK, K)          <- matmul_hadUt_cuda passes (X, hadK, K, transpose=True)
   TypeError: got an unexpected keyword argument 'transpose'

matmul_hadU(X, transpose=False)       <- matmul_hadUt passes (X, transpose=True)
   bound OK        <-- control
```

## Change

Deletes the four lines of the dead wrapper. No other behaviour touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
