### PR TITLE
fix(bnn_pynq): reload the best checkpoint for the QCDQ ONNX export too

### DIFF
--- a/src/brevitas_examples/bnn_pynq/trainer.py
+++ b/src/brevitas_examples/bnn_pynq/trainer.py
@@ -346,7 +346,7 @@ class Trainer(object):
         # training ends
         if not self.args.dry_run:
             best_path = os.path.join(self.checkpoints_dir_path, "best.tar")
-            if self.args.export_qonnx or self.args.export_qonnx:
+            if self.args.export_qonnx or self.args.export_qcdq_onnx:
                 self.model = self.load_checkpoint(self.model, best_path, strict=True)
             if self.args.export_qonnx:
                 self.export_qonnx()


### PR DESCRIPTION
### What

In `Trainer.train_model`, the gate that reloads the best checkpoint before exporting ORs `args.export_qonnx` with itself:

```python
best_path = os.path.join(self.checkpoints_dir_path, "best.tar")
if self.args.export_qonnx or self.args.export_qonnx:      # <- export_qcdq_onnx
    self.model = self.load_checkpoint(self.model, best_path, strict=True)
if self.args.export_qonnx:
    self.export_qonnx()
if self.args.export_qcdq_onnx:
    self.export_qcdq_onnx()
```

### Why it matters

Running `bnn_pynq_train.py --export_qcdq_onnx` without `--export_qonnx`:

1. `Trainer.__init__` creates the ONNX output dir (that check is spelled correctly).
2. `Trainer.validate` asserts JIT is disabled (also spelled correctly).
3. The reload above is skipped, because only `export_qonnx` is inspected.
4. `self.export_qcdq_onnx()` then exports `self.model` **as it stands after the last epoch**, not the best checkpoint.

So the QCDQ export silently ships the wrong weights, with no error and no warning. Every other place in this file that means "some ONNX export was requested" already writes both flags:

* `trainer.py:94` — `if args.export_qonnx or args.export_qcdq_onnx:` (create the output dir)
* `trainer.py:215` — `if args.export_qonnx or args.export_qcdq_onnx:` (assert JIT is off)

`trainer.py:349` is the only one that does not, which is what this PR fixes.

### Not affected

* `--export_qonnx` (alone or with `--export_qcdq_onnx`): condition was already true, stays true.
* Neither flag: condition was already false, stays false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
