### PR TITLE
Fix (notebooks): deprecated brevitas.quant.experimental imports

### DIFF
--- a/notebooks/minifloat_mx_tutorial.ipynb
+++ b/notebooks/minifloat_mx_tutorial.ipynb
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-05-09T14:50:24.350445Z",
@@ -89,10 +89,10 @@
     }
    ],
    "source": [
-    "from brevitas.quant.experimental.float_base import Fp8e4m3Mixin\n",
-    "from brevitas.quant.experimental.mx_quant_ocp import MXFloat8e4m3Weight\n",
-    "from brevitas.quant.experimental.float_quant_ocp import FpOCPWeightPerTensorFloat, FpOCPActPerTensorFloat\n",
-    "from brevitas.quant.experimental.mx_quant_ocp import MXFloat8e4m3Act\n",
+    "from brevitas.quant.float_base import Fp8e4m3Mixin\n",
+    "from brevitas.quant.mx_quant_ocp import MXFloat8e4m3Weight\n",
+    "from brevitas.quant.float_quant_ocp import FpOCPWeightPerTensorFloat, FpOCPActPerTensorFloat\n",
+    "from brevitas.quant.mx_quant_ocp import MXFloat8e4m3Act\n",
     "import brevitas.nn as qnn\n",
     "import torch.nn as nn\n",
     "import torch\n",
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-05-09T14:50:31.785658Z",
@@ -304,7 +304,7 @@
    },
    "outputs": [],
    "source": [
-    "from brevitas.quant.experimental.mx_quant_ocp import MXFloat8e4m3WeightMSE\n",
+    "from brevitas.quant.mx_quant_ocp import MXFloat8e4m3WeightMSE\n",
     "from brevitas.quant_tensor import GroupwiseFloatQuantTensor\n",
     "\n",
     "\n",
@@ -337,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-05-09T14:50:31.832443Z",
@@ -349,8 +349,8 @@
    "outputs": [],
    "source": [
     "from brevitas.quant_tensor import GroupwiseIntQuantTensor\n",
-    "from brevitas.quant.experimental.mx_quant_ocp import MXInt8Weight\n",
-    "from brevitas.quant.experimental.mx_quant_ocp import MXInt8Act\n",
+    "from brevitas.quant.mx_quant_ocp import MXInt8Weight\n",
+    "from brevitas.quant.mx_quant_ocp import MXInt8Act\n",
     "import torch.nn as nn\n",
     "import brevitas.nn as qnn\n",
     "import torch\n",


### PR DESCRIPTION
## Summary

This PR replaces, in notebooks/minifloat_mx_tutorials, deprecated import paths from:

    brevitas.quant.experimental.*

to:

    brevitas.quant.*