### PR TITLE
Fix (notebooks): fix typos

### DIFF
--- a/notebooks/ONNX_export_tutorial.ipynb
+++ b/notebooks/ONNX_export_tutorial.ipynb
@@ -89,8 +89,8 @@
     "- `DeQuantizeLinear`: Takes as input an INT8 tensor, and converts it to its FP equivalent with a given zero-point and scale factor.\n",
     "\n",
     "There are several implications associated with this set of operations:\n",
-    "- It is not possible to quantize with a bit-width higher than 8. Although `DequantizeLinear` supports both (U)Int8 and Int32 as input, currently `QuantizeLinear` can only output (U)Int8.\n",
-    "- Using only `QuantizeLinear` and `DeDuantizeLinear`, it is possible only to quantize to 8 bit (signed or unsigned).\n",
+    "- It is not possible to quantize with a bit-width higher than 8. Although `DeQuantizeLinear` supports both (U)Int8 and Int32 as input, currently `QuantizeLinear` can only output (U)Int8.\n",
+    "- Using only `QuantizeLinear` and `DeQuantizeLinear`, it is possible only to quantize to 8 bit (signed or unsigned).\n",
     "- The addition of the `Clip` function between `QuantizeLinear` and `DeQuantizeLinear`, allows to quantize a tensor to bit-width < 8. This is done by Clipping the Int8 tensor coming out of the `QuantizeLinear` node with the min/max values of the desired bit-width (e.g., for unsigned 3 bit, `min_val = 0` and `max_val = 7`).\n",
     "- It is possible to perform both per-tensor and per-channel quantization (requires ONNX Opset >=13).\n",
     "\n",
@@ -266,7 +266,7 @@
     }
    },
    "source": [
-    "As it can be seen from the exported ONNX, by default in `QuantLinear` only the weights are quantized, and they go through a Quantize/DequantizeLinear before being used for the `Gemm` operation. Moreover, there is a clipping operation that sets the min/max values for the tensor to ±127. This is because in Brevitas the default weight quantizer (but not the activation one) has the option `narrow_range=True`.\n",
+    "As it can be seen from the exported ONNX, by default in `QuantLinear` only the weights are quantized, and they go through a Quantize/DeQuantizeLinear before being used for the `Gemm` operation. Moreover, there is a clipping operation that sets the min/max values for the tensor to ±127. This is because in Brevitas the default weight quantizer (but not the activation one) has the option `narrow_range=True`.\n",
     "This option, in case of signed quantization, makes sure that the quantization interval is perfectly symmetric (otherwise, the minimum integer would be -128), so that it can absorb sign changes (e.g. from batch norm fusion).\n",
     "\n",
     "The input and bias remains in floating point. In QCDQ export this is not a problem since the weights, that are quantized at 8 bit, are dequantized to floating-point before passed as input to the `Gemm` node.\n",


### PR DESCRIPTION
## Summary

This PR corrects some typos found in ONNX_export_tutorial.ipynb 

## Changes

- Fixed spelling mistakes.
- No functional code changes.